### PR TITLE
C1: authentication alternatives — framing for discussion

### DIFF
--- a/docs/plans/components/C1-account-custody-contract.md
+++ b/docs/plans/components/C1-account-custody-contract.md
@@ -14,7 +14,8 @@ Passport-touching operation interacts with this contract.
 - **C4** — asset-custody model determines what C1 holds vs. what lives at
   addresses.
 - **C2** — name service binds names to C1.
-- **C9** — devices register as authorised keys in C1.
+- **C9** — devices register as authorised keys in C1; the chosen
+  authentication scheme determines what is stored per device.
 - **C10 · C11 · C12** — grants live in, operate on, and are enforced by
   C1.
 
@@ -30,6 +31,11 @@ the user joins?
 **Upgrade path.** Compact contracts have no built-in upgradability per
 the spec. How do we migrate the user base if the contract evolves?
 
+**Authentication scheme.** How does C1 verify device authorisation —
+preimage knowledge, Schnorr signature, or WebAuthn assertion? Trade-off
+is circuit cost, MPC composability, and hardware-bound key claims. See
+Authentication alternatives below.
+
 ## Failure modes
 
 **Deploy cost prohibitive.** Per-account deploys exceed tolerable
@@ -44,6 +50,13 @@ accounts with high precision.
 breaks operations. *Detection:* a Compact spec change makes some
 accounts incompatible with new tooling.
 
+**Auth scheme forecloses MPC custody.** Choosing a sk-as-witness scheme
+as C1's only mode means institutional / threshold-custodied flows
+cannot authorise against C1 directly — they must route through
+spending-conditions instead. *Detection:* attempt to compose a
+FROST-custodied account against C1's circuit fails because no party
+holds the full witness.
+
 ## Alternatives
 
 **A — One Compact contract per account** (NEAR-style isolation).
@@ -52,3 +65,22 @@ accounts incompatible with new tooling.
 privacy concentration).
 
 **C — Hybrid** (registry for discovery + per-account contract for state).
+
+## Authentication alternatives
+
+**A — Hash-preimage witness.** Device holds a secret derived from
+passkey PRF; C1 stores `persistentHash(s)`; circuit verifies preimage
+knowledge. Cheapest verification, no curve arithmetic, works today.
+sk-as-witness — does not compose with MPC / threshold custody.
+
+**B — Jubjub Schnorr.** Device holds a Jubjub keypair (PRF-derived or
+generated); C1 stores the public key; circuit verifies a Schnorr
+signature. More expensive than (A) due to in-circuit curve arithmetic;
+sig is exportable; composes with threshold protocols (FROST) for MPC
+custody.
+
+**C — P-256 ECDSA (passkey assertion).** Authenticator produces a
+WebAuthn assertion natively; circuit verifies the P-256 ECDSA sig
+against the structured WebAuthn payload. Blocked today — Compact has
+no in-circuit P-256 verifier. Required for high-assurance flows where
+the signing operation must occur inside the secure element.


### PR DESCRIPTION
## What this PR adds

Three authentication alternatives to C1, plus supporting structure:

- **A — Hash-preimage witness.** PRF-derived secret + `persistentHash`; cheapest, no curve arithmetic, sk-as-witness.
- **B — Jubjub Schnorr.** Stored public key + in-circuit Schnorr verify; sig exportable, composes with FROST / threshold protocols.
- **C — P-256 ECDSA (passkey assertion).** Verify WebAuthn-shaped sig in-circuit; blocked today, required for high-assurance flows.

Plus a new open question, a new failure mode (auth scheme forecloses MPC custody), and a C9 dependency cross-reference noting that per-device storage varies by scheme.

## What this PR does not do

It does not pick the scheme. It captures the framing on the canvas so we can discuss.

## Open questions for the team

- **How much MPC compatibility do we need to keep at C1?** If institutional / threshold-custodied flows are out-of-scope for direct C1 authentication — i.e. they route via spending-conditions — then (A) is viable as the consumer default. If we want C1 to admit MPC-custodied accounts directly, only (B) composes today.
- **Are there security considerations we are missing?** Particularly around (A) — hash-preimage authentication is a known pattern (Zcash spending authority, Tornado note commitments, several zk-identity systems), but each context has its own subtleties. Worth a security read before committing.
- **Multi-mode vs. single-mode?** Should C1 support more than one scheme side-by-side (entries tagged "preimage" or "sig under pk", circuit dispatches), or pick one and treat alternative custody patterns as separate components?

## Context

Discussion seeded by recent threads on passkey support, FROST and threshold-Schnorr custody, and what gets standardised at the platform layer vs. the wallet layer. We do not need answers in this PR — we need the framing on the canvas so we can have the conversation in review and beyond.