### PR TITLE
Flag zombie-state risk: private <->public state is not automatically linked

### DIFF
--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -161,6 +161,7 @@ Each canvas carries five fields — Outcome, Dependencies, Open questions, Failu
 
 - **Domain separation discipline.** Every `persistentHash` use site carries a domain prefix. See [C8](plans/components/C8-domain-separation-registry.md).
 - **Witness handling.** Key material flows into proof generation without leaving the trusted boundary. See [C7](plans/components/C7-witness-handling.md).
+- **Private-state ↔ public-state linkage is not automatic.** Kachina / Compact does not verify that a contract's public state corresponds to any party holding the matching private state. Loss of the private side orphans the public side — see [C16](plans/components/C16-wallet-local-storage.md) failure modes. Recovery flows ([C14](plans/components/C14-total-loss-recovery-flow.md)) must address this explicitly; pure chain-state inspection is insufficient.
 - **Substitutable services.** Per P8, all ancillary services (indexers, helpers) must have at least two providers, or documented self-host.
 - **MVP-vs-v1.0 migration.** Several workstreams record both an MVP pick (October demo) and a v1.0 deliverable target. See canvases for C3, C4, C5, C22, C24.
 
@@ -197,6 +198,7 @@ Component-level risks live in each canvas's Failure Modes section. Project-level
 
 - **Workstream gating (5 of 26).** C3, C4, C22, C24, C25 carry live decisions. Downstream finalisation cannot precede the gating workstream's resolution.
 - **`ownPublicKey()` ecosystem hazard.** Direct use of Compact's `ownPublicKey()` for access control is bypassable — an external audit reproduced impersonation against `example-bboard` and OpenZeppelin's `Ownable.compact` on devnet. Upstream removal is in flight at the Midnight Foundation. Passport contracts use [C5](plans/components/C5-signing-primitive.md)'s in-circuit signature-verification pattern regardless; see C5 failure modes.
+- **Private-state loss orphans public state ("zombie state").** Kachina / Compact does not link private and public state automatically. If [C16](plans/components/C16-wallet-local-storage.md) private state is destroyed or inaccessible, the user's on-chain state in C1 (and other per-account contracts) remains visible but becomes inoperable — no party can produce the witnesses needed to interact with it. Recovery flows ([C14](plans/components/C14-total-loss-recovery-flow.md)) must address this explicitly; pure chain-state inspection is insufficient. Bears on C14, C16, C19.
 - **Upstream coupling.** C25 is owned upstream; Passport-side integration is sequenced post-v1.0 initial release.
 - **Compact proof cost.** Current `midnight-did` examples reach k=19, slow on the proof server. Bears on C6, C20, and any component using selective-disclosure-shaped circuits.
 - **`did:midnight` registration.** Registered to IAMX; current spec is in our hands. Negotiation pending.

--- a/docs/plans/components/C16-wallet-local-storage.md
+++ b/docs/plans/components/C16-wallet-local-storage.md
@@ -14,6 +14,9 @@ Includes the encryption envelope.
 - **C9** — device-bound auth produces the wrapping key.
 - **C5 · C7** — signing and witness flows read from this storage.
 - **C17** — sync state lives here.
+- **C1** — the account's public state in C1 is operable only while the
+  corresponding private state in C16 is available; the binding is not
+  verified by Kachina / Compact. See Failure modes.
 - **External** — platform-specific TEE / Secure Enclave / StrongBox APIs
   for wrapping-key custody.
 
@@ -44,6 +47,16 @@ what the wallet displayed.
 **Storage migration failure.** OS or browser update changes storage
 substrate; old wallet state inaccessible. *Detection:* version-skew test
 on shipped builds.
+
+**Zombie public state on private-state loss.** Kachina / Compact does
+not automatically verify the link between a contract's public state
+and the user's private state. If C16 is wiped or corrupted, the
+account's public state in C1 (and other contracts holding per-account
+state) remains on-chain but becomes inoperable — no party can produce
+the witnesses needed to interact with it. Users often assume private
+state is automatically linked to public state; it is not. *Detection:*
+simulate a C16 wipe against a deployed account; confirm whether (and
+how) the account can be operated from chain state alone.
 
 ## Alternatives
 


### PR DESCRIPTION
## What this PR adds

Documents an architectural risk surfaced in recent canvas review: Kachina / Compact does not automatically link private and public state. If the user's private state (C16) is lost or corrupted, the corresponding public state on-chain (C1 and other per-account contracts) remains visible but becomes inoperable — no party can produce the witnesses needed to interact with it.

Changes:

- **C16:** new Dependencies cross-ref to C1; new Failure mode "Zombie public state on private-state loss" with detection method.
- **arc42 §8 Crosscutting Concepts:** new bullet — "Private-state ↔ public-state linkage is not automatic".
- **arc42 §11 Risks:** new project-level risk listed alongside the `ownPublicKey()` hazard.

## Why this matters

Many architecture readers implicitly assume on-chain account state is the source of truth and that private state is "just" a UX convenience. In Kachina / Compact, that assumption is wrong: the chain holds public state, the user holds the private state needed to produce witnesses against it, and the binding between the two is not enforced by the platform. Losing the private side does not lose the chain entry — it strands it.

This bears on recovery (C14 must address it explicitly, not assume chain-only recovery works), backup design (C16, C19), and the credential / VC storage discussions ongoing for C20 and C7.

## What this PR does not do

It does not propose a mitigation. Surfacing the risk on the canvases is step one; mitigation strategies — recovery-side state caching, credential portability, sync mechanisms — belong with the affected components (C14, C16, C19) once we have a clearer picture of which classes of private state need preservation.