### PR TITLE
docs: update repository references to midnightntwrk/passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository holds the plan, the research that backs it, the reference materi
 
 | If you are… | Read |
 |---|---|
-| A stakeholder wanting the plan | https://input-output-hk.github.io/arc-passport |
+| A stakeholder wanting the plan | https://midnightntwrk.github.io/passport |
 | A developer joining the team | [`research/README.md`](research/README.md) |
 | A partner evaluating the proposal | [`docs/plans/README.md`](docs/plans/README.md) |
 | Looking for the design vision | [`docs/secure-onboarding-design.pdf`](docs/secure-onboarding-design.pdf) |
@@ -19,7 +19,7 @@ This repository holds the plan, the research that backs it, the reference materi
 ## Repository structure
 
 ```
-arc-passport/
+passport/
 ├── site/                        Static web artefacts deployed to GitHub Pages
 │   ├── index.html               Landing page and unified entry point
 │   ├── demo.html                The October MVP — what the team builds toward October 2026

--- a/experiments/redjubjub-wallet-rs/README.md
+++ b/experiments/redjubjub-wallet-rs/README.md
@@ -43,7 +43,7 @@ to `redjubjub-wallet-rs/`.
 
 ```bash
 # From within this experiments/ directory:
-cd ..   # now inside arc-passport/experiments/
+cd ..   # now inside passport/experiments/
 git clone https://github.com/midnightntwrk/midnight-ledger.git
 cd midnight-ledger
 git checkout ledger-8.0.2   # match the devnet version
@@ -52,7 +52,7 @@ git checkout ledger-8.0.2   # match the devnet version
 The resulting layout should be:
 
 ```
-arc-passport/
+passport/
   experiments/
     redjubjub-wallet-rs/
     midnight-ledger/        ← tag ledger-8.0.2


### PR DESCRIPTION
Repository moved from input-output-hk/arc-passport to midnightntwrk/passport. Update the GitHub Pages link and the repository-tree illustrations in the READMEs accordingly.

The arc-nearfall-evaluation subtree source, local settings paths, and captured test-evidence stack traces are left unchanged: they reference different repositories or local directories, not this repository.