### PR TITLE
feat(experiments): account-custody prototype (C1/C4) with passkey wallet app and on-device proving

### DIFF
--- a/experiments/account-custody-prototype/.env.example
+++ b/experiments/account-custody-prototype/.env.example
@@ -1,0 +1,9 @@
+# Generate with: openssl rand -hex 32
+APP__INFRA__SECRET=
+
+# Fixed demo seed (do not use in production).
+# The dev node genesis gives Night tokens to this wallet.
+WALLET_SEED=0000000000000000000000000000000000000000000000000000000000000001
+
+# A second wallet for tests that need two distinct user accounts.
+WALLET_SEED_SECONDARY=0000000000000000000000000000000000000000000000000000000000000002

--- a/experiments/account-custody-prototype/.gitignore
+++ b/experiments/account-custody-prototype/.gitignore
@@ -6,3 +6,4 @@ infra/.env
 deployment.json
 faucet-deployment.json
 *.log
+app/public/zk-params/

--- a/experiments/account-custody-prototype/.gitignore
+++ b/experiments/account-custody-prototype/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+contracts/managed/
+midnight-level-db/
+infra/.env
+deployment.json
+faucet-deployment.json
+*.log

--- a/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
+++ b/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
@@ -1,0 +1,132 @@
+# Browser proving: removing the proof server from the demo
+
+Scope drafted 2026/06/10. Companion to `DECISIONS.md`; relates to component C6
+(proof generation, alternative B) and promise P8 (the user is the prover).
+
+## Goal
+
+Replace the localnet proof server in the account-custody demo with a prover
+that runs entirely in the browser, so every proof (contract circuits and
+transaction balancing) is generated on the user's device. End state: the
+`infra/` compose file runs node and indexer only, and the demo's proving dock
+truthfully says the proof was made in this browser.
+
+Non-goals: production hardening, mobile targets, multi-threaded proving
+(stretch only), and forks of the wallet SDK or midnight-js (we prefer
+adapters and request interception over forks).
+
+## Evidence
+
+We now know everything required to call this plumbing rather than research:
+
+1. **The seam is two methods.** midnight-js proves a transaction with
+   `unprovenTx.prove(provingProvider, CostModel.initialCostModel())`, where
+   `ProvingProvider` is `{ check(preimage, keyLocation), prove(preimage,
+   keyLocation, bindingInput?) }`. The shipped `httpClientProofProvider` is a
+   thin adapter over an HTTP POST; a drop-in replacement needs nothing else.
+2. **Key material already flows client-side.** For contract circuits the
+   browser fetches prover key, verifier key, and zkir from `/zk` and embeds
+   them in the proving payload (`createProvingPayload`). The server is
+   stateless per request for contract circuits.
+3. **System-circuit material is public and small.** The proof-server image
+   (8.0.3, 98 MB) bakes in no key material. At startup it downloads and
+   verifies SRS slices (`bls_midnight_2p9..2p16`, 24 MB total) plus the
+   zswap prover keys (18.7 MB) and dust spend key (2.1 MB) from a public
+   S3 bucket. A browser prover can stage exactly the same verified files.
+4. **The proving engine already runs on wasm32.** The
+   arc-midnight-proof-benchmarks corpus proves with midnight-curves 0.2,
+   midnight-proofs 0.7, midnight-circuits 6, and midnight-zk-stdlib 1
+   (crates.io) single-threaded in Chromium, Firefox, and Safari: roughly
+   3.5 s at k=12, 12 s at k=14, and 44 s at k=16 on an M-series laptop.
+5. **Our circuits are small.** Account-contract prover keys are 0.15 to
+   0.55 MB for the Night, grant, device, and recovery circuits and 19.5 MB
+   for the shielded ones; the faucet mint key is 5 MB; the zswap spend key
+   is 10.5 MB. Nothing approaches the corpus ceiling.
+6. **Latency stays in the same order of magnitude.** Measured end-to-end
+   calls on localnet take 25 to 40 s with native proving; proving is a minor
+   fraction of that. Browser proving adds seconds for the Night and grant
+   circuits and tens of seconds for the shielded path.
+
+## Architecture target
+
+```
+React app ── ActionButton ──► midnight-js ──► proofProvider (ours)
+                                                  │ ProvingProvider calls
+                                                  ▼
+                                        Web Worker: wasm prover
+                                        (payload parse → zkir exec →
+                                         synthesize → PLONK/KZG prove)
+                                                  ▲
+Wallet SDK ── provingServerUrl ──► Service Worker fetch intercept
+                                   (same-origin /local-prove/*)
+
+Param staging: SRS slices + zswap/dust keys fetched once from the public
+bucket (or a dev-server mirror, as /zk does today) and cached per origin.
+```
+
+## Phases
+
+**Phase 0 (gate): wasm32 build of the payload prove path.** Build a minimal
+crate against the midnight-ledger 8.0.3 workspace (the version must match
+`@midnight-ntwrk/ledger-v8` in the app, not the bench pins) exposing
+`prove(payload) -> proof`. Validate byte-compatibility: a payload produced by
+`createProvingPayload` in the browser yields a proof the localnet node
+accepts, identical in effect to the native server's output. Kill criteria:
+ledger dependencies that cannot target wasm32 within the budget, or output
+mismatch on identical payloads. Budget: 3 to 5 days.
+
+**Phase 1: contract circuits proved in the browser.** Worker plus JS adapter
+implementing `ProvingProvider`; our `proofProvider` swaps the HTTP client for
+the worker. The proving dock gains true progress (the prover is ours, so
+build, prove, and submit phases become real events, per circuit). The wallet
+keeps using the proof server for balancing; the demo labels which proofs were
+browser-made. Budget: 3 to 5 days.
+
+**Phase 2: balancing proofs in the browser.** Point the wallet's
+`provingServerUrl` at our own origin and intercept with a Service Worker that
+routes to the same wasm prover; stage the zswap and dust keys plus SRS
+(45 MB, cached once). Validate dust and zswap proofs against localnet. If the
+interception fights the SDK, the fallback is to request an upstream
+`ProvingProvider` injection point and keep the proof server for balancing in
+the interim. Budget: 3 to 5 days.
+
+**Phase 3: retire the service.** Remove the proof-server container from
+`infra/` compose, keep `scripts/smoke.mjs` and `scripts/e2e-devmode.mjs`
+green against the serverless stack, and record before-and-after timings (a
+real-circuit family for the benchmark corpus falls out of this for free).
+Budget: 1 to 2 days.
+
+## Asset budget (cached once per origin)
+
+| Asset | Size |
+| --- | --- |
+| SRS slices k=9..16 | 24 MB |
+| zswap prover keys (spend, output, sign) | 18.7 MB |
+| Dust spend prover key | 2.1 MB |
+| Account circuits, Night/grant/device/recovery path | 0.6 MB |
+| Account circuits, shielded path | 58.5 MB |
+| Faucet mint | 5 MB |
+| **Worst case total** | **≈ 109 MB** |
+| **Night-only demo path** | **≈ 50 MB** |
+
+## Risks
+
+- **Version skew.** The payload format belongs to ledger 8.0.3; the wasm
+  prover must build from that workspace's dependency set. Pin and assert.
+- **Memory.** The corpus completes k=16 in all three engines within the
+  wasm32 ceiling; our largest circuits sit well below. Low risk.
+- **Engine variance.** The corpus recorded sporadic errors on one Safari
+  machine; the demo targets Chromium first, others best-effort.
+- **Bucket CORS.** If the public bucket rejects browser fetches, mirror the
+  files through the dev server exactly as `/zk` mirrors contract keys.
+- **Phase 0 overrun.** Bounded by the kill criteria. The fallback position
+  (Phase 1 only) still demonstrates the user-is-the-prover posture for every
+  custody circuit, with the server retained solely for balancing.
+
+## What this buys
+
+- C6 alternative B moves from open question to working evidence: an
+  end-to-end browser-proved wallet flow on localnet.
+- P8 (no hosted prover sees user data) is demonstrated rather than asserted.
+- A reusable wasm prover artefact, and real-circuit rows for the proof
+  benchmark corpus.

--- a/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
+++ b/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
@@ -3,6 +3,17 @@
 Scope drafted 2026/06/10. Companion to `DECISIONS.md`; relates to component C6
 (proof generation, alternative B) and promise P8 (the user is the prover).
 
+**Phase 0 outcome (2026/06/10): validated, faster than scoped.** Upstream
+ships the prover as a wasm npm package (`@midnight-ntwrk/zkir-v2`, version
+paired with `ledger-v8`; see `wasm-proving-demos/` in the midnight-ledger
+repository), so no Rust port was needed. With `?prover=browser` the demo
+deploys the account contract and lands `deposit_night` on localnet with
+proofs computed in the tab (`app/src/lib/wasmProver.ts`; SRS slices staged by
+`app/scripts/fetch-zk-params.mjs`). Remaining for Phase 1: move proving off
+the main thread into a Web Worker, per-circuit progress, and timing capture.
+Phase 2 (wallet balancing proofs) is unchanged; upstream's `zkir-mt` demo
+shows the multithreaded option.
+
 ## Goal
 
 Replace the localnet proof server in the account-custody demo with a prover

--- a/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
+++ b/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
@@ -9,10 +9,24 @@ paired with `ledger-v8`; see `wasm-proving-demos/` in the midnight-ledger
 repository), so no Rust port was needed. With `?prover=browser` the demo
 deploys the account contract and lands `deposit_night` on localnet with
 proofs computed in the tab (`app/src/lib/wasmProver.ts`; SRS slices staged by
-`app/scripts/fetch-zk-params.mjs`). Remaining for Phase 1: move proving off
-the main thread into a Web Worker, per-circuit progress, and timing capture.
-Phase 2 (wallet balancing proofs) is unchanged; upstream's `zkir-mt` demo
-shows the multithreaded option.
+`app/scripts/fetch-zk-params.mjs`).
+
+**Phases 2 and 3 outcome (2026/06/10): validated the same day; the planned
+Service Worker interception was unnecessary.** `WalletFacade.init` accepts a
+custom `provingService`, and the wallet SDK itself ships a wasm proving
+path (`makeWasmProvingService` in `wallet-sdk-capabilities/proving`, built
+on the same zkir-v2 package). The demo injects a three-line ProvingService
+backed by the in-tab prover, with the zswap and dust key triples staged
+under `/zk-params` in the proof server's cache layout. The end-to-end check
+(dev-mode onboard plus proved Night deposit) passes **with the proof-server
+container stopped**: every proof in the stack (contract circuits, zswap
+balancing, dust fees, and signing) is computed in the browser.
+
+Remaining hardening, not blocking the demo: move proving off the main
+thread into a Web Worker (the SDK's `WasmProver` already does this and is
+the model; upstream's `zkir-mt` demo shows the multithreaded variant),
+per-circuit progress and timing capture, and contributing real-circuit rows
+to the benchmark corpus.
 
 ## Goal
 

--- a/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
+++ b/experiments/account-custody-prototype/BROWSER-PROVING-SCOPE.md
@@ -22,11 +22,19 @@ under `/zk-params` in the proof server's cache layout. The end-to-end check
 container stopped**: every proof in the stack (contract circuits, zswap
 balancing, dust fees, and signing) is computed in the browser.
 
-Remaining hardening, not blocking the demo: move proving off the main
-thread into a Web Worker (the SDK's `WasmProver` already does this and is
-the model; upstream's `zkir-mt` demo shows the multithreaded variant),
-per-circuit progress and timing capture, and contributing real-circuit rows
-to the benchmark corpus.
+**Worker hardening (2026/06/10): done.** Proving runs in a dedicated worker
+(`app/src/lib/proofWorker.ts`) so the UI stays live; key material resolves
+on the main thread and is proxied per request, the same split the SDK's
+`WasmProver` uses. Two pitfalls worth recording: copy preimage and proof
+bytes into fresh `Uint8Array`s before `postMessage` (wasm-bindgen can hand
+back views over wasm memory, and structured clone copies the entire backing
+buffer), and import the zkir wasm dynamically inside the worker so a failed
+or slow load is observable instead of a silent dead worker. Validated with
+the proof-server container stopped.
+
+Remaining hardening, not blocking the demo: per-circuit progress and timing
+capture, multithreaded proving (upstream's `zkir-mt` demo), and contributing
+real-circuit rows to the benchmark corpus.
 
 ## Goal
 

--- a/experiments/account-custody-prototype/DECISIONS.md
+++ b/experiments/account-custody-prototype/DECISIONS.md
@@ -1,0 +1,168 @@
+# Account-custody prototype — decision record
+
+This experiment turns the open questions of the component canvases into
+working code. Each decision below is a prototype decision: it binds this
+iteration, gives the canvases evidence, and is explicitly revisitable. Where
+a decision deliberately diverges from the expected v1.0 answer, the
+divergence and the migration seam are named.
+
+Evaluated against `midnight-node:0.22.5`, `compact` 0.30.0,
+`midnight-js` 4.0.4 (the stack proven by
+`experiments/contract-custody-feasibility/`).
+
+## C1 — Account-custody contract
+
+**Topology: one Compact contract per account (alternative A).**
+NEAR-style isolation. The ledger schema stays flat (no nesting by account),
+deployment happens at onboarding (the demo app deploys on passkey creation),
+and the ledger-schema-fixed-at-deploy constraint is per-user rather than
+ecosystem-wide. Registry-based discovery is deferred to C2 (names).
+
+**Authentication: hash-preimage witness (authentication alternative A).**
+A device holds a 32-byte secret; the ledger stores
+`transientHash(tag, secret)`; every gated circuit proves preimage knowledge
+via the `require_device()` helper. This was a directed decision for the
+prototype: JubJub Schnorr (alternative B, the C5 target) is deferred. The
+auth check is one non-exported circuit, so the Schnorr verifier replaces a
+single seam later. Known consequence (from the C1 canvas): sk-as-witness
+does not compose with MPC or threshold custody; acceptable for a prototype,
+must be revisited at C5 ratification.
+
+**Replay defence.** Every authorised circuit bumps the `round` counter, so
+every authorised call changes contract state and a captured transaction
+cannot be re-applied. The proof itself binds the witness to the specific
+circuit and arguments.
+
+**`ownPublicKey()` is not used anywhere.** Caller identity is never read
+from the wallet-supplied coin public key (see the C5 canvas on the
+impersonation failure mode).
+
+## C4 — Asset custody model
+
+**Contract-custody for Night and shielded assets (alternative A).** Night
+flows through `receiveUnshielded` / `sendUnshielded` (U1/U3-proven);
+shielded coins use the OpenZeppelin `Map<colour, QualifiedShieldedCoinInfo>`
+plus `insertCoin` pattern (S4/S6-proven), including the change path
+(`sendShielded` returning change, re-registered via `sendImmediateShielded`
+plus `insertCoin`).
+
+**QSCI publicity accepted.** Contract-held shielded coin values and colours
+are public ledger state. This is the documented C4 trade-off, accepted for
+the prototype without mitigations.
+
+**Night balance mirror.** The contract maintains
+`night_balances: Map<colour, amount>` updated by its own deposit and
+withdraw circuits. Contract Night balances are not otherwise part of
+contract ledger state, so the mirror is what makes balances readable from
+the indexer (app) and the simulator (unit tests). Blind spot: Night sent to
+the contract address outside `deposit_night` is held but not mirrored.
+
+**Dust: out of scope.** Fees are paid by the funding wallet (genesis-seeded
+on the localnet, embedded in the demo app). C24 owns the fee model.
+
+## C5 — Signing primitive
+
+**Deferred.** No JubJub Schnorr in this iteration (directed decision). What
+the prototype fixes regardless of scheme: the authorisation seam
+(`require_device`), the replay rule (`round`), and the commitment
+derivations through exported pure circuits so client and circuit can never
+disagree. `experiments/redjubjub-wallet/` remains the verified Schnorr
+implementation to slot in.
+
+## C7 — Witness handling
+
+**Witness functions over wallet private state.** The three witnesses
+(`device_secret`, `grant_secret`, `recovery_secret`) read from the
+midnight-js private state, stored as hex strings so any provider serialises
+them safely. A witness throws when its secret is absent: a connection
+holding only a grant secret structurally cannot produce device-authorised
+proofs.
+
+**In-process evaluation; local proving.** Witness evaluation happens
+in-process; proofs go to the local proof server. Nothing in the pipeline
+serialises a secret into a transaction.
+
+**Zeroisation and `mlock`: not implemented.** JavaScript runtimes offer no
+such guarantees. Recorded as a platform limitation for the C7 canvas, not
+solved here.
+
+## C8 — Domain separation
+
+**transientHash (Poseidon) everywhere (directed decision);
+persistentHash is not used.** Caveat accepted: transientHash output is not
+guaranteed stable across Compact language versions, so ledger-stored
+commitments would not survive a toolchain upgrade. A redeploy-and-migrate
+would be needed; fine for a prototype, to be revisited when the C8 registry
+ratifies hash usage.
+
+**Ad-hoc v0 tags**, pending the registry:
+`midnight:passport:device:v0`, `midnight:passport:grant:v0`,
+`midnight:passport:recovery:v0`.
+
+## C10 / C11 — Scoped grants
+
+**Schema v0: operation × object × quantitative bound.** Operation is fixed
+to "withdraw"; object scope is one token colour; the bound is a cumulative
+value cap (`spent` accumulates across calls and is enforced in-circuit).
+This is the minimal NEAR-function-call-key shape (C10 alternative A).
+
+**No expiry in v0.** No in-circuit time assertion is used; revocation is
+the only termination. Expiry joins the schema when the time-primitive
+question is settled.
+
+**Lifecycle (C11): issue and revoke.** Revocation tombstones the grant
+(`active = false`) rather than deleting it; modification is
+revoke-and-reissue, which keeps scope-widening explicit.
+
+**Grants are epoch-scoped.** A grant records the device epoch at issue
+time; recovery bumps the epoch and thereby invalidates every grant issued
+before the loss event.
+
+## C14 — Total-loss recovery
+
+**Recovery key alongside the account key, split K-of-N (2-of-3 for now),
+per the directed decision.** At onboarding the client generates a recovery
+secret, stores `transientHash(tag, secret)` in the ledger, splits the
+secret byte-wise over GF(256) (Shamir), and stores the three share values
+in the ledger keyed by share index. Recovery reconstructs from any two
+shares, proves preimage knowledge, bumps the device epoch (instantly
+invalidating all devices and grants), registers the fresh device, and
+rotates the recovery secret plus shares.
+
+**TODO(PVSS).** The shares currently sit in plaintext public ledger state,
+so anyone can reconstruct the recovery secret. This is a placeholder for a
+publicly verifiable secret sharing scheme: each share encrypted to a
+recovery helper's public key with a published proof of correct sharing
+(C15 helper protocol). The contract surface (commitment, share slots,
+recover circuit) is the part this prototype pins down; the share
+distribution and reassembly protocol is the open work. Flagged in the
+contract header, the Shamir module, the demo UI, and here. Do not ship.
+
+**Continuity (I-5.3) holds by construction.** Under contract-custody the
+assets live in the account contract; recovery changes who may authorise,
+not where assets sit. The recovery lifecycle test asserts this on-chain.
+
+**Epoch trick instead of map iteration.** Compact ledger maps cannot be
+cleared in-circuit; `device_epoch` makes device-set reset O(1) and leaves
+stale entries inert.
+
+## C9-facing — passkey derivation (demo app)
+
+**WebAuthn PRF with a fixed, domain-separated salt
+(`midnight:passport:prf:device:v0`).** Onboarding performs `create()` (with
+the PRF extension requested) followed by one `get()` whose PRF output is
+the 32-byte device secret. The secret is re-derived on every visit and
+never persisted (the demo deliberately leaves C16 wallet-local-storage
+unexercised). A dev-mode passphrase fallback (SHA-256) exists for
+environments without PRF-capable authenticators.
+
+## Known gaps and privacy notes
+
+- **Device-commitment linkability.** Each authorised call discloses the
+  calling device's commitment (it is the ledger-map key), linking calls by
+  device. A Merkle membership proof would hide it; deferred (C12-adjacent).
+- **Grant linkability.** Same shape: grant commitments are disclosed per
+  spend, which is arguably desirable for auditability and revocation.
+- **Plaintext recovery shares** (see C14 TODO).
+- **transientHash version instability** (see C8).
+- **Witness zeroisation** (see C7).

--- a/experiments/account-custody-prototype/DECISIONS.md
+++ b/experiments/account-custody-prototype/DECISIONS.md
@@ -6,9 +6,12 @@ iteration, gives the canvases evidence, and is explicitly revisitable. Where
 a decision deliberately diverges from the expected v1.0 answer, the
 divergence and the migration seam are named.
 
-Evaluated against `midnight-node:0.22.5`, `compact` 0.30.0,
+Originally evaluated against `midnight-node:0.22.5`, `compact` 0.30.0,
 `midnight-js` 4.0.4 (the stack proven by
-`experiments/contract-custody-feasibility/`).
+`experiments/contract-custody-feasibility/`); since revalidated in full
+(unit, lifecycle, and end-to-end suites) on `midnight-node:1.0.0`,
+`indexer-standalone:4.3.3`, `proof-server:8.1.0`, `compact` 0.31.0
+(language 0.23, runtime 0.16.0), and `midnight-js` 4.1.1.
 
 ## C1 — Account-custody contract
 

--- a/experiments/account-custody-prototype/README.md
+++ b/experiments/account-custody-prototype/README.md
@@ -1,0 +1,101 @@
+# Account-custody prototype
+
+A working Passport wallet against the **account-custody contract** (C1) on a
+Midnight localnet: per-account Compact contract, hash-preimage device
+authentication derived from a passkey (WebAuthn PRF), contract-custodied
+Night and shielded assets (C4), scoped grants (C10/C11), and total-loss
+recovery from on-chain 2-of-3 shares (C14, PVSS placeholder).
+
+Decisions made (and deliberately deferred) by this iteration are recorded
+in [DECISIONS.md](./DECISIONS.md).
+
+## Layout
+
+| Path | What |
+|---|---|
+| `contracts/account.compact` | The per-account custody contract (11 circuits). |
+| `contracts/faucet.compact` | Test scaffolding: shielded-token origin for localnet. |
+| `src/wallet/` | Platform-neutral client core: contract bindings, witnesses (C7), Shamir 2-of-3, `PassportAccount` API. |
+| `src/node/` | Node-side wiring: funding wallet, providers, deploy helpers. |
+| `src/tests/` | Localnet integration scenarios (see below). |
+| `test/` | Simulator unit tests (no network needed). |
+| `app/` | Vite + React demo: passkey onboarding, wallet, devices, grants, recovery. |
+| `infra/` | Localnet docker compose (node 0.22.5, indexer 4.2.1, proof server 8.0.3). |
+
+## Prerequisites
+
+- Docker, Node.js >= 22, `compact` 0.30.0 on PATH, openssl.
+
+## Everything at once
+
+```sh
+./run-all.sh            # localnet up + compile + unit tests + all scenarios
+./run-all.sh --fresh    # reset chain state first
+./run-all.sh --tests night,grants
+```
+
+## Step by step
+
+```sh
+npm install
+npm run compile                  # both contracts → contracts/managed/
+
+# unit tests — contract logic in-process, no network
+npm test
+
+# localnet
+cp .env.example infra/.env       # then fill APP__INFRA__SECRET (openssl rand -hex 32)
+cd infra && docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d --wait && cd ..
+
+# integration scenarios (each deploys its own account; minutes each — real proofs)
+set -a; source infra/.env; set +a; export MIDNIGHT_NETWORK=local
+npm run test:lifecycle           # Night: deposit/withdraw, rogue-device reject, multi-device
+npm run test:grants              # grant issue/spend/cap/revoke
+npm run test:shielded            # faucet mint → deposit → partial withdraw (change path)
+npm run test:recovery            # share reconstruction → recover → old device locked out
+```
+
+## Demo app
+
+```sh
+npm run deploy                   # deploys the faucet, saves faucet-deployment.json
+cd app && npm install && npm run dev
+```
+
+Open `http://localhost:5173` (the dev server proxies the indexer, node, and
+proof server, and serves the zk artefacts — no CORS in the way).
+
+- **Create your passport** — creates a passkey, derives the device secret
+  from the WebAuthn PRF output, deploys your account contract, and splits a
+  fresh recovery secret 2-of-3 into on-chain shares.
+- **Assets** — deposit and withdraw Night; mint shielded tokens from the
+  faucet, deposit the note, withdraw with change.
+- **Devices** — register additional passkeys, remove devices (the contract
+  refuses to remove the last one).
+- **Grants** — issue a colour-scoped, value-capped grant; act as the dApp
+  by pasting the grant secret; revoke and watch the spend path die.
+- **Recovery** — simulate total loss: reconstruct the recovery secret from
+  the on-chain shares, register a brand-new passkey, and observe the old
+  device and all grants invalidated.
+
+Passkey PRF needs a recent platform authenticator (Touch ID, Windows
+Hello, Android) or a PRF-capable security key, on `localhost` or HTTPS.
+A dev-mode toggle (passphrase-derived secret) covers everything else.
+
+The app embeds the localnet genesis wallet purely to pay fees and fund
+deposits — the fee model is C24's problem, not this prototype's.
+
+Headless checks (drive the installed Chrome; passkeys excluded):
+`node scripts/smoke.mjs` boots the app and reports console errors;
+`node scripts/e2e-devmode.mjs` onboards in dev mode (deploys an account
+from the browser) and proves one `deposit_night` through the full
+browser stack.
+
+## Caveats (prototype, not production)
+
+- Recovery shares are plaintext public ledger state — TODO(PVSS), see
+  DECISIONS.md (C14).
+- transientHash commitments do not survive Compact version upgrades (C8).
+- Device commitments are disclosed per call (linkability; C12-adjacent).
+- Hash-preimage auth does not compose with MPC custody; the JubJub Schnorr
+  upgrade path is the `require_device()` seam (C5).

--- a/experiments/account-custody-prototype/app/index.html
+++ b/experiments/account-custody-prototype/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Midnight Passport — Account Custody Demo</title>
     <meta name="theme-color" content="#000000" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/experiments/account-custody-prototype/app/index.html
+++ b/experiments/account-custody-prototype/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Midnight Passport — Account Custody Demo</title>
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#faf9f6" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/experiments/account-custody-prototype/app/index.html
+++ b/experiments/account-custody-prototype/app/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Midnight Passport — Account Custody Demo</title>
+    <meta name="theme-color" content="#000000" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600&family=Bricolage+Grotesque:wght@400;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/experiments/account-custody-prototype/app/package-lock.json
+++ b/experiments/account-custody-prototype/app/package-lock.json
@@ -24,6 +24,7 @@
         "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
         "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
         "buffer": "^6.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/experiments/account-custody-prototype/app/package-lock.json
+++ b/experiments/account-custody-prototype/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@midnight-ntwrk/compact-js": "^2.0.2",
-        "@midnight-ntwrk/compact-runtime": "^0.15.0",
+        "@midnight-ntwrk/compact-runtime": "^0.16.0",
         "@midnight-ntwrk/ledger-v8": "^8.0.3",
         "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
         "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.0.4",
@@ -889,21 +889,10 @@
         "tslib": "^2.8.1"
       }
     },
-    "node_modules/@midnight-ntwrk/compact-js/node_modules/@midnight-ntwrk/compact-runtime": {
+    "node_modules/@midnight-ntwrk/compact-runtime": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
       "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
-        "@types/object-inspect": "^1.8.1",
-        "object-inspect": "^1.12.3"
-      }
-    },
-    "node_modules/@midnight-ntwrk/compact-runtime": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.15.0.tgz",
-      "integrity": "sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
@@ -992,17 +981,6 @@
         "@midnight-ntwrk/ledger-v8": "8.1.0",
         "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
         "@midnight-ntwrk/platform-js": "2.2.4"
-      }
-    },
-    "node_modules/@midnight-ntwrk/midnight-js-protocol/node_modules/@midnight-ntwrk/compact-runtime": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
-      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
-        "@types/object-inspect": "^1.8.1",
-        "object-inspect": "^1.12.3"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-types": {

--- a/experiments/account-custody-prototype/app/package-lock.json
+++ b/experiments/account-custody-prototype/app/package-lock.json
@@ -1,0 +1,4560 @@
+{
+  "name": "account-custody-demo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "account-custody-demo",
+      "version": "0.1.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-js": "^2.0.2",
+        "@midnight-ntwrk/compact-runtime": "^0.15.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+        "@midnight-ntwrk/wallet-api": "^5.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+        "buffer": "^6.0.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "rxjs": "^7.8.2"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "puppeteer-core": "^25.1.0",
+        "typescript": "^5.9.3",
+        "vite": "^6.0.0",
+        "vite-plugin-top-level-await": "^1.4.4",
+        "vite-plugin-wasm": "^3.3.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.3.tgz",
+      "integrity": "sha512-+auRYBXow2v7cT+wKzvjyMyyEojq+G7Sf80vIR57rtEPcxRFuMXuU9IKjwxZ3muclUgdGKwZXNeuki+g0GabgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0 || ^17.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
+      "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.4",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.1.tgz",
+      "integrity": "sha512-UO0+tDiRadYFO2kaUu9PIhAOISvDKvmiyh9vSOyKEZLj3AUAY1qmmHm/oQrzPqrkiWHO0Rnln/j/zZ5dvc5vxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/platform-js": "^2.2.4",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-js/node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
+      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.15.0.tgz",
+      "integrity": "sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/ledger-v8": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger-v8/-/ledger-v8-8.1.0.tgz",
+      "integrity": "sha512-rwOVP5kBwACpYmmY6+oLeaiM3e5gHscRMjbZUOntOC5QdtqLdpeep6eQW1OngI+sxjjdVoGg2eE16sLf+DAHmQ=="
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-contracts": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-contracts/-/midnight-js-contracts-4.1.1.tgz",
+      "integrity": "sha512-vHeKyaj9RXTx+Cep3YpIRgg2EWkzibO4gxI7k/rYpXmGXc3waetrR5sb9FPR7v9SUX00/zf/sYbLp1NZhwZbjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-fetch-zk-config-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/-/midnight-js-fetch-zk-config-provider-4.1.1.tgz",
+      "integrity": "sha512-d9vPAXjCvbe3KdPDBwp8Cp4HXwdo9jfCjeyJjJPfIDHCctXrIQ7btu+CqY1+bgV05FHVMOBLjJ9TS2tc2xdwrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "cross-fetch": "^4.1.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-http-client-proof-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-http-client-proof-provider/-/midnight-js-http-client-proof-provider-4.1.1.tgz",
+      "integrity": "sha512-Q2VNRTvuWlf3MbjV7C3asuLHeFwtZMdh6t5Z+u8c8RDpejW9GhKaSjlJ2zgJII5ckE8/cocPEDwt3GKBebGHWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "cross-fetch": "^4.1.0",
+        "fetch-retry": "^6.0.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-indexer-public-data-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-indexer-public-data-provider/-/midnight-js-indexer-public-data-provider-4.1.1.tgz",
+      "integrity": "sha512-50CjiYqw/msRintyfkuNrJl1v4Zj+AaBFmV2uLjY/zpkPop4VBFH4QZSrtKsG1ljT9vzWsxU7Eo4Tn1tgKkPlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apollo/client": "^4.2.0",
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^4.1.0",
+        "graphql": "^16.14.0",
+        "graphql-ws": "^6.0.8",
+        "isomorphic-ws": "^5.0.0",
+        "rxjs": "^7.8.2",
+        "ws": "^8.20.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-network-id": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-4.1.1.tgz",
+      "integrity": "sha512-g49IBK0In1Jt2wKgi18rUvoy1ShGVrfb/VvgWALkc9Noc6+4MX5NTLVg5zqu+CyO2waIGb5lqDPnAhTD9wPAOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-protocol": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-protocol/-/midnight-js-protocol-4.1.1.tgz",
+      "integrity": "sha512-JH1010ir3YrawKsA4C08aIXWpFGHrCrAaBkZFbn+xh+iwOX5Ss0WU4//mDSEnHvQN0wD6GTc2JwUfKYFaS2CcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-js": "2.5.1",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "8.1.0",
+        "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+        "@midnight-ntwrk/platform-js": "2.2.4"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-protocol/node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
+      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-types/-/midnight-js-types-4.1.1.tgz",
+      "integrity": "sha512-MPT7YToXN2EsDtOOVSJonYZSZ4eqmdVgftBfH56w+tmZM0sZt9u+Mq18uuBQl9ebpTXnp8o7WqeISbgPMxTBcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "effect": "^3.20.0",
+        "pino": "^10.3.1",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-utils/-/midnight-js-utils-4.1.1.tgz",
+      "integrity": "sha512-b65QADd2FaZbWXe9D3fe9mSGmPlP1DTRMGSruJqhl9fOTNxBhQIzIKs0j/eL9Kv77dVeGDYgQdbV+JkDj3j5Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/onchain-runtime-v3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/onchain-runtime-v3/-/onchain-runtime-v3-3.0.0.tgz",
+      "integrity": "sha512-HbFbUOsvgpEFy1OT0Ni2LMFk4jnMQS1em+H+Mof/B3DpnNKl0Lkx5QiulKOc6pyU4KPEagOqx4fYNyVXFwgZ7g=="
+    },
+    "node_modules/@midnight-ntwrk/platform-js": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/platform-js/-/platform-js-2.2.4.tgz",
+      "integrity": "sha512-6mrYKSSE8kPgn/5rQ2xofDJk1yAZZRdLOO6Yelweuh5GOnOGz7Qw4venDG/c4TRqtV9ouFp+F5j7ta8aprMinw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-api/-/wallet-api-5.0.0.tgz",
+      "integrity": "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/zswap": "^4.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "7.x"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-abstractions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-abstractions/-/wallet-sdk-abstractions-2.1.0.tgz",
+      "integrity": "sha512-mMcHFBrNxlZhurknS9J979HhrHQ0EsKdm6Kwaq7SAk/tStLOU2/sAoQzLUzzxr8Y60PcilTJdIKhaCgaydPATg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-address-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-3.1.2.tgz",
+      "integrity": "sha512-SRkgwmKFOZSUR25iurAB8U7kTKF7AljSl+tMkuuj8Pthc/l0yIg+/q1rFSozJ0Nz9FJRhshazDyrL0l84fOabg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@scure/base": "^2.0.0",
+        "@subsquid/scale-codec": "^4.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-capabilities": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-3.3.1.tgz",
+      "integrity": "sha512-V//D0wEKN0++XE+pKsXy6U5aH5/1+AoLdCl7Zp1RZilrdABffiywbJ0ZER/ePiTCG93ltDTz7L73WDyEJy6wPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-node-client": "^1.1.2",
+        "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-dust-wallet/-/wallet-sdk-dust-wallet-4.1.0.tgz",
+      "integrity": "sha512-RA+Zvb3a4LmyxMFOuHJUZ2I7WbtDHLyKVk1++4q/w3WH/G9dMMyv0H/dxsxjSnIlX9km1Ibf6dxYN4I3fmG9XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-facade": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-facade/-/wallet-sdk-facade-4.0.1.tgz",
+      "integrity": "sha512-m1AgeoS+jQrj2h5jQRIKv4UT61sWBF5S5PtzGi8/gweug3XYqPlkxJBZKZzS2078QDi9ToH/epWQeoUEqzKhvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.1",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.1.0",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-hd": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-hd/-/wallet-sdk-hd-3.0.2.tgz",
+      "integrity": "sha512-GdzZsfURF4WBh+bmSiimwOnj2vLjtd1pvMUJjRtY3OOnnr1mSesuX9//UPzb0fCjU1ZMCNb6UK7M2YcI4Gef4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-indexer-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-indexer-client/-/wallet-sdk-indexer-client-1.2.2.tgz",
+      "integrity": "sha512-GokfgV1lOhF1h341cuglp1VoTT/+yEDuYIbiPex29JJkFrjOXdJfCKPoROySBtyIyI65lnEBAXBT0+AOBjPzhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "graphql": "^16.13.0",
+        "graphql-http": "^1.22.4",
+        "graphql-ws": "^6.0.7"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-node-client": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-node-client/-/wallet-sdk-node-client-1.1.2.tgz",
+      "integrity": "sha512-nV6lg1M0QQOGss9JiofwO3+bcI+kQIoGV36F+KwyDMgUjAH2nT2/m3SbhLDGizwvJwgniWMuZQV6k/YZ7nCcWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@polkadot/api": "^16.5.4",
+        "@polkadot/types": "^16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@types/bn.js": "^5.2.0",
+        "bn.js": "^5.2.3",
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-prover-client/-/wallet-sdk-prover-client-1.2.2.tgz",
+      "integrity": "sha512-Xbniz3S/ab1uxiEJd3OaBxLkDfygPIAWgNZfApwAeac/U8yUVUjrqJ9aWyruztMY2MZHN7QxUjlcAWDK84hX3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.96.0",
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "web-worker": "^1.5.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client/node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-runtime": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-runtime/-/wallet-sdk-runtime-1.0.4.tgz",
+      "integrity": "sha512-Sc3mAkiCCNSI/BCrOtPoQDb+1rZlcr/Is9w90hRJJ8XT/7kdcmoekoctupXBLtc5UCeDX1FqUs2hz60CnwLoZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-shielded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-shielded/-/wallet-sdk-shielded-3.0.1.tgz",
+      "integrity": "sha512-/jNIXz1T4JvJNG67s1tODTPqb2lnBAZ2TuocZQmFj9N0hG2LYtA35Tm6sFUpy68HfPnxdyEWarK27Wj0VRbEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-unshielded-wallet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-unshielded-wallet/-/wallet-sdk-unshielded-wallet-3.1.0.tgz",
+      "integrity": "sha512-GujzejaxF7Z1Pqmfp2uyz2mmtLb4ImIoL4njeh+3XLeSfJLedpizXi2WrHmcINO/z4x3pXTw3qU98dF04j97eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-utilities": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-utilities/-/wallet-sdk-utilities-1.2.0.tgz",
+      "integrity": "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/zkir-v2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zkir-v2/-/zkir-v2-2.1.0.tgz",
+      "integrity": "sha512-UDMujjzCt0SA89uqOFWUL4LZTkxVAS8JjvOaYMAgxlSrWfN7m5th1R1qGlpDJuSH39rbWt6WwtuK3k08Mta6LA=="
+    },
+    "node_modules/@midnight-ntwrk/zswap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zswap/-/zswap-4.0.0.tgz",
+      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.4.tgz",
+      "integrity": "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@subsquid/scale-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.1.tgz",
+      "integrity": "sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2"
+      }
+    },
+    "node_modules/@subsquid/util-internal-hex": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==",
+      "license": "GPL-3.0-or-later"
+    },
+    "node_modules/@subsquid/util-internal-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.3.tgz",
+      "integrity": "sha512-H5qW5kG20IzVMpb7GhPbVRxGuACEf1DPIXE1+LNXYxt8t/GX4zQREQWHRvCB3lck+RORLJD3WJbQUtxN5UYB3Q==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
+      "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.41",
+        "@swc/core-darwin-x64": "1.15.41",
+        "@swc/core-linux-arm-gnueabihf": "1.15.41",
+        "@swc/core-linux-arm64-gnu": "1.15.41",
+        "@swc/core-linux-arm64-musl": "1.15.41",
+        "@swc/core-linux-ppc64-gnu": "1.15.41",
+        "@swc/core-linux-s390x-gnu": "1.15.41",
+        "@swc/core-linux-x64-gnu": "1.15.41",
+        "@swc/core-linux-x64-musl": "1.15.41",
+        "@swc/core-win32-arm64-msvc": "1.15.41",
+        "@swc/core-win32-ia32-msvc": "1.15.41",
+        "@swc/core-win32-x64-msvc": "1.15.41"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.41.tgz",
+      "integrity": "sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.41.tgz",
+      "integrity": "sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.41.tgz",
+      "integrity": "sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.41.tgz",
+      "integrity": "sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.41.tgz",
+      "integrity": "sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.41.tgz",
+      "integrity": "sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.41.tgz",
+      "integrity": "sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.41.tgz",
+      "integrity": "sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.41.tgz",
+      "integrity": "sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.41.tgz",
+      "integrity": "sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.41.tgz",
+      "integrity": "sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.41.tgz",
+      "integrity": "sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.41.tgz",
+      "integrity": "sha512-wFocmIRY5pSvqxzvJbsKiHyP6oNrSPqBbicF1TV3n0E1ZekSQm/hG9cbRYwxd2pVGL4Nmg8JNpIeLSwRS97Gdg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1624250",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
+      "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/effect": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+      "integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
+      "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.1.0.tgz",
+      "integrity": "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.4",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1624250",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
+      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.6.0.tgz",
+      "integrity": "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/experiments/account-custody-prototype/app/package.json
+++ b/experiments/account-custody-prototype/app/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "account-custody-demo",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Passport account-custody demo — passkey (WebAuthn PRF) onboarding against a Midnight localnet.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@midnight-ntwrk/compact-js": "^2.0.2",
+    "@midnight-ntwrk/compact-runtime": "^0.15.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "buffer": "^6.0.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "puppeteer-core": "^25.1.0",
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0",
+    "vite-plugin-top-level-await": "^1.4.4",
+    "vite-plugin-wasm": "^3.3.0"
+  }
+}

--- a/experiments/account-custody-prototype/app/package.json
+++ b/experiments/account-custody-prototype/app/package.json
@@ -26,6 +26,7 @@
     "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
     "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zkir-v2": "^2.1.0",
     "buffer": "^6.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/experiments/account-custody-prototype/app/package.json
+++ b/experiments/account-custody-prototype/app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@midnight-ntwrk/compact-js": "^2.0.2",
-    "@midnight-ntwrk/compact-runtime": "^0.15.0",
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
     "@midnight-ntwrk/ledger-v8": "^8.0.3",
     "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
     "@midnight-ntwrk/midnight-js-fetch-zk-config-provider": "^4.0.4",

--- a/experiments/account-custody-prototype/app/scripts/e2e-devmode.mjs
+++ b/experiments/account-custody-prototype/app/scripts/e2e-devmode.mjs
@@ -1,0 +1,68 @@
+// Headless end-to-end check of the browser stack using dev mode (no
+// passkey): onboard (deploy from the browser) and deposit Night (a real
+// circuit call proved through the /proof proxy). WebAuthn flows still need
+// a human.
+//
+// Usage: node scripts/e2e-devmode.mjs [url]
+
+import puppeteer from 'puppeteer-core';
+
+const url = process.argv[2] ?? 'http://localhost:5173/';
+const chrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const browser = await puppeteer.launch({ executablePath: chrome, headless: 'new' });
+const page = await browser.newPage();
+page.on('pageerror', (err) => console.log(`[pageerror] ${err.message}`));
+page.on('console', (msg) => {
+  const t = msg.text();
+  if (t.includes('[passport]')) console.log(t);
+});
+
+const waitForText = async (text, timeout) => {
+  await page.waitForFunction(
+    (t) => document.body.innerText.includes(t),
+    { timeout, polling: 1000 },
+    text,
+  );
+  console.log(`✓ saw: ${text}`);
+};
+
+const clickButton = async (label) => {
+  await page.evaluate((l) => {
+    const btn = [...document.querySelectorAll('button')].find((b) => b.textContent.trim() === l);
+    if (!btn) throw new Error(`no button: ${l}`);
+    btn.click();
+  }, label);
+};
+
+try {
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await waitForText('CREATE YOUR PASSPORT', 120_000);
+
+  // Dev-mode onboarding.
+  await page.click('input[type="checkbox"]');
+  await page.type('input[type="password"]', 'e2e-test-passphrase');
+  await clickButton('Create account (dev mode)');
+  console.log('… deploying account from the browser (this takes a while)');
+  await waitForText('PASSPORT ACCOUNT', 300_000);
+
+  // One real circuit call: deposit 1000 Night.
+  await clickButton('Deposit Night');
+  console.log('… proving deposit_night in the browser stack');
+  await page.waitForFunction(
+    () => /night|01000/.test(document.body.innerText) &&
+      [...document.querySelectorAll('td')].some((td) => td.textContent.trim() === '1000'),
+    { timeout: 300_000, polling: 2000 },
+  );
+  console.log('✓ deposit_night landed — night balance 1000 visible in the ledger table');
+
+  console.log('E2E PASS');
+} catch (e) {
+  console.error(`E2E FAIL: ${e.message}`);
+  const text = await page.evaluate(() => document.body.innerText.slice(0, 1500));
+  console.log('--- body text at failure ---');
+  console.log(text);
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}

--- a/experiments/account-custody-prototype/app/scripts/fetch-zk-params.mjs
+++ b/experiments/account-custody-prototype/app/scripts/fetch-zk-params.mjs
@@ -16,16 +16,23 @@ const here = dirname(fileURLToPath(import.meta.url));
 const outDir = resolve(here, '../public/zk-params');
 mkdirSync(outDir, { recursive: true });
 
-for (let k = kLo; k <= kHi; k++) {
-  const name = `bls_midnight_2p${k}`;
+const fetchOne = async (name) => {
   const out = `${outDir}/${name}`;
   if (existsSync(out)) {
     console.log(`✓ ${name} (cached)`);
-    continue;
+    return;
   }
+  mkdirSync(dirname(out), { recursive: true });
   const resp = await fetch(`${HOST}${name}`);
   if (!resp.ok) throw new Error(`${name}: HTTP ${resp.status}`);
   writeFileSync(out, Buffer.from(await resp.arrayBuffer()));
   console.log(`↓ ${name}`);
+};
+
+for (let k = kLo; k <= kHi; k++) await fetchOne(`bls_midnight_2p${k}`);
+
+// System (balancing) circuits — zswap and dust, proof-server cache layout.
+for (const circuit of ['zswap/9/spend', 'zswap/9/output', 'zswap/9/sign', 'dust/9/spend']) {
+  for (const ext of ['prover', 'verifier', 'bzkir']) await fetchOne(`${circuit}.${ext}`);
 }
-console.log(`SRS slices staged in ${outDir}`);
+console.log(`zk params staged in ${outDir}`);

--- a/experiments/account-custody-prototype/app/scripts/fetch-zk-params.mjs
+++ b/experiments/account-custody-prototype/app/scripts/fetch-zk-params.mjs
@@ -1,0 +1,31 @@
+// Stage the KZG SRS slices the browser prover needs (?prover=browser) into
+// app/public/zk-params/. These are the same files the proof server downloads
+// and verifies at startup (base-crypto data_provider, bls_midnight_2p<k>).
+//
+// Usage: node scripts/fetch-zk-params.mjs [kLo] [kHi]
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOST = 'https://midnight-s3-fileshare-dev-eu-west-1.s3.eu-west-1.amazonaws.com/';
+const kLo = Number(process.argv[2] ?? '9');
+const kHi = Number(process.argv[3] ?? '16');
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = resolve(here, '../public/zk-params');
+mkdirSync(outDir, { recursive: true });
+
+for (let k = kLo; k <= kHi; k++) {
+  const name = `bls_midnight_2p${k}`;
+  const out = `${outDir}/${name}`;
+  if (existsSync(out)) {
+    console.log(`✓ ${name} (cached)`);
+    continue;
+  }
+  const resp = await fetch(`${HOST}${name}`);
+  if (!resp.ok) throw new Error(`${name}: HTTP ${resp.status}`);
+  writeFileSync(out, Buffer.from(await resp.arrayBuffer()));
+  console.log(`↓ ${name}`);
+}
+console.log(`SRS slices staged in ${outDir}`);

--- a/experiments/account-custody-prototype/app/scripts/screenshot-mobile.mjs
+++ b/experiments/account-custody-prototype/app/scripts/screenshot-mobile.mjs
@@ -1,0 +1,90 @@
+// Mobile-viewport capture (iPhone-sized emulation): onboarding, drawer nav,
+// proving dock, funded state — using the browser prover end to end.
+//
+// Usage: node scripts/screenshot-mobile.mjs [url] [outDir]
+
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer-core';
+
+const url = process.argv[2] ?? 'http://localhost:5173/?prover=browser';
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = process.argv[3] ?? resolve(here, '../../../../tmp/passport-ui');
+const chrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+mkdirSync(outDir, { recursive: true });
+
+const browser = await puppeteer.launch({ executablePath: chrome, headless: 'new' });
+const page = await browser.newPage();
+await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 3, isMobile: true, hasTouch: true });
+page.on('pageerror', (err) => console.log(`[pageerror] ${err.message}`));
+page.on('console', (msg) => {
+  const t = msg.text();
+  if (t.includes('[passport]')) console.log(t);
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const shot = async (name) => {
+  await page.screenshot({ path: `${outDir}/${name}.png` });
+  console.log(`📱 ${name}`);
+};
+const waitForText = async (text, timeout) => {
+  await page.waitForFunction(
+    (t) => document.body.innerText.includes(t),
+    { timeout, polling: 1000 },
+    text,
+  );
+  console.log(`✓ saw: ${text}`);
+};
+const clickButton = async (label) => {
+  await page.evaluate((l) => {
+    const btn = [...document.querySelectorAll('button')].find((b) => b.textContent.trim() === l);
+    if (!btn) throw new Error(`no button: ${l}`);
+    btn.click();
+  }, label);
+};
+
+try {
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await waitForText('CREATE YOUR PASSPORT', 180_000);
+  await sleep(800);
+  await shot('m01-onboard');
+
+  await page.click('input[type="checkbox"]');
+  await page.type('input[type="password"]', 'mobile-shot-passphrase');
+  await clickButton('Create account (dev mode)');
+  console.log('… deploying (browser prover)');
+  await waitForText('PASSPORT ACCOUNT', 300_000);
+  await sleep(1000);
+  await shot('m02-overview');
+
+  await page.click('.menu-btn');
+  await sleep(500);
+  await shot('m03-drawer');
+  await page.evaluate(() => {
+    const el = [...document.querySelectorAll('.step-title')].find(
+      (s) => s.textContent === 'Fund the account',
+    );
+    el.closest('button').click();
+  });
+  await sleep(700);
+
+  await clickButton('Deposit Night');
+  await sleep(6_000); // mid-prove: dock live with the on-device chip
+  await shot('m04-proving');
+  await page.waitForFunction(
+    () => [...document.querySelectorAll('td')].some((td) => td.textContent.trim() === '1000'),
+    { timeout: 300_000, polling: 2000 },
+  );
+  await sleep(1000);
+  await shot('m05-funded');
+
+  console.log('MOBILE SHOTS DONE');
+} catch (e) {
+  console.error(`MOBILE SHOTS FAILED: ${e.message}`);
+  await shot('m99-failure');
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}

--- a/experiments/account-custody-prototype/app/scripts/screenshot-mobile.mjs
+++ b/experiments/account-custody-prototype/app/scripts/screenshot-mobile.mjs
@@ -64,7 +64,7 @@ try {
   await shot('m03-drawer');
   await page.evaluate(() => {
     const el = [...document.querySelectorAll('.step-title')].find(
-      (s) => s.textContent === 'Fund the account',
+      (s) => s.textContent === 'Holdings',
     );
     el.closest('button').click();
   });

--- a/experiments/account-custody-prototype/app/scripts/screenshot.mjs
+++ b/experiments/account-custody-prototype/app/scripts/screenshot.mjs
@@ -1,0 +1,150 @@
+// Visual capture of the demo journey (dev-mode, headless Chrome).
+//
+//   node scripts/screenshot.mjs onboard   — boot + onboarding hero only (fast)
+//   node scripts/screenshot.mjs full      — dev-mode onboard, fund, grant,
+//                                           spend, revoke + per-view shots
+//
+// Shots land in <outDir> (default ../../../../tmp/passport-ui relative to
+// this script, i.e. repo-root tmp/).
+
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer-core';
+
+const mode = process.argv[2] ?? 'onboard';
+const url = process.argv[3] ?? 'http://localhost:5173/';
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = process.argv[4] ?? resolve(here, '../../../../tmp/passport-ui');
+const chrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+mkdirSync(outDir, { recursive: true });
+
+const browser = await puppeteer.launch({ executablePath: chrome, headless: 'new' });
+const page = await browser.newPage();
+await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 2 });
+page.on('pageerror', (err) => console.log(`[pageerror] ${err.message}`));
+page.on('console', (msg) => {
+  const t = msg.text();
+  if (t.includes('[passport]')) console.log(t);
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const shot = async (name) => {
+  await page.screenshot({ path: `${outDir}/${name}.png` });
+  console.log(`📸 ${name}`);
+};
+
+const waitForText = async (text, timeout) => {
+  await page.waitForFunction(
+    (t) => document.body.innerText.includes(t),
+    { timeout, polling: 1000 },
+    text,
+  );
+  console.log(`✓ saw: ${text}`);
+};
+
+const clickButton = async (label) => {
+  await page.evaluate((l) => {
+    const btn = [...document.querySelectorAll('button')].find((b) => b.textContent.trim() === l);
+    if (!btn) throw new Error(`no button: ${l}`);
+    btn.click();
+  }, label);
+};
+
+// Sidebar navigation by step title.
+const clickStep = async (title) => {
+  await page.evaluate((t) => {
+    const el = [...document.querySelectorAll('.step-title')].find((s) => s.textContent === t);
+    if (!el) throw new Error(`no nav step: ${t}`);
+    el.closest('button').click();
+  }, title);
+  await sleep(700); // let the reveal animation settle
+};
+
+try {
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await waitForText('CREATE YOUR PASSPORT', 180_000);
+  await sleep(1000);
+  await shot('01-onboard');
+
+  if (mode === 'onboard') {
+    console.log('DONE (onboard mode)');
+    await browser.close();
+    process.exit(0);
+  }
+
+  // ——— dev-mode onboarding ———
+  await page.click('input[type="checkbox"]');
+  await page.type('input[type="password"]', 'screenshot-run-passphrase');
+  await clickButton('Create account (dev mode)');
+  console.log('… deploying account from the browser');
+  await sleep(20_000); // mid-deploy: proving dock live
+  await shot('02-deploying');
+  await waitForText('PASSPORT ACCOUNT', 300_000);
+  await sleep(1200);
+  await shot('03-overview');
+
+  // ——— fund ———
+  await clickStep('Fund the account');
+  await clickButton('Deposit Night');
+  console.log('… proving deposit_night');
+  await sleep(15_000);
+  await shot('04-deposit-proving');
+  await page.waitForFunction(
+    () => [...document.querySelectorAll('td')].some((td) => td.textContent.trim() === '1000'),
+    { timeout: 300_000, polling: 2000 },
+  );
+  console.log('✓ deposit landed');
+  await sleep(1200);
+  await shot('05-assets-funded');
+
+  // ——— grant: issue, hand over, spend ———
+  await clickStep('Spend via a grant');
+  await clickButton('Issue grant (Night, capped)');
+  console.log('… proving add_grant');
+  await waitForText('GRANT SECRET — SHOWN ONCE', 300_000);
+  await sleep(1200);
+  await shot('06-grant-issued');
+
+  const secret = await page.evaluate(
+    () => document.querySelector('.secret-callout .mono').title.split(' ')[0],
+  );
+  console.log(`grant secret captured (${secret.length} hex chars)`);
+  await page.evaluate(() => {
+    document.querySelector('.panel-dapp input').focus();
+  });
+  await page.keyboard.type(secret);
+  await clickButton('Spend via grant');
+  console.log('… proving grant_withdraw_night');
+  await waitForText('grant_withdraw_night 50 → tx', 300_000);
+  await sleep(1500);
+  await shot('07-grant-spent');
+
+  // ——— revoke ———
+  await clickStep('Revoke the grant');
+  await sleep(700);
+  await clickButton('revoke');
+  console.log('… proving revoke_grant');
+  await waitForText('revoke_grant → tx', 300_000);
+  await sleep(1500);
+  await shot('08-grant-revoked');
+
+  // ——— browse views ———
+  await clickStep('Devices');
+  await shot('09-devices');
+  await clickStep('Recover from total loss');
+  await shot('10-recovery');
+
+  console.log('SCREENSHOTS DONE');
+} catch (e) {
+  console.error(`SCREENSHOT RUN FAILED: ${e.message}`);
+  await shot('99-failure');
+  const text = await page.evaluate(() => document.body.innerText.slice(0, 1500));
+  console.log('--- body text at failure ---');
+  console.log(text);
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}

--- a/experiments/account-custody-prototype/app/scripts/screenshot.mjs
+++ b/experiments/account-custody-prototype/app/scripts/screenshot.mjs
@@ -87,7 +87,7 @@ try {
   await shot('03-overview');
 
   // ——— fund ———
-  await clickStep('Fund the account');
+  await clickStep('Holdings');
   await clickButton('Deposit Night');
   console.log('… proving deposit_night');
   await sleep(15_000);
@@ -101,7 +101,7 @@ try {
   await shot('05-assets-funded');
 
   // ——— grant: issue, hand over, spend ———
-  await clickStep('Spend via a grant');
+  await clickStep('Connections');
   await clickButton('Issue grant (Night, capped)');
   console.log('… proving add_grant');
   await waitForText('GRANT SECRET — SHOWN ONCE', 300_000);
@@ -123,7 +123,7 @@ try {
   await shot('07-grant-spent');
 
   // ——— revoke ———
-  await clickStep('Revoke the grant');
+  // revoke happens in place on the Connections view
   await sleep(700);
   await clickButton('revoke');
   console.log('… proving revoke_grant');
@@ -134,7 +134,7 @@ try {
   // ——— browse views ———
   await clickStep('Devices');
   await shot('09-devices');
-  await clickStep('Recover from total loss');
+  await clickStep('Recovery');
   await shot('10-recovery');
 
   console.log('SCREENSHOTS DONE');

--- a/experiments/account-custody-prototype/app/scripts/smoke.mjs
+++ b/experiments/account-custody-prototype/app/scripts/smoke.mjs
@@ -1,0 +1,34 @@
+// Headless boot smoke test: loads the app, captures console output and page
+// errors, and reports what rendered. Does not exercise passkeys (WebAuthn
+// needs a user gesture) — it verifies the WASM/wallet boot path only.
+//
+// Usage: node scripts/smoke.mjs [url] [waitMs]
+
+import puppeteer from 'puppeteer-core';
+
+const url = process.argv[2] ?? 'http://localhost:5173/';
+const waitMs = Number(process.argv[3] ?? '45000');
+const chrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const browser = await puppeteer.launch({
+  executablePath: chrome,
+  headless: 'new',
+});
+const page = await browser.newPage();
+
+page.on('console', (msg) => console.log(`[console:${msg.type()}] ${msg.text()}`));
+page.on('pageerror', (err) =>
+  console.log(`[pageerror] ${err.message}\n${(err.stack ?? '').split('\n').slice(0, 6).join('\n')}`),
+);
+page.on('requestfailed', (req) =>
+  console.log(`[requestfailed] ${req.url()} — ${req.failure()?.errorText}`),
+);
+
+await page.goto(url, { waitUntil: 'domcontentloaded' });
+await new Promise((r) => setTimeout(r, waitMs));
+
+const text = await page.evaluate(() => document.body.innerText.slice(0, 1200));
+console.log('--- body text ---');
+console.log(text || '(empty)');
+
+await browser.close();

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -1,0 +1,534 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { PassportAccount } from '../../src/wallet/account.js';
+import type { Ledger } from '../../src/wallet/contract.js';
+import { hexToBytes32 } from '../../src/wallet/hex.js';
+
+import { getMidnight, type Midnight } from './lib/midnight.js';
+import { compiledAccountContract } from './lib/providers.js';
+import { loadSession, saveSession, clearSession, type Session } from './lib/session.js';
+import { useTxTask, dismissTask, type TxTask } from './lib/txTracker.js';
+import { Busy, Mono } from './ui.js';
+
+import { OnboardView } from './views/Onboard.js';
+import { OverviewView } from './views/Overview.js';
+import { WalletPanel } from './views/WalletPanel.js';
+import { DevicesPanel } from './views/DevicesPanel.js';
+import { GrantsPanel } from './views/GrantsPanel.js';
+import { RecoveryPanel } from './views/RecoveryPanel.js';
+
+export interface AppContext {
+  mid: Midnight;
+  session: Session;
+  account: PassportAccount;
+  ledger: Ledger | null;
+  refreshLedger: () => Promise<void>;
+  log: (msg: string) => void;
+  nightColor: Uint8Array;
+  resetSession: () => void;
+  reconnect: (secrets: {
+    deviceSecret?: Uint8Array;
+    grantSecret?: Uint8Array;
+    recoverySecret?: Uint8Array;
+  }) => Promise<PassportAccount>;
+  setSession: (s: Session) => void;
+  /** Commitment (decimal string) of this browser's device secret, when known. */
+  deviceCommitment: string | null;
+  setDeviceCommitment: (c: string | null) => void;
+  goToStep: (step: StepId) => void;
+}
+
+export type StepId = 1 | 2 | 3 | 4 | 5;
+type ViewId = 'overview' | 'assets' | 'grants' | 'devices' | 'recovery';
+
+const STEP_VIEW: Record<StepId, ViewId> = {
+  1: 'overview',
+  2: 'assets',
+  3: 'grants',
+  4: 'grants',
+  5: 'recovery',
+};
+
+const STEPS: { n: StepId; title: string; sub: string }[] = [
+  { n: 1, title: 'Onboard', sub: 'Passkey → on-chain account' },
+  { n: 2, title: 'Fund the account', sub: 'Night & shielded custody' },
+  { n: 3, title: 'Spend via a grant', sub: 'The dApp holds a scoped credential' },
+  { n: 4, title: 'Revoke the grant', sub: 'The contract stops honouring it' },
+  { n: 5, title: 'Recover from total loss', sub: '2-of-3 shares, fresh device' },
+];
+
+export default function App() {
+  const [mid, setMid] = useState<Midnight | null>(null);
+  const [bootError, setBootError] = useState<string | null>(null);
+  const [session, setSessionState] = useState<Session | null>(() => loadSession());
+  const [account, setAccount] = useState<PassportAccount | null>(null);
+  const [ledger, setLedger] = useState<Ledger | null>(null);
+  const [logLines, setLogLines] = useState<string[]>([]);
+  const [deviceCommitment, setDeviceCommitment] = useState<string | null>(null);
+  const [nav, setNav] = useState<{ step: StepId | null; view: ViewId }>({
+    step: 1,
+    view: 'overview',
+  });
+
+  const log = useCallback((msg: string) => {
+    const time = new Date().toLocaleTimeString();
+    setLogLines((prev) => {
+      // StrictMode double-runs effects in dev; drop consecutive repeats.
+      if (prev.length > 0 && prev[prev.length - 1].endsWith(`  ${msg}`)) return prev;
+      return [...prev.slice(-199), `${time}  ${msg}`];
+    });
+    console.log(`[passport] ${msg}`);
+  }, []);
+
+  // Boot the Midnight context (wallet sync) once.
+  useEffect(() => {
+    log('connecting to localnet (syncing fee wallet)…');
+    getMidnight()
+      .then((m) => {
+        setMid(m);
+        log('localnet connected — fee wallet synced.');
+      })
+      .catch((e) => setBootError(String(e?.message ?? e)));
+  }, [log]);
+
+  const setSession = useCallback((s: Session) => {
+    saveSession(s);
+    setSessionState(s);
+  }, []);
+
+  const resetSession = useCallback(() => {
+    clearSession();
+    setSessionState(null);
+    setAccount(null);
+    setLedger(null);
+    setDeviceCommitment(null);
+    setNav({ step: 1, view: 'overview' });
+  }, []);
+
+  const refreshLedger = useCallback(async () => {
+    if (!account) return;
+    try {
+      setLedger(await account.ledgerState());
+    } catch (e: any) {
+      log(`ledger read failed: ${e?.message ?? e}`);
+    }
+  }, [account, log]);
+
+  // Poll the ledger while an account is connected.
+  useEffect(() => {
+    if (!account) return;
+    let stop = false;
+    const tick = async () => {
+      if (stop) return;
+      try {
+        setLedger(await account.ledgerState());
+      } catch {
+        /* not indexed yet */
+      }
+    };
+    tick();
+    const t = setInterval(tick, 5_000);
+    return () => {
+      stop = true;
+      clearInterval(t);
+    };
+  }, [account]);
+
+  const reconnect = useCallback(
+    async (secrets: {
+      deviceSecret?: Uint8Array;
+      grantSecret?: Uint8Array;
+      recoverySecret?: Uint8Array;
+    }) => {
+      if (!mid || !session) throw new Error('not connected');
+      return PassportAccount.connect(
+        mid.accountProviders,
+        compiledAccountContract(),
+        session.accountAddress,
+        secrets,
+      );
+    },
+    [mid, session],
+  );
+
+  const nightColor = useMemo(
+    () => (mid ? hexToBytes32(mid.nightColorHex) : new Uint8Array(32)),
+    [mid],
+  );
+
+  const goToStep = useCallback((step: StepId) => {
+    setNav({ step, view: STEP_VIEW[step] });
+  }, []);
+
+  if (bootError) {
+    return (
+      <div className="stage stage-center">
+        <BrandMark large />
+        <div className="panel boot-card">
+          <h2 className="eyebrow">Cannot reach the localnet</h2>
+          <p className="error">{bootError}</p>
+          <p className="hint">
+            Start it with <code>cd infra && docker compose -f docker-compose.yml -f
+            docker-compose.macos.yml up -d --wait</code> and reload.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!mid) {
+    return (
+      <div className="stage stage-center">
+        <BrandMark large />
+        <div className="boot-card">
+          <Busy label="Connecting to the localnet and syncing the fee wallet…" />
+        </div>
+      </div>
+    );
+  }
+
+  // Onboarding: no account session, or session but account handle not yet
+  // re-established (page reload → re-derive device secret from passkey).
+  if (!session || !account) {
+    return (
+      <div className="stage stage-onboard">
+        <div className="onboard-top">
+          <BrandMark />
+        </div>
+        <OnboardView
+          mid={mid}
+          session={session}
+          log={log}
+          onConnected={(s, a, commitment) => {
+            setSession(s);
+            setAccount(a);
+            setDeviceCommitment(commitment ?? null);
+            setNav({ step: 1, view: 'overview' });
+          }}
+          onReset={resetSession}
+        />
+        <div className="dock-stack">
+          <ProvingDock />
+          <ActivityDock lines={logLines} />
+        </div>
+      </div>
+    );
+  }
+
+  const ctx: AppContext = {
+    mid,
+    session,
+    account,
+    ledger,
+    refreshLedger,
+    log,
+    nightColor,
+    resetSession,
+    reconnect,
+    setSession,
+    deviceCommitment,
+    setDeviceCommitment,
+    goToStep,
+  };
+
+  const stepDone = journeyProgress(ledger, account);
+
+  return (
+    <div className="shell">
+      <Sidebar
+        nav={nav}
+        stepDone={stepDone}
+        onStep={goToStep}
+        onView={(view) => setNav({ step: null, view })}
+        round={ledger ? String(ledger.round) : '…'}
+        onDisconnect={resetSession}
+      />
+      <div className="main">
+        <HeaderStrip ctx={ctx} />
+        <div className="content">
+          <div className={`view ${nav.view === 'overview' ? '' : 'view-hidden'}`}>
+            <OverviewView ctx={ctx} />
+          </div>
+          <div className={`view ${nav.view === 'assets' ? '' : 'view-hidden'}`}>
+            <WalletPanel ctx={ctx} />
+          </div>
+          <div className={`view ${nav.view === 'grants' ? '' : 'view-hidden'}`}>
+            <GrantsPanel ctx={ctx} revokeBeat={nav.step === 4} />
+          </div>
+          <div className={`view ${nav.view === 'devices' ? '' : 'view-hidden'}`}>
+            <DevicesPanel ctx={ctx} />
+          </div>
+          <div className={`view ${nav.view === 'recovery' ? '' : 'view-hidden'}`}>
+            <RecoveryPanel
+              ctx={ctx}
+              onRecovered={(s, a, commitment) => {
+                setSession(s);
+                setAccount(a);
+                setDeviceCommitment(commitment ?? null);
+              }}
+            />
+          </div>
+        </div>
+        <div className="dock-stack">
+          <ProvingDock />
+          <ActivityDock lines={logLines} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Which demo beats are complete — derived from on-chain state, not clicks. */
+function journeyProgress(ledger: Ledger | null, account: PassportAccount | null) {
+  const grants = ledger ? [...ledger.grants] : [];
+  return {
+    1: !!account,
+    2:
+      !!ledger &&
+      ([...ledger.night_balances].some(([, v]) => v > 0n) ||
+        [...ledger.coins].some(([, q]) => q.value > 0n)),
+    3: grants.some(([, g]) => g.spent > 0n),
+    4: grants.some(([, g]) => !g.active),
+    5: !!ledger && ledger.device_epoch > 0n,
+  } as Record<StepId, boolean>;
+}
+
+function BrandMark(props: { large?: boolean }) {
+  return (
+    <div className={`brand ${props.large ? 'brand-large' : ''}`}>
+      <svg className="brand-glyph" viewBox="0 0 32 32" aria-hidden="true">
+        <rect x="1.5" y="1.5" width="29" height="29" rx="8" />
+        <path
+          className="brand-moon"
+          d="M20.8 7.4a9.4 9.4 0 1 0 3.6 13.8 7.6 7.6 0 0 1-3.6-13.8z"
+        />
+      </svg>
+      <div className="brand-words">
+        <span className="brand-name">Midnight Passport</span>
+        <span className="brand-tag">Account-custody prototype</span>
+      </div>
+    </div>
+  );
+}
+
+function Sidebar(props: {
+  nav: { step: StepId | null; view: ViewId };
+  stepDone: Record<StepId, boolean>;
+  onStep: (s: StepId) => void;
+  onView: (v: ViewId) => void;
+  round: string;
+  onDisconnect: () => void;
+}) {
+  return (
+    <aside className="sidebar">
+      <BrandMark />
+      <nav className="sidenav">
+        <p className="nav-label">Demo flow</p>
+        {STEPS.map((s) => {
+          const active = props.nav.step === s.n;
+          return (
+            <button
+              key={s.n}
+              className={`step ${active ? 'step-active' : ''} ${props.stepDone[s.n] ? 'step-done' : ''}`}
+              onClick={() => props.onStep(s.n)}
+            >
+              <span className="step-num">{`0${s.n}`}</span>
+              <span className="step-words">
+                <span className="step-title">{s.title}</span>
+                <span className="step-sub">{s.sub}</span>
+              </span>
+              <span className="step-check">{props.stepDone[s.n] ? '✓' : ''}</span>
+            </button>
+          );
+        })}
+        <p className="nav-label">Browse</p>
+        <button
+          className={`step step-flat ${props.nav.view === 'devices' ? 'step-active' : ''}`}
+          onClick={() => props.onView('devices')}
+        >
+          <span className="step-num">∙</span>
+          <span className="step-words">
+            <span className="step-title">Devices</span>
+            <span className="step-sub">Epochs & commitments</span>
+          </span>
+        </button>
+      </nav>
+      <footer className="side-foot">
+        <span className="netdot" />
+        <span className="side-net">
+          localnet · round <span className="side-round">{props.round}</span>
+        </span>
+        <button className="linkish" onClick={props.onDisconnect}>
+          disconnect
+        </button>
+      </footer>
+    </aside>
+  );
+}
+
+function HeaderStrip({ ctx }: { ctx: AppContext }) {
+  const { session, ledger } = ctx;
+  return (
+    <header className="topbar">
+      <div className="topbar-id">
+        {/* "Passport account" stays verbatim — the e2e harness waits for it. */}
+        <span className="eyebrow">Passport account</span>
+        <Mono v={session.accountAddress} short className="topbar-addr" />
+      </div>
+      <div className="topbar-stats">
+        <TopStat k="round" v={ledger ? String(ledger.round) : '…'} />
+        <TopStat k="epoch" v={ledger ? String(ledger.device_epoch) : '…'} />
+        <TopStat k="devices" v={ledger ? String(ledger.device_count) : '…'} />
+      </div>
+    </header>
+  );
+}
+
+function TopStat(props: { k: string; v: string }) {
+  return (
+    <div className="topstat">
+      <span className="topstat-k">{props.k}</span>
+      <span className="topstat-v" key={props.v}>
+        {props.v}
+      </span>
+    </div>
+  );
+}
+
+const PHASES: { id: TxTask['phase']; label: string; detail: string }[] = [
+  { id: 'build', label: 'Build', detail: 'executing the circuit in this browser' },
+  { id: 'prove', label: 'Prove', detail: 'zero-knowledge proof on the proof server' },
+  { id: 'submit', label: 'Submit', detail: 'balancing, signing & confirming' },
+];
+
+function ProvingDock() {
+  const task = useTxTask();
+  const [, setTick] = useState(0);
+
+  // Tick the elapsed timer while a task is running.
+  useEffect(() => {
+    if (!task || task.phase === 'done' || task.phase === 'error') return;
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [task?.id, task?.phase]);
+
+  // Auto-dismiss a landed task after a while.
+  useEffect(() => {
+    if (!task || task.phase !== 'done') return;
+    const t = setTimeout(() => dismissTask(task.id), 45_000);
+    return () => clearTimeout(t);
+  }, [task?.id, task?.phase]);
+
+  if (!task) return null;
+
+  const elapsed = fmtElapsed((task.endedAt ?? Date.now()) - task.startedAt);
+  const phaseIdx = PHASES.findIndex((p) => p.id === task.phase);
+
+  if (task.phase === 'error') {
+    return (
+      <div className="provedock provedock-error">
+        <div className="provedock-row">
+          <span className="chip chip-danger">failed</span>
+          <span className="provedock-label">{task.label}</span>
+          <code className="provedock-circuit">{task.circuit}</code>
+          <span className="provedock-spacer" />
+          <span className="provedock-msg">{task.error}</span>
+          <button className="linkish" onClick={() => dismissTask(task.id)}>
+            dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (task.phase === 'done') {
+    return (
+      <div className="provedock provedock-done">
+        <div className="provedock-row">
+          <span className="chip chip-ok">landed</span>
+          <span className="provedock-label">{task.label}</span>
+          <code className="provedock-circuit">{task.circuit}</code>
+          <span className="provedock-spacer" />
+          {task.txId && (
+            <>
+              <span className="provedock-txk">tx</span> <Mono v={task.txId} short />
+            </>
+          )}
+          <span className="provedock-elapsed">{elapsed}</span>
+          <button className="linkish" onClick={() => dismissTask(task.id)}>
+            dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="provedock provedock-live">
+      <div className="provedock-scan" />
+      <div className="provedock-row">
+        <span className="provedock-pulse" />
+        <span className="provedock-label">{task.label}</span>
+        <code className="provedock-circuit">{task.circuit}</code>
+        <span className="provedock-spacer" />
+        <div className="provedock-phases">
+          {PHASES.map((p, i) => (
+            <span
+              key={p.id}
+              className={`phase ${i < phaseIdx ? 'phase-done' : ''} ${i === phaseIdx ? 'phase-live' : ''}`}
+              title={p.detail}
+            >
+              {i < phaseIdx ? '✓ ' : ''}
+              {p.label}
+            </span>
+          ))}
+        </div>
+        <span className="provedock-elapsed">{elapsed}</span>
+      </div>
+      <p className="provedock-detail">{PHASES[phaseIdx]?.detail} — real proving takes minutes.</p>
+    </div>
+  );
+}
+
+function fmtElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function ActivityDock({ lines }: { lines: string[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    ref.current?.scrollTo({ top: ref.current.scrollHeight });
+  }, [lines, open]);
+  return (
+    <div className={`activity ${open ? '' : 'activity-closed'}`}>
+      <button className="activity-head" onClick={() => setOpen((o) => !o)}>
+        <span className="eyebrow">Activity</span>
+        <span className="activity-count">{lines.length}</span>
+        <span className="activity-toggle">{open ? '▾' : '▴'}</span>
+      </button>
+      {open && (
+        <div className="activity-body" ref={ref}>
+          {lines.length === 0 && <div className="activity-line dim">no activity yet</div>}
+          {lines.map((l, i) => (
+            <ActivityLine key={i} line={l} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Render "… → tx <id>" suffixes as copyable chips, keep the rest verbatim.
+function ActivityLine({ line }: { line: string }) {
+  const m = line.match(/^(.*→ tx )([0-9a-fA-F]{16,})(.*)$/);
+  if (!m) return <div className="activity-line">{line}</div>;
+  return (
+    <div className="activity-line">
+      {m[1]}
+      <Mono v={m[2]} short />
+      {m[3]}
+    </div>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -546,7 +546,8 @@ function fmtElapsed(ms: number): string {
 
 function ActivityDock({ lines }: { lines: string[] }) {
   const ref = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(true);
+  // Collapsed by default on phones — vertical space is the scarce resource.
+  const [open, setOpen] = useState(() => window.innerWidth >= 700);
   useEffect(() => {
     ref.current?.scrollTo({ top: ref.current.scrollHeight });
   }, [lines, open]);

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -35,26 +35,67 @@ export interface AppContext {
   /** Commitment (decimal string) of this browser's device secret, when known. */
   deviceCommitment: string | null;
   setDeviceCommitment: (c: string | null) => void;
-  goToStep: (step: StepId) => void;
+  goToView: (view: ViewId) => void;
 }
 
-export type StepId = 1 | 2 | 3 | 4 | 5;
-type ViewId = 'overview' | 'assets' | 'grants' | 'devices' | 'recovery';
+export type ViewId = 'overview' | 'assets' | 'grants' | 'devices' | 'recovery';
 
-const STEP_VIEW: Record<StepId, ViewId> = {
-  1: 'overview',
-  2: 'assets',
-  3: 'grants',
-  4: 'grants',
-  5: 'recovery',
-};
-
-const STEPS: { n: StepId; title: string; sub: string }[] = [
-  { n: 1, title: 'Onboard', sub: 'Passkey → on-chain account' },
-  { n: 2, title: 'Fund the account', sub: 'Night & shielded custody' },
-  { n: 3, title: 'Spend via a grant', sub: 'The dApp holds a scoped credential' },
-  { n: 4, title: 'Revoke the grant', sub: 'The contract stops honouring it' },
-  { n: 5, title: 'Recover from total loss', sub: '2-of-3 shares, fresh device' },
+// App navigation — five surfaces, no demo-flow numbering. The functional
+// labels double as the screenshot harness's navigation targets.
+const NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9">
+        <rect x="3.5" y="3.5" width="7.5" height="7.5" rx="2" />
+        <rect x="13" y="3.5" width="7.5" height="7.5" rx="2" />
+        <rect x="3.5" y="13" width="7.5" height="7.5" rx="2" />
+        <rect x="13" y="13" width="7.5" height="7.5" rx="2" />
+      </svg>
+    ),
+  },
+  {
+    id: 'assets',
+    label: 'Holdings',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9">
+        <rect x="3" y="6" width="18" height="13" rx="2.5" />
+        <path d="M3 10h18M7 15h4" />
+      </svg>
+    ),
+  },
+  {
+    id: 'grants',
+    label: 'Connections',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9">
+        <circle cx="12" cy="12" r="3.2" />
+        <path d="M12 2.8v4M12 17.2v4M2.8 12h4M17.2 12h4" />
+      </svg>
+    ),
+  },
+  {
+    id: 'devices',
+    label: 'Devices',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9">
+        <rect x="3" y="5" width="13" height="9" rx="1.8" />
+        <path d="M6.5 18h6M9.5 14v4" />
+        <rect x="17" y="9" width="4.5" height="9" rx="1.4" />
+      </svg>
+    ),
+  },
+  {
+    id: 'recovery',
+    label: 'Recovery',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9">
+        <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7z" />
+        <path d="M9 12l2 2 4-4.5" />
+      </svg>
+    ),
+  },
 ];
 
 export default function App() {
@@ -65,11 +106,15 @@ export default function App() {
   const [ledger, setLedger] = useState<Ledger | null>(null);
   const [logLines, setLogLines] = useState<string[]>([]);
   const [deviceCommitment, setDeviceCommitment] = useState<string | null>(null);
-  const [nav, setNav] = useState<{ step: StepId | null; view: ViewId }>({
-    step: 1,
-    view: 'overview',
-  });
+  const [nav, setNav] = useState<ViewId>('overview');
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [explain, setExplain] = useState(() => localStorage.getItem('passport-explain') !== '0');
+
+  // Hover explainers: a body attribute the CSS and the tooltip listen to.
+  useEffect(() => {
+    document.body.dataset.explain = explain ? '1' : '0';
+    localStorage.setItem('passport-explain', explain ? '1' : '0');
+  }, [explain]);
 
   const log = useCallback((msg: string) => {
     const time = new Date().toLocaleTimeString();
@@ -108,8 +153,19 @@ export default function App() {
     setAccount(null);
     setLedger(null);
     setDeviceCommitment(null);
-    setNav({ step: 1, view: 'overview' });
+    setNav('overview');
   }, []);
+
+  // Lock: drop the in-memory account handle (and with it the device secret's
+  // session) but keep the remembered session — the unlock screen re-derives
+  // the secret from the passkey.
+  const lock = useCallback(() => {
+    log('session locked — the device secret is dropped; a passkey re-derives it next time.');
+    setAccount(null);
+    setLedger(null);
+    setDeviceCommitment(null);
+    setNav('overview');
+  }, [log]);
 
   const refreshLedger = useCallback(async () => {
     if (!account) return;
@@ -162,8 +218,8 @@ export default function App() {
     [mid],
   );
 
-  const goToStep = useCallback((step: StepId) => {
-    setNav({ step, view: STEP_VIEW[step] });
+  const goToView = useCallback((view: ViewId) => {
+    setNav(view);
   }, []);
 
   if (bootError) {
@@ -210,7 +266,7 @@ export default function App() {
             setSession(s);
             setAccount(a);
             setDeviceCommitment(commitment ?? null);
-            setNav({ step: 1, view: 'overview' });
+            setNav('overview');
           }}
           onReset={resetSession}
         />
@@ -218,6 +274,7 @@ export default function App() {
           <ProvingDock />
           <ActivityDock lines={logLines} />
         </div>
+        <ExplainTip />
       </div>
     );
   }
@@ -235,10 +292,10 @@ export default function App() {
     setSession,
     deviceCommitment,
     setDeviceCommitment,
-    goToStep,
+    goToView,
   };
 
-  const stepDone = journeyProgress(ledger, account);
+  const counts = navCounts(ledger);
 
   return (
     <div className="shell">
@@ -247,34 +304,35 @@ export default function App() {
       <Sidebar
         open={drawerOpen}
         nav={nav}
-        stepDone={stepDone}
-        onStep={(s) => {
-          goToStep(s);
-          setDrawerOpen(false);
-        }}
+        counts={counts}
         onView={(view) => {
-          setNav({ step: null, view });
+          goToView(view);
           setDrawerOpen(false);
         }}
         round={ledger ? String(ledger.round) : '…'}
         onDisconnect={resetSession}
       />
       <div className="main">
-        <HeaderStrip ctx={ctx} />
+        <HeaderStrip
+          ctx={ctx}
+          explain={explain}
+          onToggleExplain={() => setExplain((e) => !e)}
+          onLock={lock}
+        />
         <div className="content">
-          <div className={`view ${nav.view === 'overview' ? '' : 'view-hidden'}`}>
+          <div className={`view ${nav === 'overview' ? '' : 'view-hidden'}`}>
             <OverviewView ctx={ctx} />
           </div>
-          <div className={`view ${nav.view === 'assets' ? '' : 'view-hidden'}`}>
+          <div className={`view ${nav === 'assets' ? '' : 'view-hidden'}`}>
             <WalletPanel ctx={ctx} />
           </div>
-          <div className={`view ${nav.view === 'grants' ? '' : 'view-hidden'}`}>
-            <GrantsPanel ctx={ctx} revokeBeat={nav.step === 4} />
+          <div className={`view ${nav === 'grants' ? '' : 'view-hidden'}`}>
+            <GrantsPanel ctx={ctx} />
           </div>
-          <div className={`view ${nav.view === 'devices' ? '' : 'view-hidden'}`}>
+          <div className={`view ${nav === 'devices' ? '' : 'view-hidden'}`}>
             <DevicesPanel ctx={ctx} />
           </div>
-          <div className={`view ${nav.view === 'recovery' ? '' : 'view-hidden'}`}>
+          <div className={`view ${nav === 'recovery' ? '' : 'view-hidden'}`}>
             <RecoveryPanel
               ctx={ctx}
               onRecovered={(s, a, commitment) => {
@@ -290,23 +348,22 @@ export default function App() {
           <ActivityDock lines={logLines} />
         </div>
       </div>
+      <ExplainTip />
     </div>
   );
 }
 
-/** Which demo beats are complete — derived from on-chain state, not clicks. */
-function journeyProgress(ledger: Ledger | null, account: PassportAccount | null) {
-  const grants = ledger ? [...ledger.grants] : [];
+/** Live counts for the nav badges — derived from on-chain state. */
+function navCounts(ledger: Ledger | null): Partial<Record<ViewId, number>> {
+  if (!ledger) return {};
+  const epoch = ledger.device_epoch;
   return {
-    1: !!account,
-    2:
-      !!ledger &&
-      ([...ledger.night_balances].some(([, v]) => v > 0n) ||
-        [...ledger.coins].some(([, q]) => q.value > 0n)),
-    3: grants.some(([, g]) => g.spent > 0n),
-    4: grants.some(([, g]) => !g.active),
-    5: !!ledger && ledger.device_epoch > 0n,
-  } as Record<StepId, boolean>;
+    assets:
+      [...ledger.night_balances].filter(([, v]) => v > 0n).length +
+      [...ledger.coins].filter(([, q]) => q.value > 0n).length,
+    grants: [...ledger.grants].filter(([, g]) => g.active && g.epoch === epoch).length,
+    devices: [...ledger.devices].filter(([, e]) => e === epoch).length,
+  };
 }
 
 function BrandMark(props: { large?: boolean }) {
@@ -354,9 +411,8 @@ function MobileBar(props: { onMenu: () => void }) {
 
 function Sidebar(props: {
   open: boolean;
-  nav: { step: StepId | null; view: ViewId };
-  stepDone: Record<StepId, boolean>;
-  onStep: (s: StepId) => void;
+  nav: ViewId;
+  counts: Partial<Record<ViewId, number>>;
   onView: (v: ViewId) => void;
   round: string;
   onDisconnect: () => void;
@@ -365,79 +421,130 @@ function Sidebar(props: {
     <aside className={`sidebar ${props.open ? 'sidebar-open' : ''}`}>
       <BrandMark />
       <nav className="sidenav">
-        <p className="nav-label">Demo flow</p>
-        {STEPS.map((s) => {
-          const active = props.nav.step === s.n;
-          return (
-            <button
-              key={s.n}
-              className={`step ${active ? 'step-active' : ''} ${props.stepDone[s.n] ? 'step-done' : ''}`}
-              onClick={() => props.onStep(s.n)}
-            >
-              <span className="step-num">{`0${s.n}`}</span>
-              <span className="step-words">
-                <span className="step-title">{s.title}</span>
-                <span className="step-sub">{s.sub}</span>
-              </span>
-              <span className="step-check">{props.stepDone[s.n] ? '✓' : ''}</span>
-            </button>
-          );
-        })}
-        <p className="nav-label">Browse</p>
-        <button
-          className={`step step-flat ${props.nav.view === 'devices' ? 'step-active' : ''}`}
-          onClick={() => props.onView('devices')}
-        >
-          <span className="step-num">∙</span>
-          <span className="step-words">
-            <span className="step-title">Devices</span>
-            <span className="step-sub">Epochs & commitments</span>
-          </span>
-        </button>
+        {NAV.map((item) => (
+          <button
+            key={item.id}
+            className={`step ${props.nav === item.id ? 'step-active' : ''}`}
+            onClick={() => props.onView(item.id)}
+          >
+            <span className="step-ico">{item.icon}</span>
+            <span className="step-title">{item.label}</span>
+            {props.counts[item.id] !== undefined && (
+              <span className="step-n">{props.counts[item.id]}</span>
+            )}
+          </button>
+        ))}
       </nav>
       <footer className="side-foot">
         <div className="side-foot-row">
           <span className="netdot" />
-          <span className="side-net">
+          <span
+            className="side-net x"
+            data-x="Live connection to the Midnight network. Every balance and status in this app is read from chain state, not from a database; there is no server of ours behind it (P8)."
+          >
             localnet · round <span className="side-round">{props.round}</span>
           </span>
           <button className="linkish" onClick={props.onDisconnect}>
             disconnect
           </button>
         </div>
-        <ProverChip />
+        <p className="side-fine">Self-custodial · no operator</p>
       </footer>
     </aside>
   );
 }
 
-function HeaderStrip({ ctx }: { ctx: AppContext }) {
-  const { session, ledger } = ctx;
+function HeaderStrip(props: {
+  ctx: AppContext;
+  explain: boolean;
+  onToggleExplain: () => void;
+  onLock: () => void;
+}) {
+  const { session, ledger } = props.ctx;
   return (
     <header className="topbar">
       <div className="topbar-id">
         {/* "Passport account" stays verbatim — the e2e harness waits for it. */}
         <span className="eyebrow">Passport account</span>
-        <Mono v={session.accountAddress} short className="topbar-addr" />
+        <span
+          className="x"
+          data-x="The address of your personal account contract on Midnight. The passport is the contract; anyone can verify this document against the ledger."
+        >
+          <Mono v={session.accountAddress} short className="topbar-addr" />
+        </span>
       </div>
-      <div className="topbar-stats">
-        <TopStat k="round" v={ledger ? String(ledger.round) : '…'} />
-        <TopStat k="epoch" v={ledger ? String(ledger.device_epoch) : '…'} />
-        <TopStat k="devices" v={ledger ? String(ledger.device_count) : '…'} />
-      </div>
+      <span className="topbar-spacer" />
+      <span
+        className="statchip x"
+        data-x="The current ledger round and your device epoch. The epoch is bumped by recovery, which instantly retires every previously enrolled device and grant (P4, P5)."
+      >
+        round <b>{ledger ? String(ledger.round) : '…'}</b> · epoch{' '}
+        <b>{ledger ? String(ledger.device_epoch) : '…'}</b>
+      </span>
+      <span
+        className="x"
+        data-x={
+          BROWSER_PROVER
+            ? 'Zero-knowledge proofs are computed on this device by a wasm prover. Transactions leave your hands already proven; no proof server sees your witnesses (P6).'
+            : 'Proofs are computed by the local Docker proof server. Add ?prover=server to a URL to force this mode; the default is on-device proving.'
+        }
+      >
+        <ProverChip />
+      </span>
+      <button
+        className={`xtoggle ${props.explain ? 'xtoggle-on' : ''}`}
+        onClick={props.onToggleExplain}
+        title="Toggle hover explainers"
+      >
+        explain · {props.explain ? 'on' : 'off'}
+      </button>
+      <button className="lockbtn" onClick={props.onLock} title="Lock the session">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="4" y="10" width="16" height="11" rx="2.5" />
+          <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+        </svg>
+      </button>
     </header>
   );
 }
 
-function TopStat(props: { k: string; v: string }) {
-  return (
-    <div className="topstat">
-      <span className="topstat-k">{props.k}</span>
-      <span className="topstat-v" key={props.v}>
-        {props.v}
-      </span>
-    </div>
-  );
+/** Floating tooltip for the hover explainers ([data-x] elements). */
+function ExplainTip() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const tip = ref.current;
+    if (!tip) return;
+    let current: Element | null = null;
+    const over = (e: MouseEvent) => {
+      const el = (e.target as Element | null)?.closest?.('[data-x]');
+      if (!el || document.body.dataset.explain !== '1') return;
+      current = el;
+      tip.innerHTML =
+        '<span class="xtip-k">what you are seeing</span>' +
+        ((el as HTMLElement).dataset.x ?? '');
+      tip.classList.add('on');
+    };
+    const move = (e: MouseEvent) => {
+      if (!tip.classList.contains('on')) return;
+      tip.style.left = `${Math.min(e.clientX + 16, window.innerWidth - 350)}px`;
+      tip.style.top = `${Math.min(e.clientY + 18, window.innerHeight - tip.offsetHeight - 12)}px`;
+    };
+    const out = (e: MouseEvent) => {
+      if (current && !current.contains(e.relatedTarget as Node)) {
+        tip.classList.remove('on');
+        current = null;
+      }
+    };
+    document.addEventListener('mouseover', over);
+    document.addEventListener('mousemove', move);
+    document.addEventListener('mouseout', out);
+    return () => {
+      document.removeEventListener('mouseover', over);
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseout', out);
+    };
+  }, []);
+  return <div id="xtip" ref={ref} />;
 }
 
 const PHASES: { id: TxTask['phase']; label: string; detail: string }[] = [

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -515,6 +515,10 @@ function ExplainTip() {
     const tip = ref.current;
     if (!tip) return;
     let current: Element | null = null;
+    const place = (e: MouseEvent) => {
+      tip.style.left = `${Math.min(e.clientX + 16, window.innerWidth - 350)}px`;
+      tip.style.top = `${Math.min(e.clientY + 18, window.innerHeight - tip.offsetHeight - 12)}px`;
+    };
     const over = (e: MouseEvent) => {
       const el = (e.target as Element | null)?.closest?.('[data-x]');
       if (!el || document.body.dataset.explain !== '1') return;
@@ -523,11 +527,11 @@ function ExplainTip() {
         '<span class="xtip-k">what you are seeing</span>' +
         ((el as HTMLElement).dataset.x ?? '');
       tip.classList.add('on');
+      place(e);
     };
     const move = (e: MouseEvent) => {
       if (!tip.classList.contains('on')) return;
-      tip.style.left = `${Math.min(e.clientX + 16, window.innerWidth - 350)}px`;
-      tip.style.top = `${Math.min(e.clientY + 18, window.innerHeight - tip.offsetHeight - 12)}px`;
+      place(e);
     };
     const out = (e: MouseEvent) => {
       if (current && !current.contains(e.relatedTarget as Node)) {

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -88,7 +88,9 @@ export default function App() {
         setMid(m);
         log('localnet connected — fee wallet synced.');
         if (BROWSER_PROVER) {
-          log('browser proving enabled — contract circuits prove in this tab (zkir-v2 wasm).');
+          log(
+            'browser proving enabled — ALL proofs (contract circuits, zswap, dust) are computed in this tab; no proof server.',
+          );
         }
       })
       .catch((e) => setBootError(String(e?.message ?? e)));

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -8,7 +8,7 @@ import { getMidnight, type Midnight } from './lib/midnight.js';
 import { compiledAccountContract, BROWSER_PROVER } from './lib/providers.js';
 import { loadSession, saveSession, clearSession, type Session } from './lib/session.js';
 import { useTxTask, dismissTask, type TxTask } from './lib/txTracker.js';
-import { Busy, Mono } from './ui.js';
+import { Busy, Mono, Chip } from './ui.js';
 
 import { OnboardView } from './views/Onboard.js';
 import { OverviewView } from './views/Overview.js';
@@ -69,6 +69,7 @@ export default function App() {
     step: 1,
     view: 'overview',
   });
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const log = useCallback((msg: string) => {
     const time = new Date().toLocaleTimeString();
@@ -199,6 +200,7 @@ export default function App() {
       <div className="stage stage-onboard">
         <div className="onboard-top">
           <BrandMark />
+          <ProverChip />
         </div>
         <OnboardView
           mid={mid}
@@ -240,11 +242,20 @@ export default function App() {
 
   return (
     <div className="shell">
+      <MobileBar onMenu={() => setDrawerOpen(true)} />
+      {drawerOpen && <div className="scrim" onClick={() => setDrawerOpen(false)} />}
       <Sidebar
+        open={drawerOpen}
         nav={nav}
         stepDone={stepDone}
-        onStep={goToStep}
-        onView={(view) => setNav({ step: null, view })}
+        onStep={(s) => {
+          goToStep(s);
+          setDrawerOpen(false);
+        }}
+        onView={(view) => {
+          setNav({ step: null, view });
+          setDrawerOpen(false);
+        }}
         round={ledger ? String(ledger.round) : '…'}
         onDisconnect={resetSession}
       />
@@ -316,7 +327,30 @@ function BrandMark(props: { large?: boolean }) {
   );
 }
 
+function ProverChip() {
+  return (
+    <Chip tone={BROWSER_PROVER ? 'info' : 'muted'}>
+      {BROWSER_PROVER ? 'prover · this device' : 'prover · local server'}
+    </Chip>
+  );
+}
+
+// Compact top bar shown only on narrow screens (the sidebar becomes a drawer).
+function MobileBar(props: { onMenu: () => void }) {
+  return (
+    <div className="mobilebar">
+      <button className="menu-btn" onClick={props.onMenu} aria-label="open menu">
+        ☰
+      </button>
+      <BrandMark />
+      <span className="mobilebar-spacer" />
+      <ProverChip />
+    </div>
+  );
+}
+
 function Sidebar(props: {
+  open: boolean;
   nav: { step: StepId | null; view: ViewId };
   stepDone: Record<StepId, boolean>;
   onStep: (s: StepId) => void;
@@ -325,7 +359,7 @@ function Sidebar(props: {
   onDisconnect: () => void;
 }) {
   return (
-    <aside className="sidebar">
+    <aside className={`sidebar ${props.open ? 'sidebar-open' : ''}`}>
       <BrandMark />
       <nav className="sidenav">
         <p className="nav-label">Demo flow</p>
@@ -359,13 +393,16 @@ function Sidebar(props: {
         </button>
       </nav>
       <footer className="side-foot">
-        <span className="netdot" />
-        <span className="side-net">
-          localnet · round <span className="side-round">{props.round}</span>
-        </span>
-        <button className="linkish" onClick={props.onDisconnect}>
-          disconnect
-        </button>
+        <div className="side-foot-row">
+          <span className="netdot" />
+          <span className="side-net">
+            localnet · round <span className="side-round">{props.round}</span>
+          </span>
+          <button className="linkish" onClick={props.onDisconnect}>
+            disconnect
+          </button>
+        </div>
+        <ProverChip />
       </footer>
     </aside>
   );
@@ -481,6 +518,7 @@ function ProvingDock() {
         <span className="provedock-pulse" />
         <span className="provedock-label">{task.label}</span>
         <code className="provedock-circuit">{task.circuit}</code>
+        {BROWSER_PROVER && <Chip tone="info">on-device</Chip>}
         <span className="provedock-spacer" />
         <div className="provedock-phases">
           {PHASES.map((p, i) => (

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -5,7 +5,7 @@ import type { Ledger } from '../../src/wallet/contract.js';
 import { hexToBytes32 } from '../../src/wallet/hex.js';
 
 import { getMidnight, type Midnight } from './lib/midnight.js';
-import { compiledAccountContract } from './lib/providers.js';
+import { compiledAccountContract, BROWSER_PROVER } from './lib/providers.js';
 import { loadSession, saveSession, clearSession, type Session } from './lib/session.js';
 import { useTxTask, dismissTask, type TxTask } from './lib/txTracker.js';
 import { Busy, Mono } from './ui.js';
@@ -87,6 +87,9 @@ export default function App() {
       .then((m) => {
         setMid(m);
         log('localnet connected — fee wallet synced.');
+        if (BROWSER_PROVER) {
+          log('browser proving enabled — contract circuits prove in this tab (zkir-v2 wasm).');
+        }
       })
       .catch((e) => setBootError(String(e?.message ?? e)));
   }, [log]);
@@ -397,7 +400,13 @@ function TopStat(props: { k: string; v: string }) {
 
 const PHASES: { id: TxTask['phase']; label: string; detail: string }[] = [
   { id: 'build', label: 'Build', detail: 'executing the circuit in this browser' },
-  { id: 'prove', label: 'Prove', detail: 'zero-knowledge proof on the proof server' },
+  {
+    id: 'prove',
+    label: 'Prove',
+    detail: BROWSER_PROVER
+      ? 'computing the zero-knowledge proof in this browser (zkir-v2 wasm)'
+      : 'zero-knowledge proof on the proof server',
+  },
   { id: 'submit', label: 'Submit', detail: 'balancing, signing & confirming' },
 ];
 

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -534,7 +534,9 @@ function ProvingDock() {
         </div>
         <span className="provedock-elapsed">{elapsed}</span>
       </div>
-      <p className="provedock-detail">{PHASES[phaseIdx]?.detail} — real proving takes minutes.</p>
+      <p className="provedock-detail">
+        {PHASES[phaseIdx]?.detail} — real cryptographic work in progress.
+      </p>
     </div>
   );
 }

--- a/experiments/account-custody-prototype/app/src/App.tsx
+++ b/experiments/account-custody-prototype/app/src/App.tsx
@@ -310,14 +310,17 @@ function journeyProgress(ledger: Ledger | null, account: PassportAccount | null)
 }
 
 function BrandMark(props: { large?: boolean }) {
+  // Crescent marque (sketch 005). The mask carves a true crescent so the
+  // glyph works on any background; the id must be unique per instance.
+  const maskId = React.useId();
   return (
     <div className={`brand ${props.large ? 'brand-large' : ''}`}>
       <svg className="brand-glyph" viewBox="0 0 32 32" aria-hidden="true">
-        <rect x="1.5" y="1.5" width="29" height="29" rx="8" />
-        <path
-          className="brand-moon"
-          d="M20.8 7.4a9.4 9.4 0 1 0 3.6 13.8 7.6 7.6 0 0 1-3.6-13.8z"
-        />
+        <mask id={maskId}>
+          <rect width="32" height="32" fill="white" />
+          <circle cx="21.2" cy="11.8" r="10.6" fill="black" />
+        </mask>
+        <circle cx="16" cy="16" r="14.5" fill="#d92c25" mask={`url(#${maskId})`} />
       </svg>
       <div className="brand-words">
         <span className="brand-name">Midnight Passport</span>

--- a/experiments/account-custody-prototype/app/src/lib/midnight.ts
+++ b/experiments/account-custody-prototype/app/src/lib/midnight.ts
@@ -1,0 +1,72 @@
+// Lazily-initialised Midnight context shared by the whole app:
+// genesis fee wallet (synced), providers for the account and faucet
+// contracts, and the faucet handle.
+
+import { firstValueFrom } from 'rxjs';
+import { findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+
+import {
+  createWallet,
+  createProviders,
+  awaitSync,
+  compiledFaucetContract,
+  type WalletContext,
+  GENESIS_SEED,
+} from './providers.js';
+
+declare const __FAUCET_ADDRESS__: string;
+
+export interface Midnight {
+  walletCtx: WalletContext;
+  accountProviders: any;
+  faucetProviders: any;
+  nightColorHex: string;
+  faucetAddress: string;
+}
+
+let booted: Promise<Midnight> | null = null;
+
+export function getMidnight(): Promise<Midnight> {
+  if (!booted) booted = init();
+  return booted;
+}
+
+async function init(): Promise<Midnight> {
+  const walletCtx = await createWallet(GENESIS_SEED);
+  const state = await awaitSync(walletCtx);
+
+  const held = Object.entries(state.unshielded.balances as Record<string, bigint>);
+  if (held.length === 0) {
+    throw new Error('Genesis wallet holds no Night — is the localnet up and seeded?');
+  }
+  const [nightColorHex] = held[0];
+
+  const accountProviders = await createProviders(walletCtx, 'account');
+  const faucetProviders = await createProviders(walletCtx, 'faucet');
+
+  return {
+    walletCtx,
+    accountProviders,
+    faucetProviders,
+    nightColorHex,
+    faucetAddress: __FAUCET_ADDRESS__ ?? '',
+  };
+}
+
+export async function walletState(mid: Midnight): Promise<any> {
+  return firstValueFrom(mid.walletCtx.wallet.state());
+}
+
+let faucetHandle: { address: string; handle: any } | null = null;
+
+export async function getFaucet(mid: Midnight, address: string): Promise<any> {
+  if (faucetHandle?.address === address) return faucetHandle.handle;
+  const handle = await (findDeployedContract as any)(mid.faucetProviders, {
+    contractAddress: address,
+    compiledContract: compiledFaucetContract(),
+    privateStateId: 'faucet-demo',
+    initialPrivateState: {},
+  });
+  faucetHandle = { address, handle };
+  return handle;
+}

--- a/experiments/account-custody-prototype/app/src/lib/passkey.ts
+++ b/experiments/account-custody-prototype/app/src/lib/passkey.ts
@@ -1,0 +1,103 @@
+// Passkey (WebAuthn) device-secret derivation via the PRF extension.
+//
+// The device secret is the PRF output for a fixed, domain-separated salt —
+// it never exists outside this browsing context, is re-derivable on every
+// future assertion from the same authenticator, and is hardware-bound to
+// the extent the authenticator is (C9 territory).
+//
+// Flow notes:
+//   - PRF results are only guaranteed during get() (assertion), not during
+//     create(), so onboarding performs create() followed by one get().
+//   - Browsers require a user gesture and a secure context (localhost is
+//     fine for the demo).
+
+const PRF_SALT = new TextEncoder().encode('midnight:passport:prf:device:v0');
+
+const RP_NAME = 'Midnight Passport Prototype';
+
+export interface PasskeyRef {
+  credentialIdB64: string;
+  label: string;
+}
+
+function b64encode(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+function b64decode(s: string): Uint8Array<ArrayBuffer> {
+  const bytes = atob(s);
+  const out = new Uint8Array(new ArrayBuffer(bytes.length));
+  for (let i = 0; i < bytes.length; i++) out[i] = bytes.charCodeAt(i);
+  return out;
+}
+
+export async function createPasskey(label: string): Promise<PasskeyRef> {
+  const cred = (await navigator.credentials.create({
+    publicKey: {
+      rp: { name: RP_NAME, id: window.location.hostname },
+      user: {
+        id: crypto.getRandomValues(new Uint8Array(16)),
+        name: label,
+        displayName: label,
+      },
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 }, // RS256
+      ],
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'required',
+      },
+      extensions: { prf: {} } as any,
+    },
+  })) as PublicKeyCredential | null;
+  if (!cred) throw new Error('passkey creation was cancelled');
+
+  const ext: any = cred.getClientExtensionResults();
+  if (!ext?.prf?.enabled) {
+    throw new Error(
+      'This authenticator does not support the WebAuthn PRF extension. ' +
+        'Use a platform passkey (Touch ID / Windows Hello / recent Android) or a PRF-capable security key.',
+    );
+  }
+  return { credentialIdB64: b64encode(cred.rawId), label };
+}
+
+/**
+ * Evaluate the PRF for our fixed salt — returns the 32-byte device secret.
+ * When `ref` is omitted the browser offers any resident passkey for this
+ * origin (used by "connect existing account" and recovery flows).
+ */
+export async function deriveDeviceSecret(ref?: PasskeyRef): Promise<Uint8Array> {
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: ref
+        ? [{ type: 'public-key', id: b64decode(ref.credentialIdB64) }]
+        : [],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: PRF_SALT } } } as any,
+    },
+  })) as PublicKeyCredential | null;
+  if (!assertion) throw new Error('passkey assertion was cancelled');
+
+  const result: ArrayBuffer | undefined = (assertion.getClientExtensionResults() as any)?.prf
+    ?.results?.first;
+  if (!result) {
+    throw new Error('Authenticator did not return a PRF result for the assertion.');
+  }
+  const secret = new Uint8Array(result);
+  if (secret.length !== 32) throw new Error(`unexpected PRF output length ${secret.length}`);
+  return secret;
+}
+
+/**
+ * Dev-mode fallback for environments without WebAuthn PRF: derive the
+ * device secret from a passphrase via SHA-256. Demo convenience only.
+ */
+export async function deriveDevModeSecret(passphrase: string): Promise<Uint8Array> {
+  const data = new TextEncoder().encode(`midnight:passport:devmode:v0:${passphrase}`);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return new Uint8Array(digest);
+}

--- a/experiments/account-custody-prototype/app/src/lib/proofWorker.ts
+++ b/experiments/account-custody-prototype/app/src/lib/proofWorker.ts
@@ -1,0 +1,78 @@
+// Dedicated worker that runs the zkir-v2 wasm prover off the main thread,
+// so the UI stays live during the seconds-to-tens-of-seconds a PLONK proof
+// takes. Key material is resolved on the MAIN thread (it owns the
+// FetchZkConfigProvider and the cache) and proxied here per request —
+// the same split the wallet SDK's WasmProver uses.
+//
+// The zkir wasm is imported dynamically so a failed or slow wasm load is
+// observable as a message instead of a silent dead worker.
+//
+// Protocol (structured clone; BigInt and Uint8Array are clone-safe):
+//   main → worker  { id, op: 'prove' | 'check', preimage, obi? }
+//   worker → main  { id, km: 'lookupKey' | 'getParams', kmId, arg }
+//   main → worker  { kmReply: kmId, result }   (or { kmReply, error })
+//   worker → main  { id, ok: result }          (or { id, err })
+
+const ctx = self as any;
+
+let zkirPromise: Promise<any> | null = null;
+function getZkir(): Promise<any> {
+  if (!zkirPromise) {
+    console.debug('[proof-worker] loading zkir wasm…');
+    zkirPromise = import('@midnight-ntwrk/zkir-v2').then((m) => {
+      console.debug('[proof-worker] zkir wasm ready');
+      return m;
+    });
+  }
+  return zkirPromise;
+}
+
+let nextKmId = 1;
+const kmPending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
+
+function kmRequest(requestId: number, km: 'lookupKey' | 'getParams', arg: string | number) {
+  return new Promise((resolve, reject) => {
+    const kmId = nextKmId++;
+    kmPending.set(kmId, { resolve, reject });
+    ctx.postMessage({ id: requestId, km, kmId, arg });
+  });
+}
+
+ctx.onmessage = async (e: MessageEvent) => {
+  const msg = e.data;
+
+  if (msg.kmReply !== undefined) {
+    const waiter = kmPending.get(msg.kmReply);
+    if (!waiter) return;
+    kmPending.delete(msg.kmReply);
+    if (msg.error !== undefined) waiter.reject(new Error(msg.error));
+    else waiter.resolve(msg.result);
+    return;
+  }
+
+  const { id, op, preimage, obi } = msg;
+  console.debug(`[proof-worker] ${op} request ${id} (${preimage?.length} bytes)`);
+  // The preimage embeds its own key location; the wasm calls lookupKey with it.
+  const kmProxy: any = {
+    lookupKey: (keyLocation: string) => kmRequest(id, 'lookupKey', keyLocation),
+    getParams: (k: number) => kmRequest(id, 'getParams', k),
+  };
+  try {
+    const zkir = await getZkir();
+    const result =
+      op === 'prove'
+        ? await zkir.prove(preimage, kmProxy, obi)
+        : await zkir.check(preimage, kmProxy);
+    // Copy before posting: wasm-bindgen may hand back a view over wasm
+    // memory, and structured clone would clone the entire backing buffer.
+    const ok = result instanceof Uint8Array ? new Uint8Array(result) : result;
+    console.debug(`[proof-worker] ${op} request ${id} done`);
+    ctx.postMessage({ id, ok });
+  } catch (err: any) {
+    console.debug(`[proof-worker] ${op} request ${id} FAILED: ${err?.message ?? err}`);
+    ctx.postMessage({ id, err: String(err?.message ?? err) });
+  }
+};
+
+console.debug('[proof-worker] entry evaluated');
+ctx.postMessage({ ready: true });

--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -31,20 +31,17 @@ import * as FaucetModule from '../../../contracts/managed/faucet/contract/index.
 import { proveStarted, proveEnded } from './txTracker.js';
 import { wasmProofProvider, wasmWalletProvingService } from './wasmProver.js';
 
-// `?prover=browser` proves everything in this browser via the zkir-v2 wasm
-// prover instead of the proof server (see BROWSER-PROVING-SCOPE.md). On any
-// non-localhost origin (phone via tunnel, LAN) the browser prover is the
-// default — the proof server at 127.0.0.1:6300 is unreachable from there.
-// Force the server path with `?prover=server` (localhost only).
+// The browser prover is the DEFAULT: everything — contract circuits, zswap,
+// dust — is proved in this tab by the zkir-v2 wasm prover (see
+// BROWSER-PROVING-SCOPE.md). No proof server is needed anywhere in the
+// stack. `?prover=server` opts back into the Docker proof server at
+// 127.0.0.1:6300 (works on localhost only — the server is unreachable from
+// tunnel/LAN origins).
 const proverParam =
   typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('prover')
     : null;
-const isLocalhost =
-  typeof window !== 'undefined' &&
-  ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname);
-export const BROWSER_PROVER =
-  proverParam === 'browser' || (proverParam !== 'server' && !isLocalhost);
+export const BROWSER_PROVER = proverParam !== 'server';
 
 // Localnet genesis wallet — the dev node funds this seed at genesis.
 // Demo-only; never use outside a throwaway local network.

--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -29,7 +29,7 @@ import { hexToBytes } from '../../../src/wallet/hex.js';
 import * as FaucetModule from '../../../contracts/managed/faucet/contract/index.js';
 
 import { proveStarted, proveEnded } from './txTracker.js';
-import { wasmProofProvider } from './wasmProver.js';
+import { wasmProofProvider, wasmWalletProvingService } from './wasmProver.js';
 
 // Phase 0 spike: `?prover=browser` proves contract circuits in this browser
 // via the zkir-v2 wasm prover instead of the proof server (wallet balancing
@@ -119,6 +119,9 @@ export async function createWallet(seedHex: string) {
         dustSecretKey,
         ledgerPkg.LedgerParameters.initialParameters().dust,
       ),
+    // With ?prover=browser the balancing proofs (zswap, dust) are computed
+    // in this tab too — no proof server anywhere in the stack.
+    ...(BROWSER_PROVER ? { provingService: () => wasmWalletProvingService() } : {}),
   });
 
   await wallet.start(shieldedSecretKeys, dustSecretKey);

--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -1,0 +1,252 @@
+// Browser-side Midnight wiring: genesis-funded fee wallet, providers, and
+// compiled-contract handles. Mirrors src/node/wallet.ts minus the
+// Node-specific pieces (ws, fs, level db).
+//
+// The embedded wallet exists ONLY to balance and pay for transactions on
+// the localnet — fee handling is out of the custody prototype's scope (C24).
+
+import * as Rx from 'rxjs';
+
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
+import { setNetworkId, getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import * as ledgerPkg from '@midnight-ntwrk/ledger-v8';
+import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
+import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  PublicKey,
+  UnshieldedWallet,
+} from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+import { CompiledContract } from '@midnight-ntwrk/compact-js';
+
+import { Contract } from '../../../src/wallet/contract.js';
+import { makeWitnesses } from '../../../src/wallet/witnesses.js';
+import { hexToBytes } from '../../../src/wallet/hex.js';
+import * as FaucetModule from '../../../contracts/managed/faucet/contract/index.js';
+
+import { proveStarted, proveEnded } from './txTracker.js';
+
+// Localnet genesis wallet — the dev node funds this seed at genesis.
+// Demo-only; never use outside a throwaway local network.
+export const GENESIS_SEED =
+  '0000000000000000000000000000000000000000000000000000000000000001';
+
+const ORIGIN = window.location.origin;
+const WS_ORIGIN = ORIGIN.replace(/^http/, 'ws');
+
+export const CONFIG = {
+  networkId: 'undeployed',
+  indexer: `${ORIGIN}/indexer/api/v4/graphql`,
+  indexerWS: `${WS_ORIGIN}/indexer/api/v4/graphql/ws`,
+  node: `${ORIGIN}/rpc`,
+  // The proof server sends permissive CORS headers, so the browser talks to
+  // it directly — proxying the multi-megabyte streaming /prove bodies
+  // through Vite's http-proxy breaks the wallet's proving step.
+  proofServer: 'http://127.0.0.1:6300',
+};
+
+setNetworkId(CONFIG.networkId as any);
+
+const NoopTxHistoryStorage = {
+  upsert: async (..._args: unknown[]) => undefined,
+  get: async (..._args: unknown[]) => null,
+  delete: async (..._args: unknown[]) => undefined,
+  list: async (..._args: unknown[]) => [] as unknown[],
+  clear: async (..._args: unknown[]) => undefined,
+};
+
+// Workaround for ledger-v8 MerkleTree::collapse panic (see node/wallet.ts).
+const _origTryApply = (ledgerPkg.ZswapChainState.prototype as any).tryApply;
+(ledgerPkg.ZswapChainState.prototype as any).tryApply = function (...args: unknown[]) {
+  try {
+    return _origTryApply.apply(this, args as any);
+  } catch {
+    return [this, new Map()];
+  }
+};
+
+export function deriveKeys(seedHex: string) {
+  const hdWallet = HDWallet.fromSeed(hexToBytes(seedHex));
+  if (hdWallet.type !== 'seedOk') throw new Error('Invalid seed');
+  const result = hdWallet.hdWallet
+    .selectAccount(0)
+    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
+    .deriveKeysAt(0);
+  if (result.type !== 'keysDerived') throw new Error('Key derivation failed');
+  hdWallet.hdWallet.clear();
+  return result.keys;
+}
+
+export async function createWallet(seedHex: string) {
+  const keys = deriveKeys(seedHex);
+  const networkId = getNetworkId();
+
+  const shieldedSecretKeys = ledgerPkg.ZswapSecretKeys.fromSeed(keys[Roles.Zswap]);
+  const dustSecretKey = ledgerPkg.DustSecretKey.fromSeed(keys[Roles.Dust]);
+  const unshieldedKeystore = createKeystore(keys[Roles.NightExternal], networkId);
+
+  const configuration = {
+    networkId,
+    indexerClientConnection: {
+      indexerHttpUrl: CONFIG.indexer,
+      indexerWsUrl: CONFIG.indexerWS,
+    },
+    provingServerUrl: new URL(CONFIG.proofServer),
+    relayURL: new URL(CONFIG.node.replace(/^http/, 'ws')),
+    costParameters: { feeBlocksMargin: 100 },
+    txHistoryStorage: NoopTxHistoryStorage,
+  };
+
+  const wallet: any = await (WalletFacade as any).init({
+    configuration,
+    shielded: (config: any) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    unshielded: (config: any) =>
+      UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: (config: any) =>
+      DustWallet(config).startWithSecretKey(
+        dustSecretKey,
+        ledgerPkg.LedgerParameters.initialParameters().dust,
+      ),
+  });
+
+  await wallet.start(shieldedSecretKeys, dustSecretKey);
+  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+}
+
+export type WalletContext = Awaited<ReturnType<typeof createWallet>>;
+
+export async function awaitSync(walletCtx: WalletContext): Promise<any> {
+  return Rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(Rx.filter((s: any) => s.isSynced === true)),
+  );
+}
+
+// In-memory PrivateStateProvider — secrets live for the page session only.
+// (C16 wallet-local-storage is its own component; the demo deliberately
+// re-derives the device secret from the passkey on every page load.)
+export function inMemoryPrivateStateProvider(): any {
+  const states = new Map<string, unknown>();
+  const signingKeys = new Map<string, unknown>();
+  return {
+    setContractAddress(_address: string) {},
+    async set(id: string, state: unknown) {
+      states.set(id, state);
+    },
+    async get(id: string) {
+      return states.has(id) ? states.get(id) : null;
+    },
+    async remove(id: string) {
+      states.delete(id);
+    },
+    async clear() {
+      states.clear();
+    },
+    async setSigningKey(address: string, key: unknown) {
+      signingKeys.set(address, key);
+    },
+    async getSigningKey(address: string) {
+      return signingKeys.get(address) ?? null;
+    },
+    async removeSigningKey(address: string) {
+      signingKeys.delete(address);
+    },
+    async clearSigningKeys() {
+      signingKeys.clear();
+    },
+    async exportPrivateStates() {
+      throw new Error('not supported in the demo');
+    },
+    async importPrivateStates() {
+      throw new Error('not supported in the demo');
+    },
+  };
+}
+
+export async function createProviders(walletCtx: WalletContext, contractName: 'account' | 'faucet') {
+  const state = await awaitSync(walletCtx);
+
+  const signFn = (payload: Uint8Array) => walletCtx.unshieldedKeystore.signData(payload);
+
+  const walletProvider = {
+    getCoinPublicKey: () => state.shielded.coinPublicKey.toHexString(),
+    getEncryptionPublicKey: () => state.shielded.encryptionPublicKey.toHexString(),
+    async balanceTx(tx: any, ttl?: Date) {
+      const recipe = await walletCtx.wallet.balanceUnboundTransaction(
+        tx,
+        {
+          shieldedSecretKeys: walletCtx.shieldedSecretKeys,
+          dustSecretKey: walletCtx.dustSecretKey,
+        },
+        { ttl: ttl ?? new Date(Date.now() + 30 * 60 * 1000) },
+      );
+      const signed = await walletCtx.wallet.signRecipe(recipe, signFn);
+      return walletCtx.wallet.finalizeRecipe(signed);
+    },
+    submitTx: (tx: any) => walletCtx.wallet.submitTransaction(tx),
+  };
+
+  const zkConfigProvider = new FetchZkConfigProvider(
+    `${ORIGIN}/zk/${contractName}`,
+    window.fetch.bind(window),
+  );
+
+  // Wrapped so the UI's proving dock sees when the proof server is actually
+  // working (build → prove → submit phases in txTracker).
+  const baseProofProvider: any = httpClientProofProvider(CONFIG.proofServer, zkConfigProvider as any);
+  const proofProvider = {
+    ...baseProofProvider,
+    proveTx: async (...args: unknown[]) => {
+      proveStarted();
+      try {
+        return await baseProofProvider.proveTx(...args);
+      } finally {
+        proveEnded();
+      }
+    },
+  };
+
+  return {
+    privateStateProvider: inMemoryPrivateStateProvider(),
+    publicDataProvider: indexerPublicDataProvider(CONFIG.indexer, CONFIG.indexerWS),
+    zkConfigProvider,
+    proofProvider,
+    walletProvider,
+    midnightProvider: walletProvider,
+  };
+}
+
+export function compiledAccountContract() {
+  return CompiledContract.make('account', Contract as any).pipe(
+    CompiledContract.withWitnesses(makeWitnesses() as any),
+    CompiledContract.withCompiledFileAssets('/zk/account'),
+  );
+}
+
+export function compiledFaucetContract() {
+  return CompiledContract.make('faucet', (FaucetModule as any).Contract).pipe(
+    CompiledContract.withVacantWitnesses,
+    CompiledContract.withCompiledFileAssets('/zk/faucet'),
+  );
+}
+
+// User-facing byte helpers (mirrors src/node/wallet.ts).
+
+export function userAddressBytes(walletCtx: WalletContext): Uint8Array {
+  const pk: any = walletCtx.unshieldedKeystore.getPublicKey();
+  const hex: string = typeof pk?.toHexString === 'function' ? pk.toHexString() : String(pk?.bytes ?? pk);
+  const out = new Uint8Array(32);
+  out.set(hexToBytes(hex.replace(/^0x/, '')).subarray(0, 32));
+  return out;
+}
+
+export function coinPublicKeyBytes(state: any): Uint8Array {
+  const cpk = state.shielded.coinPublicKey;
+  const hex: string = typeof cpk?.toHexString === 'function' ? cpk.toHexString() : String(cpk?.bytes ?? cpk);
+  const out = new Uint8Array(32);
+  out.set(hexToBytes(hex.replace(/^0x/, '')).subarray(0, 32));
+  return out;
+}

--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -29,6 +29,14 @@ import { hexToBytes } from '../../../src/wallet/hex.js';
 import * as FaucetModule from '../../../contracts/managed/faucet/contract/index.js';
 
 import { proveStarted, proveEnded } from './txTracker.js';
+import { wasmProofProvider } from './wasmProver.js';
+
+// Phase 0 spike: `?prover=browser` proves contract circuits in this browser
+// via the zkir-v2 wasm prover instead of the proof server (wallet balancing
+// still uses the server — Phase 2 in BROWSER-PROVING-SCOPE.md).
+export const BROWSER_PROVER =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('prover') === 'browser';
 
 // Localnet genesis wallet — the dev node funds this seed at genesis.
 // Demo-only; never use outside a throwaway local network.
@@ -194,20 +202,24 @@ export async function createProviders(walletCtx: WalletContext, contractName: 'a
     window.fetch.bind(window),
   );
 
-  // Wrapped so the UI's proving dock sees when the proof server is actually
-  // working (build → prove → submit phases in txTracker).
+  // Wrapped so the UI's proving dock sees when the prover is actually
+  // working (build → prove → submit phases in txTracker). With
+  // ?prover=browser the proof is computed in this tab by the zkir-v2 wasm
+  // prover; otherwise it goes to the local proof server.
   const baseProofProvider: any = httpClientProofProvider(CONFIG.proofServer, zkConfigProvider as any);
-  const proofProvider = {
-    ...baseProofProvider,
-    proveTx: async (...args: unknown[]) => {
-      proveStarted();
-      try {
-        return await baseProofProvider.proveTx(...args);
-      } finally {
-        proveEnded();
-      }
-    },
-  };
+  const proofProvider = BROWSER_PROVER
+    ? wasmProofProvider(zkConfigProvider)
+    : {
+        ...baseProofProvider,
+        proveTx: async (...args: unknown[]) => {
+          proveStarted();
+          try {
+            return await baseProofProvider.proveTx(...args);
+          } finally {
+            proveEnded();
+          }
+        },
+      };
 
   return {
     privateStateProvider: inMemoryPrivateStateProvider(),

--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -31,12 +31,20 @@ import * as FaucetModule from '../../../contracts/managed/faucet/contract/index.
 import { proveStarted, proveEnded } from './txTracker.js';
 import { wasmProofProvider, wasmWalletProvingService } from './wasmProver.js';
 
-// Phase 0 spike: `?prover=browser` proves contract circuits in this browser
-// via the zkir-v2 wasm prover instead of the proof server (wallet balancing
-// still uses the server — Phase 2 in BROWSER-PROVING-SCOPE.md).
-export const BROWSER_PROVER =
+// `?prover=browser` proves everything in this browser via the zkir-v2 wasm
+// prover instead of the proof server (see BROWSER-PROVING-SCOPE.md). On any
+// non-localhost origin (phone via tunnel, LAN) the browser prover is the
+// default — the proof server at 127.0.0.1:6300 is unreachable from there.
+// Force the server path with `?prover=server` (localhost only).
+const proverParam =
+  typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('prover')
+    : null;
+const isLocalhost =
   typeof window !== 'undefined' &&
-  new URLSearchParams(window.location.search).get('prover') === 'browser';
+  ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname);
+export const BROWSER_PROVER =
+  proverParam === 'browser' || (proverParam !== 'server' && !isLocalhost);
 
 // Localnet genesis wallet — the dev node funds this seed at genesis.
 // Demo-only; never use outside a throwaway local network.

--- a/experiments/account-custody-prototype/app/src/lib/session.ts
+++ b/experiments/account-custody-prototype/app/src/lib/session.ts
@@ -1,0 +1,31 @@
+// LocalStorage persistence of the user's session. Secrets are NOT stored:
+// the device secret is re-derived from the passkey (PRF) on each use; the
+// recovery secret only ever exists transiently (and as on-chain shares —
+// TODO(PVSS)).
+
+import type { PasskeyRef } from './passkey.js';
+
+export interface Session {
+  accountAddress: string;
+  passkey?: PasskeyRef;
+  devMode?: boolean;
+}
+
+const KEY = 'passport-demo-session';
+
+export function loadSession(): Session | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Session) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSession(s: Session): void {
+  localStorage.setItem(KEY, JSON.stringify(s));
+}
+
+export function clearSession(): void {
+  localStorage.removeItem(KEY);
+}

--- a/experiments/account-custody-prototype/app/src/lib/txTracker.ts
+++ b/experiments/account-custody-prototype/app/src/lib/txTracker.ts
@@ -1,0 +1,89 @@
+// Honest transaction-progress tracking. A contract call in this stack runs
+// for minutes, in three observable stages:
+//
+//   build  — circuit execution in the browser (compact-runtime, WASM)
+//   prove  — the proof server generates the ZK proof (signalled by the
+//            proofProvider.proveTx wrapper in providers.ts)
+//   submit — wallet balancing (incl. dust proving), signing, submission,
+//            and waiting for the indexer to confirm
+//
+// One task is active at a time (demo actions are serialised); finished
+// tasks are kept so the UI can show the landed tx id.
+
+import { useSyncExternalStore } from 'react';
+
+export type TxPhase = 'build' | 'prove' | 'submit' | 'done' | 'error';
+
+export interface TxTask {
+  id: number;
+  /** Presenter-facing label, e.g. "Depositing Night". */
+  label: string;
+  /** Circuit being exercised, e.g. "deposit_night". */
+  circuit: string;
+  phase: TxPhase;
+  startedAt: number;
+  phaseAt: number;
+  endedAt?: number;
+  txId?: string;
+  error?: string;
+}
+
+let nextId = 1;
+let current: TxTask | null = null;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function update(patch: Partial<TxTask>) {
+  if (!current) return;
+  current = { ...current, ...patch, phaseAt: Date.now() };
+  emit();
+}
+
+export function beginTask(label: string, circuit: string): void {
+  current = {
+    id: nextId++,
+    label,
+    circuit,
+    phase: 'build',
+    startedAt: Date.now(),
+    phaseAt: Date.now(),
+  };
+  emit();
+}
+
+export function completeTask(txId?: string): void {
+  update({ phase: 'done', txId, endedAt: Date.now() });
+}
+
+export function failTask(error: string): void {
+  update({ phase: 'error', error, endedAt: Date.now() });
+}
+
+export function dismissTask(id: number): void {
+  if (current?.id === id) {
+    current = null;
+    emit();
+  }
+}
+
+// Called by the proofProvider wrapper — only meaningful mid-task.
+export function proveStarted(): void {
+  if (current && current.phase === 'build') update({ phase: 'prove' });
+}
+
+export function proveEnded(): void {
+  if (current && current.phase === 'prove') update({ phase: 'submit' });
+}
+
+export function useTxTask(): TxTask | null {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => current,
+  );
+}

--- a/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
+++ b/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
@@ -1,0 +1,55 @@
+// Browser-side proving (Phase 0 spike, see ../../BROWSER-PROVING-SCOPE.md).
+//
+// The upstream zkir-v2 wasm prover plugged into the midnight-js ProofProvider
+// seam: `Transaction.prove(provingProvider, costModel)` with a provider that
+// computes the PLONK proof in this browser instead of POSTing the preimage to
+// the proof server. Key material resolves through the SAME FetchZkConfigProvider
+// the HTTP path uses (binary .bzkir + prover/verifier keys from /zk); SRS
+// slices are served from /zk-params — byte-identical to the files the proof
+// server itself downloads and verifies from the public bucket.
+//
+// Selected with `?prover=browser` (see providers.ts). The wallet's balancing
+// proofs still go to the proof server; that is Phase 2.
+
+import * as zkir from '@midnight-ntwrk/zkir-v2';
+import { CostModel } from '@midnight-ntwrk/ledger-v8';
+import { zkConfigToProvingKeyMaterial } from '@midnight-ntwrk/midnight-js-types';
+
+import { proveStarted, proveEnded } from './txTracker.js';
+
+interface ZkConfigProviderLike {
+  get(keyLocation: string): Promise<unknown>;
+}
+
+export function wasmProofProvider(zkConfigProvider: ZkConfigProviderLike): any {
+  const kmProvider = {
+    lookupKey: async (keyLocation: string) => {
+      console.debug(`[wasm-prover] lookupKey: ${keyLocation}`);
+      const zkConfig = await zkConfigProvider.get(keyLocation);
+      return zkConfigToProvingKeyMaterial(zkConfig as any);
+    },
+    getParams: async (k: number) => {
+      console.debug(`[wasm-prover] getParams: k=${k}`);
+      const resp = await fetch(`/zk-params/bls_midnight_2p${k}`);
+      if (!resp.ok) {
+        throw new Error(
+          `missing SRS slice for k=${k} — run scripts/fetch-zk-params.mjs to stage app/public/zk-params`,
+        );
+      }
+      return new Uint8Array(await resp.arrayBuffer());
+    },
+  };
+
+  const provingProvider = zkir.provingProvider(kmProvider);
+
+  return {
+    async proveTx(unprovenTx: any) {
+      proveStarted();
+      try {
+        return await unprovenTx.prove(provingProvider, CostModel.initialCostModel());
+      } finally {
+        proveEnded();
+      }
+    },
+  };
+}

--- a/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
+++ b/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
@@ -9,7 +9,9 @@
 // server itself downloads and verifies from the public bucket.
 //
 // Selected with `?prover=browser` (see providers.ts). The wallet's balancing
-// proofs still go to the proof server; that is Phase 2.
+// proofs (zswap and dust) are covered too: WalletFacade.init accepts a
+// custom provingService, and the system-circuit key material lives in
+// /zk-params alongside the SRS (same files the proof server downloads).
 
 import * as zkir from '@midnight-ntwrk/zkir-v2';
 import { CostModel } from '@midnight-ntwrk/ledger-v8';
@@ -21,23 +23,50 @@ interface ZkConfigProviderLike {
   get(keyLocation: string): Promise<unknown>;
 }
 
+async function fetchBytes(path: string, what: string): Promise<Uint8Array> {
+  const resp = await fetch(path);
+  if (!resp.ok) {
+    throw new Error(
+      `missing ${what} (${path}) — run scripts/fetch-zk-params.mjs to stage app/public/zk-params`,
+    );
+  }
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+const getParams = async (k: number) => {
+  console.debug(`[wasm-prover] getParams: k=${k}`);
+  return fetchBytes(`/zk-params/bls_midnight_2p${k}`, `SRS slice for k=${k}`);
+};
+
+// System (balancing) circuits, mirroring the proof server's key layout.
+const SYSTEM_KEYS: Record<string, string> = {
+  'midnight/zswap/spend': 'zswap/9/spend',
+  'midnight/zswap/output': 'zswap/9/output',
+  'midnight/zswap/sign': 'zswap/9/sign',
+  'midnight/dust/spend': 'dust/9/spend',
+};
+
+async function lookupSystemKey(keyLocation: string) {
+  const path = SYSTEM_KEYS[keyLocation];
+  if (!path) return undefined;
+  const [proverKey, verifierKey, ir] = await Promise.all([
+    fetchBytes(`/zk-params/${path}.prover`, `${keyLocation} prover key`),
+    fetchBytes(`/zk-params/${path}.verifier`, `${keyLocation} verifier key`),
+    fetchBytes(`/zk-params/${path}.bzkir`, `${keyLocation} IR`),
+  ]);
+  return { proverKey, verifierKey, ir };
+}
+
 export function wasmProofProvider(zkConfigProvider: ZkConfigProviderLike): any {
   const kmProvider = {
     lookupKey: async (keyLocation: string) => {
       console.debug(`[wasm-prover] lookupKey: ${keyLocation}`);
+      const system = await lookupSystemKey(keyLocation);
+      if (system) return system;
       const zkConfig = await zkConfigProvider.get(keyLocation);
       return zkConfigToProvingKeyMaterial(zkConfig as any);
     },
-    getParams: async (k: number) => {
-      console.debug(`[wasm-prover] getParams: k=${k}`);
-      const resp = await fetch(`/zk-params/bls_midnight_2p${k}`);
-      if (!resp.ok) {
-        throw new Error(
-          `missing SRS slice for k=${k} — run scripts/fetch-zk-params.mjs to stage app/public/zk-params`,
-        );
-      }
-      return new Uint8Array(await resp.arrayBuffer());
-    },
+    getParams,
   };
 
   const provingProvider = zkir.provingProvider(kmProvider);
@@ -51,5 +80,24 @@ export function wasmProofProvider(zkConfigProvider: ZkConfigProviderLike): any {
         proveEnded();
       }
     },
+  };
+}
+
+/**
+ * Wallet-side proving service (balancing: zswap spends/outputs/signs and
+ * dust fee spends). Same shape the wallet SDK's makeWasmProvingService
+ * builds; injected through WalletFacade.init({ provingService }).
+ */
+export function wasmWalletProvingService(): { prove(tx: any): Promise<any> } {
+  const kmProvider = {
+    lookupKey: async (keyLocation: string) => {
+      console.debug(`[wasm-prover/wallet] lookupKey: ${keyLocation}`);
+      return lookupSystemKey(keyLocation);
+    },
+    getParams,
+  };
+  const provingProvider = zkir.provingProvider(kmProvider);
+  return {
+    prove: (tx: any) => tx.prove(provingProvider, CostModel.initialCostModel()),
   };
 }

--- a/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
+++ b/experiments/account-custody-prototype/app/src/lib/wasmProver.ts
@@ -1,19 +1,17 @@
-// Browser-side proving (Phase 0 spike, see ../../BROWSER-PROVING-SCOPE.md).
+// Browser-side proving (see ../../BROWSER-PROVING-SCOPE.md).
 //
-// The upstream zkir-v2 wasm prover plugged into the midnight-js ProofProvider
-// seam: `Transaction.prove(provingProvider, costModel)` with a provider that
-// computes the PLONK proof in this browser instead of POSTing the preimage to
-// the proof server. Key material resolves through the SAME FetchZkConfigProvider
-// the HTTP path uses (binary .bzkir + prover/verifier keys from /zk); SRS
-// slices are served from /zk-params — byte-identical to the files the proof
-// server itself downloads and verifies from the public bucket.
+// The zkir-v2 wasm prover runs in a dedicated worker (proofWorker.ts) so the
+// UI stays live while a PLONK proof is computed; this module owns key
+// resolution on the main thread and proxies it to the worker per request —
+// the same split the wallet SDK's WasmProver uses. Key material for contract
+// circuits resolves through the SAME FetchZkConfigProvider the HTTP path
+// uses; system (balancing) circuits and SRS slices are served from
+// /zk-params — byte-identical to the files the proof server downloads and
+// verifies from the public bucket.
 //
-// Selected with `?prover=browser` (see providers.ts). The wallet's balancing
-// proofs (zswap and dust) are covered too: WalletFacade.init accepts a
-// custom provingService, and the system-circuit key material lives in
-// /zk-params alongside the SRS (same files the proof server downloads).
+// Selected with `?prover=browser` (see providers.ts). With the flag set, no
+// proof server is needed anywhere in the stack.
 
-import * as zkir from '@midnight-ntwrk/zkir-v2';
 import { CostModel } from '@midnight-ntwrk/ledger-v8';
 import { zkConfigToProvingKeyMaterial } from '@midnight-ntwrk/midnight-js-types';
 
@@ -22,6 +20,21 @@ import { proveStarted, proveEnded } from './txTracker.js';
 interface ZkConfigProviderLike {
   get(keyLocation: string): Promise<unknown>;
 }
+
+interface KeyMaterial {
+  proverKey: Uint8Array;
+  verifierKey: Uint8Array;
+  ir: Uint8Array;
+}
+
+interface KmProvider {
+  lookupKey(keyLocation: string): Promise<KeyMaterial | undefined>;
+  getParams(k: number): Promise<Uint8Array>;
+}
+
+// ——— key material (main thread, cached) ———
+
+const cache = new Map<string, unknown>();
 
 async function fetchBytes(path: string, what: string): Promise<Uint8Array> {
   const resp = await fetch(path);
@@ -33,10 +46,14 @@ async function fetchBytes(path: string, what: string): Promise<Uint8Array> {
   return new Uint8Array(await resp.arrayBuffer());
 }
 
-const getParams = async (k: number) => {
-  console.debug(`[wasm-prover] getParams: k=${k}`);
-  return fetchBytes(`/zk-params/bls_midnight_2p${k}`, `SRS slice for k=${k}`);
-};
+async function getParams(k: number): Promise<Uint8Array> {
+  const key = `srs-${k}`;
+  if (!cache.has(key)) {
+    console.debug(`[wasm-prover] getParams: k=${k}`);
+    cache.set(key, await fetchBytes(`/zk-params/bls_midnight_2p${k}`, `SRS slice for k=${k}`));
+  }
+  return cache.get(key) as Uint8Array;
+}
 
 // System (balancing) circuits, mirroring the proof server's key layout.
 const SYSTEM_KEYS: Record<string, string> = {
@@ -46,31 +63,110 @@ const SYSTEM_KEYS: Record<string, string> = {
   'midnight/dust/spend': 'dust/9/spend',
 };
 
-async function lookupSystemKey(keyLocation: string) {
+async function lookupSystemKey(keyLocation: string): Promise<KeyMaterial | undefined> {
   const path = SYSTEM_KEYS[keyLocation];
   if (!path) return undefined;
-  const [proverKey, verifierKey, ir] = await Promise.all([
-    fetchBytes(`/zk-params/${path}.prover`, `${keyLocation} prover key`),
-    fetchBytes(`/zk-params/${path}.verifier`, `${keyLocation} verifier key`),
-    fetchBytes(`/zk-params/${path}.bzkir`, `${keyLocation} IR`),
-  ]);
-  return { proverKey, verifierKey, ir };
+  if (!cache.has(path)) {
+    const [proverKey, verifierKey, ir] = await Promise.all([
+      fetchBytes(`/zk-params/${path}.prover`, `${keyLocation} prover key`),
+      fetchBytes(`/zk-params/${path}.verifier`, `${keyLocation} verifier key`),
+      fetchBytes(`/zk-params/${path}.bzkir`, `${keyLocation} IR`),
+    ]);
+    cache.set(path, { proverKey, verifierKey, ir });
+  }
+  return cache.get(path) as KeyMaterial;
 }
 
+// ——— worker plumbing ———
+// One shared worker; each in-flight request carries its own KmProvider so
+// the worker's key-material callbacks route back to the right resolver.
+
+let worker: Worker | null = null;
+let nextReqId = 1;
+const pending = new Map<
+  number,
+  { resolve: (v: any) => void; reject: (e: Error) => void; km: KmProvider }
+>();
+
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  worker = new Worker(new URL('./proofWorker.ts', import.meta.url), { type: 'module' });
+  worker.onmessage = async (e: MessageEvent) => {
+    const msg = e.data;
+    if (msg.ready) {
+      console.debug('[wasm-prover] proof worker ready');
+      return;
+    }
+    if (msg.km !== undefined) {
+      const req = pending.get(msg.id);
+      if (!req || !worker) return;
+      try {
+        const result =
+          msg.km === 'lookupKey' ? await req.km.lookupKey(msg.arg) : await req.km.getParams(msg.arg);
+        worker.postMessage({ kmReply: msg.kmId, result });
+      } catch (err: any) {
+        worker.postMessage({ kmReply: msg.kmId, error: String(err?.message ?? err) });
+      }
+      return;
+    }
+    const req = pending.get(msg.id);
+    if (!req) return;
+    pending.delete(msg.id);
+    if (msg.err !== undefined) req.reject(new Error(msg.err));
+    else req.resolve(msg.ok);
+  };
+  worker.onerror = (e: ErrorEvent) => {
+    const error = new Error(`proof worker crashed: ${e.message}`);
+    for (const req of pending.values()) req.reject(error);
+    pending.clear();
+    worker?.terminate();
+    worker = null;
+  };
+  return worker;
+}
+
+function callWorker(
+  op: 'prove' | 'check',
+  km: KmProvider,
+  preimage: Uint8Array,
+  obi?: bigint,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const id = nextReqId++;
+    pending.set(id, { resolve, reject, km });
+    // Copy before posting: the ledger may hand us a view over its wasm
+    // memory, and structured clone would clone the entire backing buffer.
+    const bytes = new Uint8Array(preimage);
+    console.debug(`[wasm-prover] → worker: ${op} (req ${id}, ${bytes.length} bytes)`);
+    ensureWorker().postMessage({ id, op, preimage: bytes, obi });
+  });
+}
+
+// The ledger's two-method ProvingProvider, computed in the worker. The
+// keyLocation argument is unused by the wasm side: the preimage embeds its
+// own location, which comes back through the km proxy.
+function workerProvingProvider(km: KmProvider): any {
+  return {
+    check: (preimage: Uint8Array, _keyLocation: string) => callWorker('check', km, preimage),
+    prove: (preimage: Uint8Array, _keyLocation: string, obi?: bigint) =>
+      callWorker('prove', km, preimage, obi),
+  };
+}
+
+// ——— public surface ———
+
 export function wasmProofProvider(zkConfigProvider: ZkConfigProviderLike): any {
-  const kmProvider = {
+  const km: KmProvider = {
     lookupKey: async (keyLocation: string) => {
       console.debug(`[wasm-prover] lookupKey: ${keyLocation}`);
       const system = await lookupSystemKey(keyLocation);
       if (system) return system;
       const zkConfig = await zkConfigProvider.get(keyLocation);
-      return zkConfigToProvingKeyMaterial(zkConfig as any);
+      return zkConfigToProvingKeyMaterial(zkConfig as any) as KeyMaterial;
     },
     getParams,
   };
-
-  const provingProvider = zkir.provingProvider(kmProvider);
-
+  const provingProvider = workerProvingProvider(km);
   return {
     async proveTx(unprovenTx: any) {
       proveStarted();
@@ -89,14 +185,14 @@ export function wasmProofProvider(zkConfigProvider: ZkConfigProviderLike): any {
  * builds; injected through WalletFacade.init({ provingService }).
  */
 export function wasmWalletProvingService(): { prove(tx: any): Promise<any> } {
-  const kmProvider = {
+  const km: KmProvider = {
     lookupKey: async (keyLocation: string) => {
       console.debug(`[wasm-prover/wallet] lookupKey: ${keyLocation}`);
       return lookupSystemKey(keyLocation);
     },
     getParams,
   };
-  const provingProvider = zkir.provingProvider(kmProvider);
+  const provingProvider = workerProvingProvider(km);
   return {
     prove: (tx: any) => tx.prove(provingProvider, CostModel.initialCostModel()),
   };

--- a/experiments/account-custody-prototype/app/src/lib/ws-shim.ts
+++ b/experiments/account-custody-prototype/app/src/lib/ws-shim.ts
@@ -1,0 +1,6 @@
+// Browser shim for isomorphic-ws: its browser build only has a default
+// export, but @midnight-ntwrk/midnight-js-indexer-public-data-provider does
+// a named `import { WebSocket }`. Alias resolves here instead (vite.config).
+
+export const WebSocket = globalThis.WebSocket;
+export default globalThis.WebSocket;

--- a/experiments/account-custody-prototype/app/src/main.tsx
+++ b/experiments/account-custody-prototype/app/src/main.tsx
@@ -1,0 +1,13 @@
+import './polyfills.js';
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App.js';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/experiments/account-custody-prototype/app/src/polyfills.ts
+++ b/experiments/account-custody-prototype/app/src/polyfills.ts
@@ -1,0 +1,9 @@
+// Node-global shims for the wallet SDK in the browser. Must be the first
+// import of main.tsx.
+
+import { Buffer } from 'buffer';
+
+const g = globalThis as any;
+g.Buffer = g.Buffer ?? Buffer;
+g.global = g.global ?? globalThis;
+g.process = g.process ?? { env: {} };

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -327,19 +327,19 @@ body::after {
 }
 
 .step {
-  display: grid;
-  grid-template-columns: 30px 1fr 16px;
+  display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 11px;
+  width: 100%;
   text-align: left;
   background: none;
-  border: 1px solid transparent;
+  border: 0;
   border-radius: 10px;
-  padding: 9px 10px;
+  padding: 9.5px 12px;
   cursor: pointer;
   color: var(--ink-2);
   font-family: inherit;
-  transition: background 0.15s, border-color 0.15s, color 0.15s, box-shadow 0.15s;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
 }
 
 .step:hover {
@@ -358,59 +358,31 @@ body::after {
   color: #ffffff;
 }
 
-.step-num {
-  font-family: var(--font-disp);
-  font-weight: 700;
-  font-size: 0.92rem;
-  color: var(--faint);
-  letter-spacing: -0.02em;
+.step-ico {
+  display: grid;
+  place-items: center;
+  flex: none;
 }
 
-.step-active .step-num {
-  color: rgba(255, 255, 255, 0.65);
-}
-
-.step-words {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
+.step-ico svg {
+  width: 17px;
+  height: 17px;
 }
 
 .step-title {
   font-weight: 500;
-  font-size: 0.92rem;
+  font-size: 0.95rem;
   line-height: 1.2;
 }
 
-.step-sub {
-  font-weight: 400;
-  font-size: 0.72rem;
-  color: var(--faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.step-active .step-sub {
-  color: rgba(255, 255, 255, 0.55);
-}
-
-.step-check {
-  color: var(--green);
-  font-size: 0.85rem;
+.step-n {
+  margin-left: auto;
+  font-family: var(--font-mono);
   font-weight: 600;
-}
-
-.step-active .step-check {
-  color: #7fd6ac;
-}
-
-.step-done .step-num {
-  color: var(--green);
-}
-
-.step-active.step-done .step-num {
-  color: #7fd6ac;
+  font-size: 0.7rem;
+  color: inherit;
+  opacity: 0.55;
+  font-variant-numeric: tabular-nums;
 }
 
 .side-foot {
@@ -455,6 +427,13 @@ body::after {
   font-variant-numeric: tabular-nums;
 }
 
+.side-fine {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--faint);
+}
+
 /* ——— top bar ——— */
 
 .topbar {
@@ -474,31 +453,74 @@ body::after {
   min-width: 0;
 }
 
-.topbar-stats {
-  display: flex;
-  gap: 26px;
+.topbar-spacer {
+  flex: 1;
 }
 
-.topstat {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+.statchip {
+  display: inline-flex;
+  gap: 5px;
+  align-items: baseline;
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 13px;
+  white-space: nowrap;
 }
 
-.topstat-k {
+.statchip b {
   font-weight: 600;
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--faint);
-}
-
-.topstat-v {
+  color: var(--ink);
   font-variant-numeric: tabular-nums;
-  font-family: var(--font-disp);
-  font-weight: 600;
-  font-size: 1.02rem;
-  animation: statpop 0.9s ease-out;
+}
+
+.xtoggle {
+  background: none;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.xtoggle:hover {
+  color: var(--ink);
+  border-color: #b9b4a6;
+}
+
+.xtoggle-on {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+
+.lockbtn {
+  background: none;
+  border: 0;
+  border-radius: 9px;
+  color: var(--muted);
+  padding: 7px 9px;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: all 0.15s ease;
+}
+
+.lockbtn:hover {
+  color: var(--ink);
+  background: #f1efe9;
+}
+
+.lockbtn svg {
+  width: 16px;
+  height: 16px;
 }
 
 @keyframes statpop {
@@ -1204,6 +1226,108 @@ th {
   justify-content: flex-end;
 }
 
+/* ——— overview summary tiles ——— */
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--sh-1);
+  padding: 15px 18px;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--ink);
+  transition: box-shadow 0.18s ease, transform 0.18s ease, border-color 0.18s ease;
+}
+
+.tile:hover {
+  box-shadow: var(--sh-2);
+  transform: translateY(-2px);
+  border-color: var(--line-2);
+}
+
+.tile-k {
+  font-weight: 600;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  color: var(--muted);
+}
+
+.tile-v {
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: 1.45rem;
+  letter-spacing: -0.015em;
+  font-variant-numeric: tabular-nums;
+}
+
+.tile-v small {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0;
+}
+
+.tile-sub {
+  font-size: 0.76rem;
+  font-weight: 400;
+  color: var(--faint);
+}
+
+/* ——— hover explainers ——— */
+
+[data-x] {
+  cursor: help;
+}
+
+body[data-explain='1'] .x {
+  text-decoration: underline dashed 1px;
+  text-underline-offset: 4px;
+  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+}
+
+#xtip {
+  position: fixed;
+  z-index: 1000;
+  max-width: 330px;
+  pointer-events: none;
+  background: #1d1e22;
+  color: #f2f3f5;
+  padding: 11px 13px;
+  border-radius: 10px;
+  font: 400 13px/1.5 var(--font-body);
+  box-shadow: var(--sh-3);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.14s ease, transform 0.14s ease;
+}
+
+#xtip.on {
+  opacity: 1;
+  transform: none;
+}
+
+.xtip-k {
+  display: block;
+  font-weight: 600;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #9ea1a8;
+  margin-bottom: 4px;
+}
+
 /* ——— recovery shares ——— */
 
 .share-row {
@@ -1739,6 +1863,14 @@ th {
   .doc::after {
     width: 130px;
     height: 130px;
+  }
+
+  .tiles {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .topbar .statchip {
+    display: none;
   }
 
   .listrow {

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -1,26 +1,33 @@
-/* Midnight Passport demo — IOG dark-first identity.
-   Black canvas, Enlightenment gradient atmosphere, schematic linework.
-   Barlow (body/headlines), Bricolage Grotesque (display numerals),
-   JetBrains Mono (hashes). */
+/* Midnight Passport — "Clarity" identity (sketch 005).
+   Light, readable, pure: warm near-white paper, ink text, one calm red
+   accent, green only for live/landed status. Bricolage Grotesque (display),
+   Barlow (body/UI), JetBrains Mono (hashes). Derived from the IOG brand
+   (Barlow + Bricolage are the brand stack) without the dark-first look. */
 
 :root {
-  /* primary */
-  --infared: #e52321;
-  --dawn: #ec641d;
-  --black: #000000;
-  --white: #ffffff;
-  /* secondary (functional roles only) */
-  --acid: #06ff89;
-  --electric: #16e9d8;
-  --amber: #ffba36;
-  /* surfaces */
-  --panel: rgba(255, 255, 255, 0.025);
-  --panel-solid: #0c0c0f;
-  --line: #232329;
-  --line-soft: #18181d;
-  --text: #ffffff;
-  --muted: #8f8f9a;
-  --dim: #5c5c66;
+  /* clarity palette */
+  --paper: #faf9f6;
+  --surface: #ffffff;
+  --ink: #1a1b1e;
+  --ink-2: #43454c;
+  --muted: #6e7178;
+  --faint: #9a9da4;
+  --line: #eae7e0;
+  --line-2: #dcd8cd;
+  --red: #d92c25;
+  --red-deep: #b7211b;
+  --red-tint: #fcefee;
+  --green: #157f52;
+  --green-tint: #e9f5ef;
+  --amber: #9a6b15;
+  --amber-tint: #fdf6e6;
+  --teal: #14695a;
+  --teal-tint: #eef4f2;
+  --card-paper: #fffefb;
+  /* shadows (warm, light-theme calibrated) */
+  --sh-1: 0 1px 2px rgba(43, 38, 28, 0.05);
+  --sh-2: 0 2px 8px rgba(43, 38, 28, 0.06), 0 12px 32px rgba(43, 38, 28, 0.07);
+  --sh-3: 0 24px 70px rgba(43, 38, 28, 0.18);
   /* type */
   --font-body: 'Barlow', 'Bricolage Grotesque', sans-serif;
   --font-disp: 'Bricolage Grotesque', 'Barlow', sans-serif;
@@ -39,8 +46,8 @@ body,
 
 body {
   margin: 0;
-  background: var(--black);
-  color: var(--text);
+  background: var(--paper);
+  color: var(--ink);
   font-family: var(--font-body);
   font-size: 15px;
   line-height: 1.5;
@@ -54,7 +61,7 @@ input {
   font-size: max(16px, 0.95rem) !important;
 }
 
-/* ——— atmosphere: Enlightenment gradient + schematic grid ——— */
+/* ——— atmosphere: letterhead rule, warm glow, paper grain ——— */
 
 body::before {
   content: '';
@@ -62,9 +69,9 @@ body::before {
   inset: 0;
   z-index: -2;
   background:
-    radial-gradient(1100px 700px at -8% 112%, rgba(232, 128, 4, 0.18), transparent 62%),
-    radial-gradient(1300px 850px at -4% 118%, rgba(174, 20, 15, 0.26), transparent 66%),
-    radial-gradient(900px 600px at 108% -12%, rgba(174, 20, 15, 0.10), transparent 60%);
+    linear-gradient(90deg, var(--red), var(--red-deep)) top / 100% 3px no-repeat,
+    radial-gradient(900px 420px at 50% -80px, #ffffff 0%, rgba(255, 255, 255, 0) 70%),
+    var(--paper);
 }
 
 body::after {
@@ -73,38 +80,36 @@ body::after {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background:
-    linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px);
-  background-size: 72px 72px;
-  mask-image: radial-gradient(120% 90% at 20% 100%, black 0%, transparent 75%);
-  -webkit-mask-image: radial-gradient(120% 90% at 20% 100%, black 0%, transparent 75%);
+  opacity: 0.35;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
 }
 
 /* ——— type hierarchy ——— */
 
 .eyebrow {
   font-family: var(--font-body);
-  font-weight: 300;
-  font-size: 0.74rem;
+  font-weight: 600;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--dawn);
+  letter-spacing: 0.14em;
+  color: var(--muted);
   margin: 0;
 }
 
 .hero-title {
-  font-weight: 500;
-  font-size: clamp(2rem, 4vw, 3rem);
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: clamp(2rem, 4vw, 2.9rem);
   letter-spacing: -0.02em;
   line-height: 1.08;
   margin: 12px 0 16px;
+  color: var(--ink);
 }
 
 .lede {
-  color: var(--muted);
+  color: var(--ink-2);
   font-weight: 300;
-  font-size: 1.06rem;
+  font-size: 1.12rem;
   max-width: 46ch;
   margin: 0 0 26px;
 }
@@ -119,25 +124,26 @@ body::after {
 .view-num {
   font-family: var(--font-disp);
   font-weight: 700;
-  font-size: 2.4rem;
+  font-size: 2.3rem;
   line-height: 1;
-  color: var(--infared);
-  opacity: 0.9;
+  color: var(--red);
   min-width: 56px;
   letter-spacing: -0.04em;
 }
 
 .view-title {
-  font-weight: 500;
-  font-size: 1.55rem;
-  letter-spacing: -0.02em;
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: -0.015em;
   margin: 0 0 6px;
   line-height: 1.15;
 }
 
 .view-narration {
   color: var(--muted);
-  font-weight: 300;
+  font-weight: 400;
+  font-size: 0.94rem;
   max-width: 78ch;
   margin: 0;
 }
@@ -146,11 +152,11 @@ body::after {
 .dim {
   color: var(--muted);
   font-size: 0.85rem;
-  font-weight: 300;
+  font-weight: 400;
 }
 
 .error {
-  color: var(--infared);
+  color: var(--red-deep);
   font-size: 0.9rem;
 }
 
@@ -158,7 +164,7 @@ body::after {
 
 .shell {
   display: grid;
-  grid-template-columns: 272px 1fr;
+  grid-template-columns: 252px 1fr;
   /* dvh: keep the bottom docks above iOS Safari's dynamic toolbar */
   height: 100vh;
   height: 100dvh;
@@ -179,10 +185,10 @@ body::after {
 }
 
 .menu-btn {
-  background: none;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--ink);
   font-size: 1.05rem;
   line-height: 1;
   padding: 7px 11px;
@@ -198,7 +204,7 @@ body::after {
   position: fixed;
   inset: 0;
   z-index: 55;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(28, 25, 18, 0.32);
   backdrop-filter: blur(2px);
 }
 
@@ -249,33 +255,23 @@ body::after {
 .sidebar {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--line-soft);
-  padding: 24px 18px 18px;
-  background: rgba(0, 0, 0, 0.45);
+  border-right: 1px solid var(--line);
+  padding: 24px 16px 18px;
+  background: rgba(255, 255, 255, 0.5);
   overflow-y: auto;
 }
 
 .brand {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 11px;
   padding: 2px 8px 22px;
 }
 
 .brand-glyph {
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   flex: none;
-}
-
-.brand-glyph rect {
-  fill: none;
-  stroke: var(--infared);
-  stroke-width: 2;
-}
-
-.brand-glyph .brand-moon {
-  fill: var(--infared);
 }
 
 .brand-words {
@@ -288,18 +284,19 @@ body::after {
   display: block;
   font-family: var(--font-disp);
   font-weight: 600;
-  font-size: 1.02rem;
+  font-size: 1.04rem;
   letter-spacing: -0.01em;
   line-height: 1.1;
+  color: var(--ink);
 }
 
 .brand-tag {
   display: block;
-  font-weight: 300;
-  font-size: 0.66rem;
+  font-weight: 500;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--dim);
+  letter-spacing: 0.13em;
+  color: var(--faint);
 }
 
 .brand-large {
@@ -309,24 +306,24 @@ body::after {
 }
 
 .brand-large .brand-glyph {
-  width: 52px;
-  height: 52px;
+  width: 50px;
+  height: 50px;
 }
 
 .sidenav {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   flex: 1;
 }
 
 .nav-label {
-  font-weight: 300;
-  font-size: 0.68rem;
+  font-weight: 600;
+  font-size: 0.64rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--dim);
-  margin: 18px 8px 6px;
+  letter-spacing: 0.16em;
+  color: var(--faint);
+  margin: 18px 10px 6px;
 }
 
 .step {
@@ -340,32 +337,37 @@ body::after {
   border-radius: 10px;
   padding: 9px 10px;
   cursor: pointer;
-  color: var(--muted);
+  color: var(--ink-2);
   font-family: inherit;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, box-shadow 0.15s;
 }
 
 .step:hover {
-  background: rgba(255, 255, 255, 0.035);
-  color: var(--text);
+  background: #f1efe9;
+  color: var(--ink);
 }
 
 .step-active {
-  background: rgba(229, 35, 33, 0.09);
-  border-color: rgba(229, 35, 33, 0.4);
-  color: var(--text);
+  background: var(--ink);
+  color: #ffffff;
+  box-shadow: var(--sh-1);
+}
+
+.step-active:hover {
+  background: var(--ink);
+  color: #ffffff;
 }
 
 .step-num {
   font-family: var(--font-disp);
   font-weight: 700;
-  font-size: 0.95rem;
-  color: var(--dim);
+  font-size: 0.92rem;
+  color: var(--faint);
   letter-spacing: -0.02em;
 }
 
 .step-active .step-num {
-  color: var(--infared);
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .step-words {
@@ -381,21 +383,34 @@ body::after {
 }
 
 .step-sub {
-  font-weight: 300;
+  font-weight: 400;
   font-size: 0.72rem;
-  color: var(--dim);
+  color: var(--faint);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
+.step-active .step-sub {
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .step-check {
-  color: var(--acid);
+  color: var(--green);
   font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.step-active .step-check {
+  color: #7fd6ac;
 }
 
 .step-done .step-num {
-  color: var(--acid);
+  color: var(--green);
+}
+
+.step-active.step-done .step-num {
+  color: #7fd6ac;
 }
 
 .side-foot {
@@ -404,7 +419,7 @@ body::after {
   align-items: flex-start;
   gap: 9px;
   padding: 14px 8px 0;
-  border-top: 1px solid var(--line-soft);
+  border-top: 1px solid var(--line);
   margin-top: 12px;
 }
 
@@ -419,8 +434,7 @@ body::after {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--acid);
-  box-shadow: 0 0 8px rgba(6, 255, 137, 0.6);
+  background: var(--green);
   animation: breathe 2.4s ease-in-out infinite;
 }
 
@@ -432,7 +446,7 @@ body::after {
 
 .side-net {
   font-size: 0.76rem;
-  font-weight: 300;
+  font-weight: 400;
   color: var(--muted);
   flex: 1;
 }
@@ -448,9 +462,9 @@ body::after {
   align-items: center;
   justify-content: space-between;
   gap: 18px;
-  padding: 16px 38px;
-  border-bottom: 1px solid var(--line-soft);
-  background: rgba(0, 0, 0, 0.35);
+  padding: 14px 38px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.6);
 }
 
 .topbar-id {
@@ -472,33 +486,35 @@ body::after {
 }
 
 .topstat-k {
-  font-weight: 300;
-  font-size: 0.64rem;
+  font-weight: 600;
+  font-size: 0.6rem;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--dim);
+  letter-spacing: 0.14em;
+  color: var(--faint);
 }
 
 .topstat-v {
   font-variant-numeric: tabular-nums;
-  font-weight: 500;
+  font-family: var(--font-disp);
+  font-weight: 600;
   font-size: 1.02rem;
   animation: statpop 0.9s ease-out;
 }
 
 @keyframes statpop {
   from {
-    color: var(--dawn);
+    color: var(--red);
   }
 }
 
 /* ——— panels ——— */
 
 .panel {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012));
+  background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 20px 22px;
+  border-radius: 16px;
+  box-shadow: var(--sh-1);
+  padding: 20px 24px;
   margin: 0 0 18px;
 }
 
@@ -508,29 +524,30 @@ body::after {
 
 .panel-sub {
   color: var(--muted);
-  font-weight: 300;
+  font-weight: 400;
   font-size: 0.86rem;
   margin: 6px 0 0;
   max-width: 80ch;
 }
 
 .panel-dapp {
-  border-color: rgba(22, 233, 216, 0.35);
-  background: linear-gradient(180deg, rgba(22, 233, 216, 0.05), rgba(255, 255, 255, 0.01));
+  border-color: #d3e2dd;
+  background: linear-gradient(180deg, var(--teal-tint), var(--surface) 55%);
 }
 
 .panel-dapp > .panel-head .eyebrow {
-  color: var(--electric);
+  color: var(--teal);
 }
 
 .panel-scaffold {
   border-style: dashed;
-  border-color: var(--line);
+  border-color: var(--line-2);
   background: none;
+  box-shadow: none;
 }
 
 .panel-scaffold > .panel-head .eyebrow {
-  color: var(--dim);
+  color: var(--faint);
 }
 
 /* ——— forms & buttons ——— */
@@ -568,24 +585,24 @@ body::after {
 }
 
 .field-label {
-  font-weight: 300;
-  font-size: 0.68rem;
+  font-weight: 600;
+  font-size: 0.64rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--dim);
+  letter-spacing: 0.13em;
+  color: var(--muted);
 }
 
 label {
-  color: var(--muted);
+  color: var(--ink-2);
   font-size: 0.9rem;
 }
 
 input {
-  background: rgba(0, 0, 0, 0.55);
-  color: var(--text);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 9px 11px;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 9px 12px;
   font-family: inherit;
   font-size: 0.92rem;
   transition: border-color 0.15s, box-shadow 0.15s;
@@ -593,14 +610,14 @@ input {
 
 input:focus {
   outline: none;
-  border-color: var(--dawn);
-  box-shadow: 0 0 0 3px rgba(236, 100, 29, 0.15);
+  border-color: var(--ink);
+  box-shadow: 0 0 0 3px rgba(26, 27, 30, 0.08);
 }
 
 input[type='checkbox'] {
-  accent-color: var(--infared);
-  width: 15px;
-  height: 15px;
+  accent-color: var(--red);
+  width: 16px;
+  height: 16px;
   padding: 0;
 }
 
@@ -609,9 +626,9 @@ input[type='checkbox'] {
   align-items: center;
   gap: 9px;
   margin-top: 14px;
-  font-weight: 300;
+  font-weight: 400;
   font-size: 0.82rem;
-  color: var(--dim);
+  color: var(--muted);
   cursor: pointer;
 }
 
@@ -621,10 +638,10 @@ input[type='checkbox'] {
   justify-content: center;
   gap: 8px;
   border: 1px solid transparent;
-  border-radius: 9px;
+  border-radius: 10px;
   padding: 9px 18px;
   font-family: inherit;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 0.92rem;
   cursor: pointer;
   transition: background 0.15s, box-shadow 0.15s, border-color 0.15s, transform 0.1s;
@@ -640,34 +657,36 @@ input[type='checkbox'] {
 }
 
 .btn-primary {
-  background: var(--infared);
-  color: var(--white);
+  background: var(--red);
+  color: #ffffff;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #f53330;
-  box-shadow: 0 4px 28px rgba(229, 35, 33, 0.35);
+  background: var(--red-deep);
+  box-shadow: 0 6px 18px rgba(217, 44, 37, 0.25);
   transform: translateY(-1px);
 }
 
 .btn-ghost {
-  background: transparent;
-  border-color: var(--line);
-  color: var(--text);
+  background: var(--surface);
+  border-color: var(--line-2);
+  color: var(--ink);
 }
 
 .btn-ghost:hover:not(:disabled) {
-  border-color: var(--muted);
+  border-color: #b9b4a6;
+  box-shadow: var(--sh-1);
 }
 
 .btn-danger {
-  background: transparent;
-  border-color: rgba(229, 35, 33, 0.55);
-  color: var(--infared);
+  background: var(--surface);
+  border-color: #ecc8c5;
+  color: var(--red-deep);
 }
 
 .btn-danger:hover:not(:disabled) {
-  background: rgba(229, 35, 33, 0.1);
+  background: var(--red-tint);
+  border-color: var(--red);
 }
 
 .btn-block {
@@ -680,18 +699,18 @@ input[type='checkbox'] {
 button.linkish {
   background: none;
   border: none;
-  color: var(--dim);
+  color: var(--muted);
   text-decoration: underline;
   text-underline-offset: 3px;
   padding: 0 6px;
   font-family: inherit;
-  font-weight: 300;
+  font-weight: 400;
   font-size: 0.8rem;
   cursor: pointer;
 }
 
 button.linkish:hover {
-  color: var(--muted);
+  color: var(--ink);
 }
 
 /* ——— tables ——— */
@@ -704,7 +723,7 @@ table {
 
 td,
 th {
-  border-bottom: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line);
   padding: 9px 10px;
   text-align: left;
   font-weight: 400;
@@ -716,11 +735,11 @@ tr:last-child td {
 }
 
 th {
-  color: var(--dim);
-  font-size: 0.68rem;
-  font-weight: 300;
+  color: var(--muted);
+  font-size: 0.66rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.13em;
 }
 
 .num {
@@ -729,8 +748,9 @@ th {
 }
 
 .num-big {
+  font-family: var(--font-disp);
   font-size: 1.15rem;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .row-actions {
@@ -744,49 +764,46 @@ th {
 }
 
 .stale {
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 .cell-capbar {
   min-width: 190px;
 }
 
-/* ——— the document: passport data page ——— */
+/* ——— the document: passport card (light, sketch-005 artefact) ——— */
 
 .doc {
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(255, 186, 54, 0.22);
-  border-radius: 16px;
-  padding: 18px 22px 0;
+  border: 1px solid var(--line-2);
+  border-radius: 20px;
+  padding: 18px 24px 0;
   margin: 0 0 18px;
-  background:
-    radial-gradient(110% 160% at 85% -20%, rgba(236, 100, 29, 0.07), transparent 55%),
-    linear-gradient(180deg, #121013, #0a0a0c);
+  background: radial-gradient(140% 120% at 0% 0%, var(--card-paper) 0%, #f7f4ec 100%);
+  box-shadow: var(--sh-2);
 }
 
-/* guilloché: fine engraved ringwork, the schematic-overlay rule applied the
-   way passports apply engraving */
+/* guilloché: fine engraved ringwork in ink, as passports engrave value */
 .doc::before {
   content: '';
   position: absolute;
-  inset: -40% -25% auto auto;
-  width: 520px;
-  height: 520px;
+  inset: 0;
   pointer-events: none;
+  opacity: 0.55;
   background-image: repeating-radial-gradient(
-      circle at 60% 40%,
+      circle at 108% 110%,
       transparent 0,
-      transparent 7px,
-      rgba(236, 100, 29, 0.05) 7.6px,
-      transparent 8.4px
+      transparent 26px,
+      rgba(26, 27, 30, 0.05) 26.5px,
+      transparent 27.5px
     ),
     repeating-radial-gradient(
-      circle at 42% 58%,
+      circle at -6% -10%,
       transparent 0,
-      transparent 11px,
-      rgba(255, 186, 54, 0.038) 11.6px,
-      transparent 12.6px
+      transparent 30px,
+      rgba(26, 27, 30, 0.04) 30.5px,
+      transparent 31.5px
     );
 }
 
@@ -794,14 +811,13 @@ th {
 .doc::after {
   content: '';
   position: absolute;
-  right: 6%;
-  top: 18%;
-  width: 190px;
-  height: 190px;
+  right: -34px;
+  bottom: -52px;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
   pointer-events: none;
-  opacity: 0.055;
-  background: no-repeat center / contain
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23E52321' d='M20.8 7.4a9.4 9.4 0 1 0 3.6 13.8 7.6 7.6 0 0 1-3.6-13.8z'/%3E%3C/svg%3E");
+  background: radial-gradient(circle at 64% 36%, transparent 58%, rgba(217, 44, 37, 0.08) 59%);
 }
 
 .doc-head {
@@ -811,36 +827,37 @@ th {
   flex-wrap: wrap;
   padding-bottom: 12px;
   margin-bottom: 16px;
-  border-bottom: 1px solid rgba(255, 186, 54, 0.16);
+  border-bottom: 1px solid var(--line);
 }
 
 .doc-authority,
 .doc-type {
-  font-weight: 300;
-  font-size: 0.68rem;
+  font-weight: 600;
+  font-size: 0.64rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  color: var(--amber);
-  opacity: 0.85;
+  color: var(--ink-2);
 }
 
 .doc-type {
-  color: var(--muted);
+  color: var(--faint);
 }
 
 /* e-passport contact chip */
 .doc-chipmark {
   position: absolute;
-  left: 22px;
+  left: 24px;
   top: 64px;
   width: 34px;
   height: 26px;
-  border: 1px solid rgba(255, 186, 54, 0.55);
+  border: 1px solid #cdc7b6;
   border-radius: 6px;
   background:
-    linear-gradient(rgba(255, 186, 54, 0.35), rgba(255, 186, 54, 0.35)) 50% 50% / 100% 1px no-repeat,
-    linear-gradient(rgba(255, 186, 54, 0.35), rgba(255, 186, 54, 0.35)) 50% 50% / 1px 100% no-repeat,
-    rgba(255, 186, 54, 0.07);
+    linear-gradient(rgba(154, 142, 109, 0.4), rgba(154, 142, 109, 0.4)) 50% 50% / 100% 1px
+      no-repeat,
+    linear-gradient(rgba(154, 142, 109, 0.4), rgba(154, 142, 109, 0.4)) 50% 50% / 1px 100%
+      no-repeat,
+    #f3efe3;
 }
 
 .doc-grid {
@@ -863,34 +880,35 @@ th {
 }
 
 .docfield-k {
-  font-weight: 300;
-  font-size: 0.62rem;
+  font-weight: 600;
+  font-size: 0.58rem;
   text-transform: uppercase;
-  letter-spacing: 0.17em;
-  color: var(--dim);
+  letter-spacing: 0.16em;
+  color: var(--muted);
 }
 
 .docfield-v {
   font-size: 0.98rem;
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
+  color: var(--ink);
 }
 
 .docfield-big {
   font-family: var(--font-disp);
   font-weight: 600;
   font-size: 1.55rem;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
   line-height: 1.1;
 }
 
 /* machine-readable zone */
 .doc-mrz {
   position: relative;
-  margin: 0 -22px;
-  padding: 12px 22px 14px;
-  background: rgba(255, 255, 255, 0.05);
-  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  margin: 0 -24px;
+  padding: 12px 24px 14px;
+  background: #f1ede0;
+  border-top: 1px solid var(--line-2);
   display: flex;
   flex-direction: column;
   gap: 3px;
@@ -900,7 +918,7 @@ th {
   font-family: var(--font-mono);
   font-size: clamp(0.55rem, 2.1vw, 0.8rem);
   letter-spacing: 0.14em;
-  color: rgba(255, 255, 255, 0.62);
+  color: #6a6753;
   white-space: nowrap;
   overflow: hidden;
 }
@@ -918,10 +936,11 @@ th {
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  border: 1px solid var(--line-soft);
-  border-radius: 12px;
-  background: rgba(0, 0, 0, 0.3);
-  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: var(--sh-1);
+  padding: 12px 16px;
 }
 
 .listrow-id {
@@ -952,8 +971,9 @@ th {
 .mono {
   font-family: var(--font-mono);
   font-size: 0.78rem;
-  background: rgba(0, 0, 0, 0.5);
-  border: 1px solid var(--line-soft);
+  color: var(--ink-2);
+  background: #f4f2ec;
+  border: 1px solid var(--line);
   padding: 3px 7px;
   border-radius: 6px;
   cursor: copy;
@@ -961,12 +981,13 @@ th {
 }
 
 .mono:hover {
-  border-color: var(--dawn);
+  border-color: var(--red);
 }
 
 .mono.copied {
-  color: var(--acid);
-  border-color: rgba(6, 255, 137, 0.4);
+  color: var(--green);
+  border-color: #bfdfd0;
+  background: var(--green-tint);
 }
 
 .addr-hero {
@@ -982,53 +1003,70 @@ th {
   align-items: center;
   gap: 5px;
   font-size: 0.66rem;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  padding: 3px 9px;
+  letter-spacing: 0.11em;
+  padding: 3px 10px;
   border-radius: 999px;
-  border: 1px solid;
+  border: 1px solid transparent;
   white-space: nowrap;
 }
 
 .chip-ok {
-  color: var(--acid);
-  border-color: rgba(6, 255, 137, 0.4);
-  background: rgba(6, 255, 137, 0.07);
+  color: var(--green);
+  border-color: #cde7da;
+  background: var(--green-tint);
 }
 
 .chip-danger {
-  color: var(--infared);
-  border-color: rgba(229, 35, 33, 0.5);
-  background: rgba(229, 35, 33, 0.08);
+  color: var(--red-deep);
+  border-color: #ecc8c5;
+  background: var(--red-tint);
 }
 
 .chip-warn {
   color: var(--amber);
-  border-color: rgba(255, 186, 54, 0.45);
-  background: rgba(255, 186, 54, 0.07);
+  border-color: #ead9b3;
+  background: var(--amber-tint);
 }
 
 .chip-info {
-  color: var(--electric);
-  border-color: rgba(22, 233, 216, 0.4);
-  background: rgba(22, 233, 216, 0.07);
+  color: var(--teal);
+  border-color: #cbdfd9;
+  background: var(--teal-tint);
 }
 
 .chip-muted {
   color: var(--muted);
-  border-color: var(--line);
-  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--line-2);
+  background: #f1efe9;
 }
 
 /* rubber-stamp status — document officialdom */
 .chip-stamp {
-  border-width: 1.5px;
+  border-width: 2px;
   border-radius: 5px;
-  font-weight: 600;
-  letter-spacing: 0.17em;
+  font-weight: 700;
+  letter-spacing: 0.16em;
   padding: 4px 11px;
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.35);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.chip-stamp.chip-ok {
+  border-color: var(--green);
+}
+
+.chip-stamp.chip-danger {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.chip-stamp.chip-warn {
+  border-color: #d3a73f;
+}
+
+.chip-stamp.chip-muted {
+  border-color: var(--faint);
 }
 
 .chip-tilt {
@@ -1047,18 +1085,19 @@ th {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid var(--line-soft);
-  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--sh-1);
   padding: 12px 14px;
 }
 
 .stat-k {
-  font-weight: 300;
-  font-size: 0.66rem;
+  font-weight: 600;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: var(--dim);
+  letter-spacing: 0.14em;
+  color: var(--muted);
 }
 
 .stat-v {
@@ -1080,7 +1119,7 @@ th {
   flex: 1;
   height: 6px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.07);
+  background: #eceae3;
   overflow: hidden;
   min-width: 90px;
 }
@@ -1088,7 +1127,7 @@ th {
 .capbar-fill {
   height: 100%;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--infared), var(--dawn));
+  background: var(--ink-2);
   transition: width 0.6s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
@@ -1100,9 +1139,9 @@ th {
 
 .secret-callout {
   margin-top: 14px;
-  border: 1px solid rgba(255, 186, 54, 0.4);
-  background: rgba(255, 186, 54, 0.05);
-  border-radius: 10px;
+  border: 1px solid #ead9b3;
+  background: var(--amber-tint);
+  border-radius: 12px;
   padding: 12px 14px;
   word-break: break-all;
 }
@@ -1119,17 +1158,17 @@ th {
   align-items: flex-start;
   gap: 12px;
   margin-top: 16px;
-  border-left: 3px solid var(--amber);
-  background: rgba(255, 186, 54, 0.06);
-  border-radius: 0 10px 10px 0;
+  border-left: 3px solid #d3a73f;
+  background: var(--amber-tint);
+  border-radius: 0 12px 12px 0;
   padding: 10px 14px;
 }
 
 .caveat p {
   margin: 0;
   font-size: 0.86rem;
-  font-weight: 300;
-  color: var(--muted);
+  font-weight: 400;
+  color: var(--ink-2);
   max-width: 75ch;
 }
 
@@ -1155,7 +1194,7 @@ th {
 .explain p {
   margin: 8px 0 0;
   font-size: 0.86rem;
-  font-weight: 300;
+  font-weight: 400;
   color: var(--muted);
 }
 
@@ -1176,39 +1215,40 @@ th {
 
 .share-slot {
   width: 108px;
-  border: 1px dashed var(--line);
+  border: 1px dashed var(--line-2);
   border-radius: 12px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  color: var(--dim);
+  color: var(--faint);
+  background: var(--surface);
 }
 
 .share-live {
   border-style: solid;
-  border-color: rgba(236, 100, 29, 0.5);
-  background: rgba(236, 100, 29, 0.06);
-  color: var(--text);
+  border-color: #bfdfd0;
+  background: var(--green-tint);
+  color: var(--ink);
 }
 
 .share-n {
   font-family: var(--font-disp);
   font-weight: 700;
   font-size: 1.6rem;
-  color: var(--dawn);
+  color: var(--green);
 }
 
 .share-slot:not(.share-live) .share-n {
-  color: var(--dim);
+  color: var(--faint);
 }
 
 .share-k {
-  font-weight: 300;
-  font-size: 0.62rem;
+  font-weight: 600;
+  font-size: 0.58rem;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.15em;
 }
 
 .share-v {
@@ -1289,19 +1329,21 @@ th {
   display: flex;
   gap: 14px;
   align-items: flex-start;
-  color: var(--muted);
-  font-weight: 300;
+  color: var(--ink-2);
+  font-weight: 400;
   font-size: 0.92rem;
 }
 
 .hero-step-n {
   font-family: var(--font-disp);
   font-weight: 700;
-  color: var(--infared);
-  border: 1px solid rgba(229, 35, 33, 0.45);
-  border-radius: 8px;
-  width: 26px;
-  height: 26px;
+  color: var(--red);
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  box-shadow: var(--sh-1);
+  border-radius: 9px;
+  width: 27px;
+  height: 27px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1336,9 +1378,10 @@ th {
 
 .provedock {
   margin: 0 22px 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(229, 35, 33, 0.45);
-  background: linear-gradient(180deg, rgba(229, 35, 33, 0.10), rgba(0, 0, 0, 0.7));
+  border-radius: 14px;
+  border: 1px solid var(--line-2);
+  background: var(--surface);
+  box-shadow: var(--sh-2);
   position: relative;
   overflow: hidden;
   padding: 10px 16px;
@@ -1346,13 +1389,13 @@ th {
 }
 
 .provedock-done {
-  border-color: rgba(6, 255, 137, 0.4);
-  background: linear-gradient(180deg, rgba(6, 255, 137, 0.07), rgba(0, 0, 0, 0.7));
+  border-color: #bfdfd0;
+  background: linear-gradient(180deg, var(--green-tint), var(--surface) 70%);
 }
 
 .provedock-error {
-  border-color: rgba(229, 35, 33, 0.7);
-  background: linear-gradient(180deg, rgba(229, 35, 33, 0.14), rgba(0, 0, 0, 0.7));
+  border-color: #ecc8c5;
+  background: linear-gradient(180deg, var(--red-tint), var(--surface) 70%);
 }
 
 .provedock-scan {
@@ -1361,7 +1404,7 @@ th {
   left: -40%;
   height: 2px;
   width: 40%;
-  background: linear-gradient(90deg, transparent, var(--infared), transparent);
+  background: linear-gradient(90deg, transparent, var(--red), transparent);
   animation: scan 1.8s linear infinite;
 }
 
@@ -1382,22 +1425,21 @@ th {
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: var(--infared);
-  box-shadow: 0 0 10px rgba(229, 35, 33, 0.8);
+  background: var(--red);
   animation: breathe 1.1s ease-in-out infinite;
   flex: none;
 }
 
 .provedock-label {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 0.95rem;
 }
 
 .provedock-circuit {
   font-family: var(--font-mono);
   font-size: 0.74rem;
-  color: var(--dawn);
-  background: rgba(0, 0, 0, 0.5);
+  color: var(--red-deep);
+  background: var(--red-tint);
   border-radius: 6px;
   padding: 2px 7px;
 }
@@ -1412,19 +1454,19 @@ th {
 }
 
 .phase {
-  font-weight: 300;
-  font-size: 0.72rem;
+  font-weight: 600;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--dim);
+  letter-spacing: 0.13em;
+  color: var(--faint);
 }
 
 .phase-done {
-  color: var(--acid);
+  color: var(--green);
 }
 
 .phase-live {
-  color: var(--white);
+  color: var(--ink);
   animation: breathe 1.4s ease-in-out infinite;
 }
 
@@ -1438,13 +1480,13 @@ th {
 
 .provedock-detail {
   margin: 6px 0 0 21px;
-  font-weight: 300;
+  font-weight: 400;
   font-size: 0.78rem;
-  color: var(--dim);
+  color: var(--muted);
 }
 
 .provedock-msg {
-  color: var(--infared);
+  color: var(--red-deep);
   font-size: 0.84rem;
   max-width: 60ch;
   overflow: hidden;
@@ -1453,16 +1495,16 @@ th {
 }
 
 .provedock-txk {
-  font-weight: 300;
-  font-size: 0.72rem;
+  font-weight: 600;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--dim);
+  letter-spacing: 0.13em;
+  color: var(--faint);
 }
 
 .activity {
-  border-top: 1px solid var(--line-soft);
-  background: rgba(0, 0, 0, 0.78);
+  border-top: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(10px);
   /* keep clear of the iOS home indicator */
   padding-bottom: env(safe-area-inset-bottom, 0px);
@@ -1482,21 +1524,22 @@ th {
 }
 
 .activity-head .eyebrow {
-  color: var(--dim);
+  color: var(--faint);
 }
 
 .activity-count {
   font-variant-numeric: tabular-nums;
   font-size: 0.72rem;
-  color: var(--dim);
-  border: 1px solid var(--line-soft);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  background: #f1efe9;
   border-radius: 999px;
   padding: 0 8px;
 }
 
 .activity-toggle {
   margin-left: auto;
-  color: var(--dim);
+  color: var(--faint);
   font-size: 0.72rem;
 }
 
@@ -1509,9 +1552,13 @@ th {
 .activity-line {
   font-family: var(--font-mono);
   font-size: 0.72rem;
-  color: var(--muted);
+  color: var(--ink-2);
   padding: 1.5px 0;
   word-break: break-all;
+}
+
+.activity-line.dim {
+  color: var(--faint);
 }
 
 .activity-line .mono {
@@ -1531,8 +1578,8 @@ th {
 .spinner {
   width: 14px;
   height: 14px;
-  border: 2px solid var(--line);
-  border-top-color: var(--infared);
+  border: 2px solid var(--line-2);
+  border-top-color: var(--red);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
   display: inline-block;
@@ -1542,8 +1589,8 @@ th {
 .spinner-btn {
   width: 11px;
   height: 11px;
-  border-color: rgba(255, 255, 255, 0.35);
-  border-top-color: var(--white);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
 }
 
 @keyframes spin {
@@ -1579,8 +1626,8 @@ th {
     align-items: center;
     gap: 12px;
     padding: 10px 14px;
-    border-bottom: 1px solid var(--line-soft);
-    background: rgba(0, 0, 0, 0.5);
+    border-bottom: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.75);
     min-width: 0;
   }
 
@@ -1622,15 +1669,15 @@ th {
     bottom: 0;
     width: min(312px, 85vw);
     z-index: 60;
-    background: #0a0a0c;
-    border-right: 1px solid var(--line);
+    background: var(--paper);
+    border-right: 1px solid var(--line-2);
     transform: translateX(-105%);
     transition: transform 0.22s ease-out;
   }
 
   .sidebar-open {
     transform: none;
-    box-shadow: 24px 0 60px rgba(0, 0, 0, 0.6);
+    box-shadow: var(--sh-3);
   }
 
   .content {
@@ -1692,7 +1739,6 @@ th {
   .doc::after {
     width: 130px;
     height: 130px;
-    top: 8%;
   }
 
   .listrow {

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -1232,6 +1232,7 @@ th {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 14px;
+  margin-bottom: 18px;
 }
 
 .tile {
@@ -1283,6 +1284,281 @@ th {
   font-size: 0.76rem;
   font-weight: 400;
   color: var(--faint);
+}
+
+/* ——— live custody flow diagram ——— */
+
+.flow {
+  display: flex;
+  align-items: stretch;
+  margin-top: 4px;
+}
+
+.flow-node {
+  background: var(--surface);
+  border: 1px solid var(--line-2);
+  border-radius: 14px;
+  box-shadow: var(--sh-1);
+  padding: 13px 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.flow-node-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.86rem;
+}
+
+.flow-node-head svg {
+  width: 16px;
+  height: 16px;
+  color: var(--ink-2);
+  flex: none;
+}
+
+.flow-user {
+  flex: none;
+  align-self: center;
+  align-items: center;
+  text-align: center;
+  padding: 16px 20px;
+  gap: 4px;
+}
+
+.flow-user svg {
+  width: 28px;
+  height: 28px;
+  color: var(--ink-2);
+}
+
+.flow-user b {
+  font-size: 0.92rem;
+}
+
+.flow-dim {
+  font-size: 0.7rem;
+  color: var(--faint);
+}
+
+.flow-link {
+  flex: 1;
+  min-width: 72px;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 0 12px;
+}
+
+.flow-link-label {
+  font-weight: 600;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  color: var(--ink-2);
+}
+
+.flow-link-line {
+  position: relative;
+  width: 100%;
+  height: 2px;
+  background: repeating-linear-gradient(90deg, var(--line-2) 0 7px, transparent 7px 12px);
+}
+
+.flow-link-line::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 5px solid transparent;
+  border-left-color: var(--line-2);
+  border-right: 0;
+}
+
+.flow-flowing .flow-link-line {
+  background: repeating-linear-gradient(90deg, var(--red) 0 7px, transparent 7px 12px);
+  animation: flowdash 0.6s linear infinite;
+}
+
+.flow-flowing .flow-link-line::after {
+  border-left-color: var(--red);
+}
+
+@keyframes flowdash {
+  to {
+    background-position: 12px 0;
+  }
+}
+
+@keyframes flowdash-v {
+  to {
+    background-position: 0 12px;
+  }
+}
+
+.flow-link-sub {
+  font-size: 0.69rem;
+  font-weight: 400;
+  color: var(--faint);
+  text-align: center;
+  line-height: 1.35;
+}
+
+.flow-device {
+  flex: none;
+  width: 252px;
+}
+
+.flow-on {
+  border-color: #b9b4a6;
+  box-shadow: var(--sh-2);
+}
+
+.flow-more {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 0.64rem;
+  color: var(--muted);
+  background: #f1efe9;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.flow-inner {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 0.8rem;
+  color: var(--ink-2);
+  background: #f6f4ef;
+  border-radius: 9px;
+  padding: 8px 11px;
+}
+
+.flow-inner svg {
+  width: 15px;
+  height: 15px;
+  flex: none;
+}
+
+.flow-prover {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 1px dashed var(--line-2);
+  border-radius: 10px;
+  padding: 9px 11px;
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+
+.flow-prover-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--faint);
+  flex: none;
+  transition: background 0.3s ease;
+}
+
+.flow-prover-words {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.flow-prover-words b {
+  font-size: 0.8rem;
+}
+
+.flow-prover-words span {
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+
+.flow-prover-state {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--faint);
+  white-space: nowrap;
+}
+
+.flow-proving {
+  border: 1px solid var(--red);
+  background: var(--red-tint);
+}
+
+.flow-proving .flow-prover-dot {
+  background: var(--red);
+  animation: breathe 1.1s ease-in-out infinite;
+}
+
+.flow-proving .flow-prover-state {
+  color: var(--red-deep);
+}
+
+.flow-scan {
+  position: absolute;
+  top: 0;
+  left: -40%;
+  height: 2px;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, var(--red), transparent);
+  animation: scan 1.8s linear infinite;
+}
+
+.flow-foot {
+  margin: 0;
+  font-size: 0.66rem;
+  font-weight: 400;
+  color: var(--faint);
+}
+
+.flow-chain {
+  flex: none;
+  width: 268px;
+}
+
+.flow-contract {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  padding: 10px 12px;
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+
+.flow-contract b {
+  font-size: 0.82rem;
+}
+
+.flow-landed .flow-contract {
+  border-color: var(--green);
+  background: var(--green-tint);
+}
+
+.flow-stats {
+  font-size: 0.7rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-hint {
+  margin: 14px 0 0;
 }
 
 /* ——— hover explainers ——— */
@@ -1871,6 +2147,57 @@ body[data-explain='1'] .x {
 
   .topbar .statchip {
     display: none;
+  }
+
+  /* the flow map stacks; arrows point downwards */
+  .flow {
+    flex-direction: column;
+  }
+
+  .flow-user {
+    align-self: stretch;
+    flex-direction: row;
+    gap: 10px;
+    text-align: left;
+    padding: 13px 15px;
+  }
+
+  .flow-device,
+  .flow-chain {
+    width: auto;
+  }
+
+  .flow-link {
+    align-self: stretch;
+    padding: 10px 0;
+    min-width: 0;
+  }
+
+  .flow-link-line {
+    width: 2px;
+    height: 26px;
+    background: repeating-linear-gradient(180deg, var(--line-2) 0 7px, transparent 7px 12px);
+  }
+
+  .flow-link-line::after {
+    right: auto;
+    top: auto;
+    left: 50%;
+    bottom: -1px;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: var(--line-2);
+    border-bottom: 0;
+  }
+
+  .flow-flowing .flow-link-line {
+    background: repeating-linear-gradient(180deg, var(--red) 0 7px, transparent 7px 12px);
+    animation: flowdash-v 0.6s linear infinite;
+  }
+
+  .flow-flowing .flow-link-line::after {
+    border-left-color: transparent;
+    border-top-color: var(--red);
   }
 
   .listrow {

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -45,6 +45,13 @@ body {
   font-size: 15px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* iOS Safari zooms the page when a focused input is under 16px — never
+   let that happen. */
+input {
+  font-size: max(16px, 0.95rem) !important;
 }
 
 /* ——— atmosphere: Enlightenment gradient + schematic grid ——— */
@@ -628,6 +635,10 @@ input[type='checkbox'] {
   cursor: default;
 }
 
+.btn:active:not(:disabled) {
+  transform: scale(0.985);
+}
+
 .btn-primary {
   background: var(--infared);
   color: var(--white);
@@ -740,6 +751,202 @@ th {
   min-width: 190px;
 }
 
+/* ——— the document: passport data page ——— */
+
+.doc {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 186, 54, 0.22);
+  border-radius: 16px;
+  padding: 18px 22px 0;
+  margin: 0 0 18px;
+  background:
+    radial-gradient(110% 160% at 85% -20%, rgba(236, 100, 29, 0.07), transparent 55%),
+    linear-gradient(180deg, #121013, #0a0a0c);
+}
+
+/* guilloché: fine engraved ringwork, the schematic-overlay rule applied the
+   way passports apply engraving */
+.doc::before {
+  content: '';
+  position: absolute;
+  inset: -40% -25% auto auto;
+  width: 520px;
+  height: 520px;
+  pointer-events: none;
+  background-image: repeating-radial-gradient(
+      circle at 60% 40%,
+      transparent 0,
+      transparent 7px,
+      rgba(236, 100, 29, 0.05) 7.6px,
+      transparent 8.4px
+    ),
+    repeating-radial-gradient(
+      circle at 42% 58%,
+      transparent 0,
+      transparent 11px,
+      rgba(255, 186, 54, 0.038) 11.6px,
+      transparent 12.6px
+    );
+}
+
+/* the crescent as a watermark coat-of-arms */
+.doc::after {
+  content: '';
+  position: absolute;
+  right: 6%;
+  top: 18%;
+  width: 190px;
+  height: 190px;
+  pointer-events: none;
+  opacity: 0.055;
+  background: no-repeat center / contain
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23E52321' d='M20.8 7.4a9.4 9.4 0 1 0 3.6 13.8 7.6 7.6 0 0 1-3.6-13.8z'/%3E%3C/svg%3E");
+}
+
+.doc-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid rgba(255, 186, 54, 0.16);
+}
+
+.doc-authority,
+.doc-type {
+  font-weight: 300;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--amber);
+  opacity: 0.85;
+}
+
+.doc-type {
+  color: var(--muted);
+}
+
+/* e-passport contact chip */
+.doc-chipmark {
+  position: absolute;
+  left: 22px;
+  top: 64px;
+  width: 34px;
+  height: 26px;
+  border: 1px solid rgba(255, 186, 54, 0.55);
+  border-radius: 6px;
+  background:
+    linear-gradient(rgba(255, 186, 54, 0.35), rgba(255, 186, 54, 0.35)) 50% 50% / 100% 1px no-repeat,
+    linear-gradient(rgba(255, 186, 54, 0.35), rgba(255, 186, 54, 0.35)) 50% 50% / 1px 100% no-repeat,
+    rgba(255, 186, 54, 0.07);
+}
+
+.doc-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px 18px;
+  padding: 0 0 18px 56px;
+}
+
+.docfield {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.docfield-wide {
+  grid-column: span 3;
+}
+
+.docfield-k {
+  font-weight: 300;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.17em;
+  color: var(--dim);
+}
+
+.docfield-v {
+  font-size: 0.98rem;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.docfield-big {
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: 1.55rem;
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+}
+
+/* machine-readable zone */
+.doc-mrz {
+  position: relative;
+  margin: 0 -22px;
+  padding: 12px 22px 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.doc-mrz span {
+  font-family: var(--font-mono);
+  font-size: clamp(0.55rem, 2.1vw, 0.8rem);
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.62);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* ——— list rows (grants, devices) ——— */
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.listrow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 12px 14px;
+}
+
+.listrow-id {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.listrow-meter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 170px;
+}
+
+.listrow-side {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
 /* ——— atoms ——— */
 
 .mono {
@@ -812,6 +1019,20 @@ th {
   color: var(--muted);
   border-color: var(--line);
   background: rgba(255, 255, 255, 0.03);
+}
+
+/* rubber-stamp status — document officialdom */
+.chip-stamp {
+  border-width: 1.5px;
+  border-radius: 5px;
+  font-weight: 600;
+  letter-spacing: 0.17em;
+  padding: 4px 11px;
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.35);
+}
+
+.chip-tilt {
+  transform: rotate(-3deg);
 }
 
 .stat-row {
@@ -1243,6 +1464,8 @@ th {
   border-top: 1px solid var(--line-soft);
   background: rgba(0, 0, 0, 0.78);
   backdrop-filter: blur(10px);
+  /* keep clear of the iOS home indicator */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .activity-head {
@@ -1346,7 +1569,8 @@ th {
 
 @media (max-width: 900px) {
   .shell {
-    grid-template-columns: 1fr;
+    /* minmax(0, …): never let content widen the column past the viewport */
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto minmax(0, 1fr);
   }
 
@@ -1357,10 +1581,22 @@ th {
     padding: 10px 14px;
     border-bottom: 1px solid var(--line-soft);
     background: rgba(0, 0, 0, 0.5);
+    min-width: 0;
   }
 
   .mobilebar .brand {
     padding: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .mobilebar .brand-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .mobilebar .chip {
+    flex: none;
   }
 
   .mobilebar .brand-name {
@@ -1370,6 +1606,12 @@ th {
 
   .mobilebar .brand-tag {
     display: none;
+  }
+
+  .mobilebar .chip {
+    font-size: 0.58rem;
+    padding: 3px 8px;
+    letter-spacing: 0.1em;
   }
 
   /* The sidebar becomes a drawer over the content. */
@@ -1420,6 +1662,60 @@ th {
 
   .activity-body {
     max-height: 108px;
+  }
+
+  /* document card on a phone: two columns, chip mark inline */
+  .doc {
+    padding: 16px 16px 0;
+  }
+
+  .doc-grid {
+    grid-template-columns: 1fr 1fr;
+    padding: 36px 0 16px 0;
+    gap: 14px;
+  }
+
+  .docfield-wide {
+    grid-column: span 2;
+  }
+
+  .doc-chipmark {
+    left: 16px;
+    top: 58px;
+  }
+
+  .doc-mrz {
+    margin: 0 -16px;
+    padding: 10px 16px 12px;
+  }
+
+  .doc::after {
+    width: 130px;
+    height: 130px;
+    top: 8%;
+  }
+
+  .listrow {
+    gap: 10px;
+  }
+
+  .listrow-side {
+    margin-left: 0;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  /* generous touch targets */
+  .btn {
+    padding: 11px 18px;
+  }
+
+  .step {
+    padding: 12px 10px;
+  }
+
+  .activity-head {
+    padding: 10px 16px;
   }
 }
 

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -152,14 +152,47 @@ body::after {
 .shell {
   display: grid;
   grid-template-columns: 272px 1fr;
+  /* dvh: keep the bottom docks above iOS Safari's dynamic toolbar */
   height: 100vh;
+  height: 100dvh;
 }
 
 .main {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  height: 100vh;
+  height: 100%;
+  min-height: 0;
+}
+
+/* ——— mobile bar + drawer (≤900px) ——— */
+
+.mobilebar {
+  display: none;
+}
+
+.menu-btn {
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 1.05rem;
+  line-height: 1;
+  padding: 7px 11px;
+  cursor: pointer;
+  flex: none;
+}
+
+.mobilebar-spacer {
+  flex: 1;
+}
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 55;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
 }
 
 .content {
@@ -360,11 +393,19 @@ body::after {
 
 .side-foot {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 9px;
   padding: 14px 8px 0;
   border-top: 1px solid var(--line-soft);
   margin-top: 12px;
+}
+
+.side-foot-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
 }
 
 .netdot {
@@ -964,6 +1005,7 @@ th {
 
 .stage {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -986,6 +1028,14 @@ th {
 
 .onboard-top {
   margin-bottom: 4vh;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.onboard-top .brand {
+  padding-bottom: 0;
 }
 
 .onboard-grid {
@@ -1297,10 +1347,79 @@ th {
 @media (max-width: 900px) {
   .shell {
     grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
   }
 
-  .sidebar {
+  .mobilebar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line-soft);
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  .mobilebar .brand {
+    padding: 0;
+  }
+
+  .mobilebar .brand-name {
+    white-space: nowrap;
+    font-size: 0.95rem;
+  }
+
+  .mobilebar .brand-tag {
     display: none;
+  }
+
+  /* The sidebar becomes a drawer over the content. */
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(312px, 85vw);
+    z-index: 60;
+    background: #0a0a0c;
+    border-right: 1px solid var(--line);
+    transform: translateX(-105%);
+    transition: transform 0.22s ease-out;
+  }
+
+  .sidebar-open {
+    transform: none;
+    box-shadow: 24px 0 60px rgba(0, 0, 0, 0.6);
+  }
+
+  .content {
+    padding: 18px 16px 20px;
+  }
+
+  .topbar {
+    padding: 12px 16px;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .stage-onboard {
+    padding: 16px 18px 0;
+  }
+
+  .view-head {
+    gap: 12px;
+  }
+
+  .view-num {
+    min-width: 40px;
+    font-size: 1.8rem;
+  }
+
+  .provedock {
+    margin: 0 10px 8px;
+  }
+
+  .activity-body {
+    max-height: 108px;
   }
 }
 

--- a/experiments/account-custody-prototype/app/src/styles.css
+++ b/experiments/account-custody-prototype/app/src/styles.css
@@ -1,0 +1,1310 @@
+/* Midnight Passport demo — IOG dark-first identity.
+   Black canvas, Enlightenment gradient atmosphere, schematic linework.
+   Barlow (body/headlines), Bricolage Grotesque (display numerals),
+   JetBrains Mono (hashes). */
+
+:root {
+  /* primary */
+  --infared: #e52321;
+  --dawn: #ec641d;
+  --black: #000000;
+  --white: #ffffff;
+  /* secondary (functional roles only) */
+  --acid: #06ff89;
+  --electric: #16e9d8;
+  --amber: #ffba36;
+  /* surfaces */
+  --panel: rgba(255, 255, 255, 0.025);
+  --panel-solid: #0c0c0f;
+  --line: #232329;
+  --line-soft: #18181d;
+  --text: #ffffff;
+  --muted: #8f8f9a;
+  --dim: #5c5c66;
+  /* type */
+  --font-body: 'Barlow', 'Bricolage Grotesque', sans-serif;
+  --font-disp: 'Bricolage Grotesque', 'Barlow', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--black);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ——— atmosphere: Enlightenment gradient + schematic grid ——— */
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(1100px 700px at -8% 112%, rgba(232, 128, 4, 0.18), transparent 62%),
+    radial-gradient(1300px 850px at -4% 118%, rgba(174, 20, 15, 0.26), transparent 66%),
+    radial-gradient(900px 600px at 108% -12%, rgba(174, 20, 15, 0.10), transparent 60%);
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: radial-gradient(120% 90% at 20% 100%, black 0%, transparent 75%);
+  -webkit-mask-image: radial-gradient(120% 90% at 20% 100%, black 0%, transparent 75%);
+}
+
+/* ——— type hierarchy ——— */
+
+.eyebrow {
+  font-family: var(--font-body);
+  font-weight: 300;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--dawn);
+  margin: 0;
+}
+
+.hero-title {
+  font-weight: 500;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  margin: 12px 0 16px;
+}
+
+.lede {
+  color: var(--muted);
+  font-weight: 300;
+  font-size: 1.06rem;
+  max-width: 46ch;
+  margin: 0 0 26px;
+}
+
+.view-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  margin: 4px 0 22px;
+}
+
+.view-num {
+  font-family: var(--font-disp);
+  font-weight: 700;
+  font-size: 2.4rem;
+  line-height: 1;
+  color: var(--infared);
+  opacity: 0.9;
+  min-width: 56px;
+  letter-spacing: -0.04em;
+}
+
+.view-title {
+  font-weight: 500;
+  font-size: 1.55rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+  line-height: 1.15;
+}
+
+.view-narration {
+  color: var(--muted);
+  font-weight: 300;
+  max-width: 78ch;
+  margin: 0;
+}
+
+.hint,
+.dim {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 300;
+}
+
+.error {
+  color: var(--infared);
+  font-size: 0.9rem;
+}
+
+/* ——— shell layout ——— */
+
+.shell {
+  display: grid;
+  grid-template-columns: 272px 1fr;
+  height: 100vh;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100vh;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 26px 38px 28px;
+}
+
+.view {
+  max-width: 1020px;
+}
+
+.view-hidden {
+  display: none;
+}
+
+/* staggered reveal each time a view is shown */
+.view > * {
+  animation: rise 0.5s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.view > *:nth-child(2) {
+  animation-delay: 0.06s;
+}
+
+.view > *:nth-child(3) {
+  animation-delay: 0.12s;
+}
+
+.view > *:nth-child(4) {
+  animation-delay: 0.18s;
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ——— sidebar ——— */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--line-soft);
+  padding: 24px 18px 18px;
+  background: rgba(0, 0, 0, 0.45);
+  overflow-y: auto;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 2px 8px 22px;
+}
+
+.brand-glyph {
+  width: 34px;
+  height: 34px;
+  flex: none;
+}
+
+.brand-glyph rect {
+  fill: none;
+  stroke: var(--infared);
+  stroke-width: 2;
+}
+
+.brand-glyph .brand-moon {
+  fill: var(--infared);
+}
+
+.brand-words {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand-name {
+  display: block;
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: 1.02rem;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+
+.brand-tag {
+  display: block;
+  font-weight: 300;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+.brand-large {
+  flex-direction: column;
+  text-align: center;
+  padding: 0 0 26px;
+}
+
+.brand-large .brand-glyph {
+  width: 52px;
+  height: 52px;
+}
+
+.sidenav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.nav-label {
+  font-weight: 300;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--dim);
+  margin: 18px 8px 6px;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 30px 1fr 16px;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 9px 10px;
+  cursor: pointer;
+  color: var(--muted);
+  font-family: inherit;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.step:hover {
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text);
+}
+
+.step-active {
+  background: rgba(229, 35, 33, 0.09);
+  border-color: rgba(229, 35, 33, 0.4);
+  color: var(--text);
+}
+
+.step-num {
+  font-family: var(--font-disp);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--dim);
+  letter-spacing: -0.02em;
+}
+
+.step-active .step-num {
+  color: var(--infared);
+}
+
+.step-words {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.step-title {
+  font-weight: 500;
+  font-size: 0.92rem;
+  line-height: 1.2;
+}
+
+.step-sub {
+  font-weight: 300;
+  font-size: 0.72rem;
+  color: var(--dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.step-check {
+  color: var(--acid);
+  font-size: 0.85rem;
+}
+
+.step-done .step-num {
+  color: var(--acid);
+}
+
+.side-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 8px 0;
+  border-top: 1px solid var(--line-soft);
+  margin-top: 12px;
+}
+
+.netdot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--acid);
+  box-shadow: 0 0 8px rgba(6, 255, 137, 0.6);
+  animation: breathe 2.4s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+.side-net {
+  font-size: 0.76rem;
+  font-weight: 300;
+  color: var(--muted);
+  flex: 1;
+}
+
+.side-round {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ——— top bar ——— */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px 38px;
+  border-bottom: 1px solid var(--line-soft);
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.topbar-id {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  min-width: 0;
+}
+
+.topbar-stats {
+  display: flex;
+  gap: 26px;
+}
+
+.topstat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.topstat-k {
+  font-weight: 300;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--dim);
+}
+
+.topstat-v {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  font-size: 1.02rem;
+  animation: statpop 0.9s ease-out;
+}
+
+@keyframes statpop {
+  from {
+    color: var(--dawn);
+  }
+}
+
+/* ——— panels ——— */
+
+.panel {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 20px 22px;
+  margin: 0 0 18px;
+}
+
+.panel-head {
+  margin-bottom: 14px;
+}
+
+.panel-sub {
+  color: var(--muted);
+  font-weight: 300;
+  font-size: 0.86rem;
+  margin: 6px 0 0;
+  max-width: 80ch;
+}
+
+.panel-dapp {
+  border-color: rgba(22, 233, 216, 0.35);
+  background: linear-gradient(180deg, rgba(22, 233, 216, 0.05), rgba(255, 255, 255, 0.01));
+}
+
+.panel-dapp > .panel-head .eyebrow {
+  color: var(--electric);
+}
+
+.panel-scaffold {
+  border-style: dashed;
+  border-color: var(--line);
+  background: none;
+}
+
+.panel-scaffold > .panel-head .eyebrow {
+  color: var(--dim);
+}
+
+/* ——— forms & buttons ——— */
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 10px 0;
+  flex-wrap: wrap;
+}
+
+.controls {
+  margin-top: 14px;
+}
+
+.ctrl-gap {
+  width: 14px;
+}
+
+.grow {
+  flex: 1;
+  min-width: 160px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 10px 0;
+}
+
+.field-inline {
+  margin: 0;
+}
+
+.field-label {
+  font-weight: 300;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+input {
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 9px 11px;
+  font-family: inherit;
+  font-size: 0.92rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--dawn);
+  box-shadow: 0 0 0 3px rgba(236, 100, 29, 0.15);
+}
+
+input[type='checkbox'] {
+  accent-color: var(--infared);
+  width: 15px;
+  height: 15px;
+  padding: 0;
+}
+
+.devmode-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 14px;
+  font-weight: 300;
+  font-size: 0.82rem;
+  color: var(--dim);
+  cursor: pointer;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: 9px 18px;
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: background 0.15s, box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.btn-primary {
+  background: var(--infared);
+  color: var(--white);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #f53330;
+  box-shadow: 0 4px 28px rgba(229, 35, 33, 0.35);
+  transform: translateY(-1px);
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--text);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  border-color: var(--muted);
+}
+
+.btn-danger {
+  background: transparent;
+  border-color: rgba(229, 35, 33, 0.55);
+  color: var(--infared);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: rgba(229, 35, 33, 0.1);
+}
+
+.btn-block {
+  width: 100%;
+  padding: 12px 18px;
+  font-size: 1rem;
+  margin-top: 6px;
+}
+
+button.linkish {
+  background: none;
+  border: none;
+  color: var(--dim);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  padding: 0 6px;
+  font-family: inherit;
+  font-weight: 300;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+button.linkish:hover {
+  color: var(--muted);
+}
+
+/* ——— tables ——— */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 4px 0;
+}
+
+td,
+th {
+  border-bottom: 1px solid var(--line-soft);
+  padding: 9px 10px;
+  text-align: left;
+  font-weight: 400;
+  vertical-align: middle;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+th {
+  color: var(--dim);
+  font-size: 0.68rem;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.num-big {
+  font-size: 1.15rem;
+  font-weight: 500;
+}
+
+.row-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.row-actions input {
+  width: 76px;
+  margin-right: 8px;
+}
+
+.stale {
+  opacity: 0.5;
+}
+
+.cell-capbar {
+  min-width: 190px;
+}
+
+/* ——— atoms ——— */
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--line-soft);
+  padding: 3px 7px;
+  border-radius: 6px;
+  cursor: copy;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.mono:hover {
+  border-color: var(--dawn);
+}
+
+.mono.copied {
+  color: var(--acid);
+  border-color: rgba(6, 255, 137, 0.4);
+}
+
+.addr-hero {
+  display: inline-block;
+  font-size: 0.92rem;
+  padding: 9px 13px;
+  margin-bottom: 16px;
+  word-break: break-all;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.66rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid;
+  white-space: nowrap;
+}
+
+.chip-ok {
+  color: var(--acid);
+  border-color: rgba(6, 255, 137, 0.4);
+  background: rgba(6, 255, 137, 0.07);
+}
+
+.chip-danger {
+  color: var(--infared);
+  border-color: rgba(229, 35, 33, 0.5);
+  background: rgba(229, 35, 33, 0.08);
+}
+
+.chip-warn {
+  color: var(--amber);
+  border-color: rgba(255, 186, 54, 0.45);
+  background: rgba(255, 186, 54, 0.07);
+}
+
+.chip-info {
+  color: var(--electric);
+  border-color: rgba(22, 233, 216, 0.4);
+  background: rgba(22, 233, 216, 0.07);
+}
+
+.chip-muted {
+  color: var(--muted);
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.stat-row {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.stat {
+  flex: 1;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.stat-k {
+  font-weight: 300;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--dim);
+}
+
+.stat-v {
+  font-family: var(--font-disp);
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  animation: statpop 0.9s ease-out;
+}
+
+.capbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.capbar-track {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+  min-width: 90px;
+}
+
+.capbar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--infared), var(--dawn));
+  transition: width 0.6s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.capbar-label {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.84rem;
+  white-space: nowrap;
+}
+
+.secret-callout {
+  margin-top: 14px;
+  border: 1px solid rgba(255, 186, 54, 0.4);
+  background: rgba(255, 186, 54, 0.05);
+  border-radius: 10px;
+  padding: 12px 14px;
+  word-break: break-all;
+}
+
+.secret-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.caveat {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 16px;
+  border-left: 3px solid var(--amber);
+  background: rgba(255, 186, 54, 0.06);
+  border-radius: 0 10px 10px 0;
+  padding: 10px 14px;
+}
+
+.caveat p {
+  margin: 0;
+  font-size: 0.86rem;
+  font-weight: 300;
+  color: var(--muted);
+  max-width: 75ch;
+}
+
+.caveat .chip {
+  margin-top: 2px;
+  flex: none;
+}
+
+.note-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0 0;
+  flex-wrap: wrap;
+}
+
+.explain-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.explain p {
+  margin: 8px 0 0;
+  font-size: 0.86rem;
+  font-weight: 300;
+  color: var(--muted);
+}
+
+.next-cue {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ——— recovery shares ——— */
+
+.share-row {
+  display: flex;
+  gap: 14px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.share-slot {
+  width: 108px;
+  border: 1px dashed var(--line);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  color: var(--dim);
+}
+
+.share-live {
+  border-style: solid;
+  border-color: rgba(236, 100, 29, 0.5);
+  background: rgba(236, 100, 29, 0.06);
+  color: var(--text);
+}
+
+.share-n {
+  font-family: var(--font-disp);
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: var(--dawn);
+}
+
+.share-slot:not(.share-live) .share-n {
+  color: var(--dim);
+}
+
+.share-k {
+  font-weight: 300;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.share-v {
+  font-size: 0.78rem;
+}
+
+.share-meta {
+  display: flex;
+  gap: 14px;
+  flex: 1;
+  min-width: 220px;
+}
+
+/* ——— onboarding stage ——— */
+
+.stage {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.stage-center {
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.boot-card {
+  max-width: 560px;
+  text-align: center;
+  padding: 18px 24px;
+}
+
+.stage-onboard {
+  padding: 26px 48px 0;
+}
+
+.onboard-top {
+  margin-bottom: 4vh;
+}
+
+.onboard-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(380px, 1.1fr) minmax(360px, 1fr);
+  gap: 56px;
+  align-items: center;
+  max-width: 1180px;
+  margin: 0 auto;
+  width: 100%;
+  padding-bottom: 26px;
+}
+
+.onboard-grid-narrow {
+  grid-template-columns: minmax(380px, 1.1fr) minmax(320px, 0.8fr);
+}
+
+.hero-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 52ch;
+}
+
+.hero-steps li {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  color: var(--muted);
+  font-weight: 300;
+  font-size: 0.92rem;
+}
+
+.hero-step-n {
+  font-family: var(--font-disp);
+  font-weight: 700;
+  color: var(--infared);
+  border: 1px solid rgba(229, 35, 33, 0.45);
+  border-radius: 8px;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  font-size: 0.82rem;
+}
+
+.onboard-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.onboard-card {
+  margin: 0;
+  animation: rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.onboard-card-secondary {
+  animation-delay: 0.08s;
+}
+
+.onboard-copy {
+  animation: rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+/* ——— docks ——— */
+
+.dock-stack {
+  flex: none;
+}
+
+.provedock {
+  margin: 0 22px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(229, 35, 33, 0.45);
+  background: linear-gradient(180deg, rgba(229, 35, 33, 0.10), rgba(0, 0, 0, 0.7));
+  position: relative;
+  overflow: hidden;
+  padding: 10px 16px;
+  animation: rise 0.3s ease-out both;
+}
+
+.provedock-done {
+  border-color: rgba(6, 255, 137, 0.4);
+  background: linear-gradient(180deg, rgba(6, 255, 137, 0.07), rgba(0, 0, 0, 0.7));
+}
+
+.provedock-error {
+  border-color: rgba(229, 35, 33, 0.7);
+  background: linear-gradient(180deg, rgba(229, 35, 33, 0.14), rgba(0, 0, 0, 0.7));
+}
+
+.provedock-scan {
+  position: absolute;
+  top: 0;
+  left: -40%;
+  height: 2px;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, var(--infared), transparent);
+  animation: scan 1.8s linear infinite;
+}
+
+@keyframes scan {
+  to {
+    left: 100%;
+  }
+}
+
+.provedock-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.provedock-pulse {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--infared);
+  box-shadow: 0 0 10px rgba(229, 35, 33, 0.8);
+  animation: breathe 1.1s ease-in-out infinite;
+  flex: none;
+}
+
+.provedock-label {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.provedock-circuit {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--dawn);
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 6px;
+  padding: 2px 7px;
+}
+
+.provedock-spacer {
+  flex: 1;
+}
+
+.provedock-phases {
+  display: flex;
+  gap: 16px;
+}
+
+.phase {
+  font-weight: 300;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+.phase-done {
+  color: var(--acid);
+}
+
+.phase-live {
+  color: var(--white);
+  animation: breathe 1.4s ease-in-out infinite;
+}
+
+.provedock-elapsed {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.84rem;
+  color: var(--muted);
+  min-width: 48px;
+  text-align: right;
+}
+
+.provedock-detail {
+  margin: 6px 0 0 21px;
+  font-weight: 300;
+  font-size: 0.78rem;
+  color: var(--dim);
+}
+
+.provedock-msg {
+  color: var(--infared);
+  font-size: 0.84rem;
+  max-width: 60ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.provedock-txk {
+  font-weight: 300;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+.activity {
+  border-top: 1px solid var(--line-soft);
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.activity-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-family: inherit;
+  padding: 7px 22px;
+  cursor: pointer;
+}
+
+.activity-head .eyebrow {
+  color: var(--dim);
+}
+
+.activity-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.72rem;
+  color: var(--dim);
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  padding: 0 8px;
+}
+
+.activity-toggle {
+  margin-left: auto;
+  color: var(--dim);
+  font-size: 0.72rem;
+}
+
+.activity-body {
+  max-height: 132px;
+  overflow-y: auto;
+  padding: 0 22px 10px;
+}
+
+.activity-line {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+  padding: 1.5px 0;
+  word-break: break-all;
+}
+
+.activity-line .mono {
+  font-size: 0.68rem;
+  padding: 1px 5px;
+}
+
+/* ——— spinners ——— */
+
+.busy {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--line);
+  border-top-color: var(--infared);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+  flex: none;
+}
+
+.spinner-btn {
+  width: 11px;
+  height: 11px;
+  border-color: rgba(255, 255, 255, 0.35);
+  border-top-color: var(--white);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ——— responsive ——— */
+
+@media (max-width: 1080px) {
+  .onboard-grid,
+  .onboard-grid-narrow {
+    grid-template-columns: 1fr;
+    gap: 28px;
+    align-items: start;
+  }
+
+  .explain-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+}

--- a/experiments/account-custody-prototype/app/src/ui.tsx
+++ b/experiments/account-custody-prototype/app/src/ui.tsx
@@ -45,11 +45,35 @@ export function Busy(props: { label: string }) {
   );
 }
 
-/** Copyable hash / address. */
-export function Mono(props: { v: string; short?: boolean; className?: string }) {
+/** Label-over-value document field, passport-data-page style. */
+export function Field(props: {
+  k: string;
+  v: React.ReactNode;
+  big?: boolean;
+  wide?: boolean;
+}) {
+  return (
+    <div className={`docfield ${props.wide ? 'docfield-wide' : ''}`}>
+      <span className="docfield-k">{props.k}</span>
+      <span className={`docfield-v ${props.big ? 'docfield-big' : ''}`}>{props.v}</span>
+    </div>
+  );
+}
+
+const group4 = (s: string) => s.replace(/(....)/g, '$1 ').trim().toUpperCase();
+
+/** Copyable hash / address. `group` renders document-number spacing. */
+export function Mono(props: { v: string; short?: boolean; group?: boolean; className?: string }) {
   const [copied, setCopied] = useState(false);
-  const text =
-    props.short && props.v.length > 24 ? `${props.v.slice(0, 12)}…${props.v.slice(-8)}` : props.v;
+  let text: string;
+  if (props.group && props.short && props.v.length > 28) {
+    text = `${group4(props.v.slice(0, 16))} … ${group4(props.v.slice(-8))}`;
+  } else if (props.short && props.v.length > 24) {
+    text = `${props.v.slice(0, 12)}…${props.v.slice(-8)}`;
+  } else {
+    text = props.v;
+  }
+  if (props.group && !(props.short && props.v.length > 28)) text = group4(text);
   return (
     <code
       className={`mono ${copied ? 'copied' : ''} ${props.className ?? ''}`}
@@ -68,8 +92,18 @@ export function Mono(props: { v: string; short?: boolean; className?: string }) 
 export function Chip(props: {
   tone: 'ok' | 'muted' | 'danger' | 'warn' | 'info';
   children: React.ReactNode;
+  /** Rubber-stamp rendering for document status (tilted when danger). */
+  stamp?: boolean;
 }) {
-  return <span className={`chip chip-${props.tone}`}>{props.children}</span>;
+  return (
+    <span
+      className={`chip chip-${props.tone} ${props.stamp ? 'chip-stamp' : ''} ${
+        props.stamp && props.tone === 'danger' ? 'chip-tilt' : ''
+      }`}
+    >
+      {props.children}
+    </span>
+  );
 }
 
 export function StatTile(props: { label: string; value: string }) {

--- a/experiments/account-custody-prototype/app/src/ui.tsx
+++ b/experiments/account-custody-prototype/app/src/ui.tsx
@@ -1,0 +1,148 @@
+// Shared UI atoms for the demo shell.
+
+import React, { useState } from 'react';
+
+import { beginTask, completeTask, failTask } from './lib/txTracker.js';
+
+/** Card with brand "page furniture" header. */
+export function Panel(props: {
+  title: string;
+  sub?: string;
+  children: React.ReactNode;
+  tone?: 'default' | 'dapp' | 'scaffold';
+  className?: string;
+}) {
+  const tone = props.tone ?? 'default';
+  return (
+    <section className={`panel panel-${tone} ${props.className ?? ''}`}>
+      <header className="panel-head">
+        <h2 className="eyebrow">{props.title}</h2>
+        {props.sub && <p className="panel-sub">{props.sub}</p>}
+      </header>
+      {props.children}
+    </section>
+  );
+}
+
+/** Numbered view header — the presenter's beat. */
+export function ViewHeader(props: { numeral?: string; title: string; narration: string }) {
+  return (
+    <header className="view-head">
+      {props.numeral && <span className="view-num">{props.numeral}</span>}
+      <div>
+        <h1 className="view-title">{props.title}</h1>
+        <p className="view-narration">{props.narration}</p>
+      </div>
+    </header>
+  );
+}
+
+export function Busy(props: { label: string }) {
+  return (
+    <span className="busy">
+      <span className="spinner" /> {props.label}
+    </span>
+  );
+}
+
+/** Copyable hash / address. */
+export function Mono(props: { v: string; short?: boolean; className?: string }) {
+  const [copied, setCopied] = useState(false);
+  const text =
+    props.short && props.v.length > 24 ? `${props.v.slice(0, 12)}…${props.v.slice(-8)}` : props.v;
+  return (
+    <code
+      className={`mono ${copied ? 'copied' : ''} ${props.className ?? ''}`}
+      title={copied ? 'copied' : `${props.v} — click to copy`}
+      onClick={() => {
+        navigator.clipboard?.writeText(props.v);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      }}
+    >
+      {copied ? 'copied ✓' : text}
+    </code>
+  );
+}
+
+export function Chip(props: {
+  tone: 'ok' | 'muted' | 'danger' | 'warn' | 'info';
+  children: React.ReactNode;
+}) {
+  return <span className={`chip chip-${props.tone}`}>{props.children}</span>;
+}
+
+export function StatTile(props: { label: string; value: string }) {
+  return (
+    <div className="stat">
+      <span className="stat-k">{props.label}</span>
+      {/* keyed so a value change re-mounts and replays the pulse animation */}
+      <span className="stat-v" key={props.value}>
+        {props.value}
+      </span>
+    </div>
+  );
+}
+
+/** Spent-against-cap meter for grants. */
+export function CapBar(props: { spent: bigint; cap: bigint }) {
+  const pct = props.cap > 0n ? Math.min(100, Number((props.spent * 100n) / props.cap)) : 0;
+  return (
+    <div className="capbar" title={`${props.spent} of ${props.cap} spent`}>
+      <div className="capbar-track">
+        <div className="capbar-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="capbar-label">
+        {String(props.spent)} <span className="dim">/ {String(props.cap)}</span>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Async action button. When `task` is given the run is tracked in the
+ * proving dock (build → prove → submit); `onRun` may return the landed tx
+ * id so the dock can show it.
+ */
+export function ActionButton(props: {
+  label: string;
+  busyLabel?: string;
+  onRun: () => Promise<string | void>;
+  disabled?: boolean;
+  kind?: 'primary' | 'ghost' | 'danger';
+  block?: boolean;
+  task?: { label: string; circuit: string };
+  onError?: (message: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const kind = props.kind ?? 'primary';
+  return (
+    <button
+      className={`btn btn-${kind} ${props.block ? 'btn-block' : ''}`}
+      disabled={busy || props.disabled}
+      onClick={async () => {
+        setBusy(true);
+        if (props.task) beginTask(props.task.label, props.task.circuit);
+        try {
+          const txId = await props.onRun();
+          if (props.task) completeTask(typeof txId === 'string' ? txId : undefined);
+        } catch (e: any) {
+          const message = String(e?.message ?? e);
+          if (props.task) failTask(message);
+          props.onError?.(message);
+          console.error(`[passport] action failed: ${message}`, e);
+        } finally {
+          setBusy(false);
+        }
+      }}
+    >
+      {busy ? (
+        <>
+          <span className="spinner spinner-btn" /> {props.busyLabel ?? 'working…'}
+        </>
+      ) : (
+        props.label
+      )}
+    </button>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/ui.tsx
+++ b/experiments/account-custody-prototype/app/src/ui.tsx
@@ -4,18 +4,19 @@ import React, { useState } from 'react';
 
 import { beginTask, completeTask, failTask } from './lib/txTracker.js';
 
-/** Card with brand "page furniture" header. */
+/** Card with brand "page furniture" header. `x` adds a hover explainer. */
 export function Panel(props: {
   title: string;
   sub?: string;
   children: React.ReactNode;
   tone?: 'default' | 'dapp' | 'scaffold';
   className?: string;
+  x?: string;
 }) {
   const tone = props.tone ?? 'default';
   return (
     <section className={`panel panel-${tone} ${props.className ?? ''}`}>
-      <header className="panel-head">
+      <header className="panel-head" data-x={props.x}>
         <h2 className="eyebrow">{props.title}</h2>
         {props.sub && <p className="panel-sub">{props.sub}</p>}
       </header>
@@ -34,6 +35,16 @@ export function ViewHeader(props: { numeral?: string; title: string; narration: 
         <p className="view-narration">{props.narration}</p>
       </div>
     </header>
+  );
+}
+
+/** Hover-explainer wrapper: dashed-underlined when explain mode is on; the
+    global ExplainTip tooltip (App.tsx) renders the `x` text on hover. */
+export function X(props: { x: string; children: React.ReactNode }) {
+  return (
+    <span className="x" data-x={props.x}>
+      {props.children}
+    </span>
   );
 }
 

--- a/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
@@ -24,59 +24,46 @@ export function DevicesPanel({ ctx }: { ctx: AppContext }) {
         title="Registered devices"
         sub="Hash-preimage auth — the prototype stand-in for C5's JubJub Schnorr. Any active device is admin (1-of-n). Removing your own device locks this browser out."
       >
-        <table>
-          <thead>
-            <tr>
-              <th>commitment</th>
-              <th>epoch</th>
-              <th>status</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {active.map(([commitment, e]) => (
-              <tr key={String(commitment)}>
-                <td>
-                  <Mono v={commitment.toString(16)} short />
-                </td>
-                <td className="num">{String(e)}</td>
-                <td>
-                  <Chip tone="ok">active</Chip>{' '}
-                  {ctx.deviceCommitment === commitment.toString() && (
-                    <Chip tone="info">this device</Chip>
-                  )}
-                </td>
-                <td className="row-actions">
-                  <ActionButton
-                    label="remove"
-                    busyLabel="removing…"
-                    kind="danger"
-                    disabled={active.length <= 1}
-                    task={{ label: 'Removing the device', circuit: 'remove_device' }}
-                    onRun={async () => {
-                      const r = await account.removeDeviceByCommitment(commitment);
-                      log(`remove_device → tx ${r.txId}`);
-                      await ctx.refreshLedger();
-                      return r.txId;
-                    }}
-                  />
-                </td>
-              </tr>
-            ))}
-            {stale.map(([commitment, e]) => (
-              <tr key={String(commitment)} className="stale">
-                <td>
-                  <Mono v={commitment.toString(16)} short />
-                </td>
-                <td className="num">{String(e)}</td>
-                <td>
-                  <Chip tone="muted">revoked — epoch {String(e)}</Chip>
-                </td>
-                <td />
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="list">
+          {active.map(([commitment, e]) => (
+            <div className="listrow" key={String(commitment)}>
+              <div className="listrow-id">
+                <span className="docfield-k">commitment · epoch {String(e)}</span>
+                <Mono v={commitment.toString(16)} short group />
+              </div>
+              <div className="listrow-side">
+                <Chip stamp tone="ok">active</Chip>
+                {ctx.deviceCommitment === commitment.toString() && (
+                  <Chip tone="info">this device</Chip>
+                )}
+                <ActionButton
+                  label="remove"
+                  busyLabel="removing…"
+                  kind="danger"
+                  disabled={active.length <= 1}
+                  task={{ label: 'Removing the device', circuit: 'remove_device' }}
+                  onRun={async () => {
+                    const r = await account.removeDeviceByCommitment(commitment);
+                    log(`remove_device → tx ${r.txId}`);
+                    await ctx.refreshLedger();
+                    return r.txId;
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+          {stale.map(([commitment, e]) => (
+            <div className="listrow stale" key={String(commitment)}>
+              <div className="listrow-id">
+                <span className="docfield-k">commitment · epoch {String(e)}</span>
+                <Mono v={commitment.toString(16)} short group />
+              </div>
+              <div className="listrow-side">
+                <Chip stamp tone="muted">revoked — epoch {String(e)}</Chip>
+              </div>
+            </div>
+          ))}
+        </div>
         <div className="row controls">
           <ActionButton
             label="Add device (new passkey)"

--- a/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+
+import { createPasskey, deriveDeviceSecret, deriveDevModeSecret } from '../lib/passkey.js';
+import { ViewHeader, Panel, ActionButton, Mono, Chip } from '../ui.js';
+import type { AppContext } from '../App.js';
+
+export function DevicesPanel({ ctx }: { ctx: AppContext }) {
+  const { ledger, account, log } = ctx;
+  const [devPassphrase, setDevPassphrase] = useState('');
+
+  const epoch = ledger?.device_epoch ?? 0n;
+  const devices = ledger ? [...ledger.devices] : [];
+  const active = devices.filter(([, e]) => e === epoch);
+  const stale = devices.filter(([, e]) => e !== epoch);
+
+  return (
+    <>
+      <ViewHeader
+        title="Devices"
+        narration="Each row is a device-secret commitment in public state, tagged with the epoch it was registered in. Only commitments at the current epoch authorise anything; recovery bumps the epoch and strands the rest."
+      />
+
+      <Panel
+        title="Registered devices"
+        sub="Hash-preimage auth — the prototype stand-in for C5's JubJub Schnorr. Any active device is admin (1-of-n). Removing your own device locks this browser out."
+      >
+        <table>
+          <thead>
+            <tr>
+              <th>commitment</th>
+              <th>epoch</th>
+              <th>status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {active.map(([commitment, e]) => (
+              <tr key={String(commitment)}>
+                <td>
+                  <Mono v={commitment.toString(16)} short />
+                </td>
+                <td className="num">{String(e)}</td>
+                <td>
+                  <Chip tone="ok">active</Chip>{' '}
+                  {ctx.deviceCommitment === commitment.toString() && (
+                    <Chip tone="info">this device</Chip>
+                  )}
+                </td>
+                <td className="row-actions">
+                  <ActionButton
+                    label="remove"
+                    busyLabel="removing…"
+                    kind="danger"
+                    disabled={active.length <= 1}
+                    task={{ label: 'Removing the device', circuit: 'remove_device' }}
+                    onRun={async () => {
+                      const r = await account.removeDeviceByCommitment(commitment);
+                      log(`remove_device → tx ${r.txId}`);
+                      await ctx.refreshLedger();
+                      return r.txId;
+                    }}
+                  />
+                </td>
+              </tr>
+            ))}
+            {stale.map(([commitment, e]) => (
+              <tr key={String(commitment)} className="stale">
+                <td>
+                  <Mono v={commitment.toString(16)} short />
+                </td>
+                <td className="num">{String(e)}</td>
+                <td>
+                  <Chip tone="muted">revoked — epoch {String(e)}</Chip>
+                </td>
+                <td />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="row controls">
+          <ActionButton
+            label="Add device (new passkey)"
+            busyLabel="adding…"
+            task={{ label: 'Registering a new device', circuit: 'add_device' }}
+            onRun={async () => {
+              const ref = await createPasskey(`device-${Date.now() % 10_000}`);
+              const secret = await deriveDeviceSecret(ref);
+              const r = await account.addDevice(secret);
+              log(`add_device (passkey ${ref.label}) → tx ${r.txId}`);
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+          <span className="ctrl-gap" />
+          <label className="field field-inline">
+            <span className="field-label">or dev-mode passphrase</span>
+            <input
+              type="password"
+              value={devPassphrase}
+              onChange={(e) => setDevPassphrase(e.target.value)}
+              size={14}
+            />
+          </label>
+          <ActionButton
+            label="Add (dev mode)"
+            busyLabel="adding…"
+            kind="ghost"
+            disabled={!devPassphrase}
+            task={{ label: 'Registering a new device', circuit: 'add_device' }}
+            onRun={async () => {
+              const secret = await deriveDevModeSecret(devPassphrase);
+              const r = await account.addDevice(secret);
+              log(`add_device (dev mode) → tx ${r.txId}`);
+              setDevPassphrase('');
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+        </div>
+      </Panel>
+    </>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/DevicesPanel.tsx
@@ -23,6 +23,7 @@ export function DevicesPanel({ ctx }: { ctx: AppContext }) {
       <Panel
         title="Registered devices"
         sub="Hash-preimage auth — the prototype stand-in for C5's JubJub Schnorr. Any active device is admin (1-of-n). Removing your own device locks this browser out."
+        x="Each row is a device-secret commitment in public ledger state, tagged with its enrolment epoch. Only commitments at the current epoch authorise anything; recovery bumps the epoch and strands the rest (P3, P4)."
       >
         <div className="list">
           {active.map(([commitment, e]) => (
@@ -34,7 +35,9 @@ export function DevicesPanel({ ctx }: { ctx: AppContext }) {
               <div className="listrow-side">
                 <Chip stamp tone="ok">active</Chip>
                 {ctx.deviceCommitment === commitment.toString() && (
-                  <Chip tone="info">this device</Chip>
+                  <span data-x="This browser's device commitment — re-derived from your passkey via PRF moments ago and matched against the on-chain registry. The secret itself never left the device (P1, P6).">
+                    <Chip tone="info">this device</Chip>
+                  </span>
                 )}
                 <ActionButton
                   label="remove"

--- a/experiments/account-custody-prototype/app/src/views/FlowDiagram.tsx
+++ b/experiments/account-custody-prototype/app/src/views/FlowDiagram.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+
+import { Panel, Mono } from '../ui.js';
+import { useTxTask } from '../lib/txTracker.js';
+import { BROWSER_PROVER } from '../lib/providers.js';
+import type { AppContext } from '../App.js';
+
+/**
+ * Live architecture map: bearer → (biometrics) → device → (zk proof) →
+ * account-custody contract on chain. The prover box sits inside the device
+ * and lights up during the real prove phase (txTracker), so the audience
+ * sees the cryptographic work happening on their machine.
+ */
+export function FlowDiagram({ ctx }: { ctx: AppContext }) {
+  const { session, ledger } = ctx;
+  const task = useTxTask();
+  const phase = task && task.phase !== 'error' ? task.phase : null;
+  const deviceLive = phase === 'build' || phase === 'prove';
+  const holder = session.devMode ? 'bearer' : (session.passkey?.label ?? 'bearer');
+  const epoch = ledger?.device_epoch ?? 0n;
+  const deviceCount = ledger
+    ? [...ledger.devices].filter(([, e]) => e === epoch).length
+    : 0;
+  const grantCount = ledger
+    ? [...ledger.grants].filter(([, g]) => g.active && g.epoch === epoch).length
+    : 0;
+  const others = Math.max(0, deviceCount - 1);
+
+  return (
+    <Panel
+      title="How this account works"
+      sub="A live map of the custody model — it animates whenever this tab acts on the contract."
+      x="The whole model in one picture: your biometrics unlock a passkey on the device, the device proves its authority in zero knowledge, and the contract on chain enforces the rules. No server anywhere in the path (P8)."
+    >
+      <div className="flow">
+        {/* the bearer */}
+        <div
+          className="flow-node flow-user"
+          data-x="You — the bearer. Your face or fingerprint never leaves the device's secure hardware; it only unlocks the passkey. There is no username, no password, and no seed phrase (P1)."
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <circle cx="12" cy="8" r="3.6" />
+            <path d="M5 20c.8-4 3.5-6 7-6s6.2 2 7 6" />
+          </svg>
+          <b>{holder}</b>
+          <span className="flow-dim">the bearer</span>
+        </div>
+
+        {/* biometrics arrow */}
+        <div
+          className={`flow-link ${deviceLive ? 'flow-flowing' : ''}`}
+          data-x="WebAuthn user verification: the biometric gesture unlocks the passkey, and the passkey's PRF output becomes the 32-byte device secret — re-derived on every visit, never written down, never uploaded (P1)."
+        >
+          <span className="flow-link-label">biometrics</span>
+          <span className="flow-link-line" />
+          <span className="flow-link-sub">Face ID · Touch ID unlocks the passkey</span>
+        </div>
+
+        {/* the device, with the prover inside */}
+        <div
+          className={`flow-node flow-device ${deviceLive ? 'flow-on' : ''}`}
+          data-x="Your device — a first-class peer, not a 'main device' (P3). It stores nothing durable: the passkey re-derives the device secret when needed, and the secret never crosses the network boundary (P6)."
+        >
+          <div className="flow-node-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <rect x="3" y="5" width="13" height="9" rx="1.8" />
+              <path d="M6.5 18h6M9.5 14v4" />
+              <rect x="17" y="9" width="4.5" height="9" rx="1.4" />
+            </svg>
+            this device
+            {others > 0 && (
+              <span
+                className="flow-more"
+                data-x="Other devices enrolled at the current epoch. Each is an equal peer: any of them can act, enrol another, or revoke one (P3, P4)."
+              >
+                +{others} peer{others > 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+          <div
+            className="flow-inner"
+            data-x="The ledger stores only a commitment to the device secret. Every authorised call proves knowledge of the preimage in zero knowledge — the secret itself is the witness and stays here."
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <circle cx="8.5" cy="11" r="4.5" />
+              <path d="M12.5 12.5L20 20m-3-1l2-2m-5-1l2-2" />
+            </svg>
+            passkey → device secret
+          </div>
+          <div
+            className={`flow-prover ${phase === 'prove' ? 'flow-proving' : ''}`}
+            data-x={
+              BROWSER_PROVER
+                ? 'The zero-knowledge prover runs in this tab (wasm). When it lights up, your machine is doing the real cryptographic work — the witness (your secret) never leaves it. Nothing to intercept, no server to trust (P6).'
+                : 'Server mode (?prover=server): proofs go to the local Docker proof server. The default is on-device proving in this tab.'
+            }
+          >
+            {phase === 'prove' && <span className="flow-scan" />}
+            <span className="flow-prover-dot" />
+            <span className="flow-prover-words">
+              <b>zk prover</b>
+              <span>{BROWSER_PROVER ? 'in this browser' : 'local proof server'}</span>
+            </span>
+            <span className="flow-prover-state">
+              {phase === 'prove' ? 'proving…' : phase === 'build' ? 'preparing' : 'idle'}
+            </span>
+          </div>
+          <p className="flow-foot">the secret never leaves this device</p>
+        </div>
+
+        {/* authorisation arrow */}
+        <div
+          className={`flow-link ${phase === 'submit' ? 'flow-flowing' : ''}`}
+          data-x="The only thing that travels: a transaction carrying a zero-knowledge proof. No key, no secret, no biometric is in it — anyone can verify the proof, no one can learn the witness from it (P6)."
+        >
+          <span className="flow-link-label">authorises</span>
+          <span className="flow-link-line" />
+          <span className="flow-link-sub">zero-knowledge proof → transaction</span>
+        </div>
+
+        {/* the chain */}
+        <div
+          className={`flow-node flow-chain ${phase === 'done' ? 'flow-landed' : ''}`}
+          data-x="Only the Midnight chain is required to operate this account. Indexers and helpers are replaceable; no named operator sits on any critical path (P8)."
+        >
+          <div className="flow-node-head">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <circle cx="12" cy="12" r="9" />
+              <path d="M3.5 9h17M3.5 15h17M12 3c2.7 2.6 2.7 15.4 0 18M12 3c-2.7 2.6-2.7 15.4 0 18" />
+            </svg>
+            Midnight ledger
+          </div>
+          <div
+            className="flow-contract"
+            data-x="Your account-custody contract. It holds the assets and enforces in-circuit who may move them — device commitments, grant scopes, caps, and epochs. The rules are code on chain, not policy on a server (P7, P8)."
+          >
+            <b>account-custody contract</b>
+            <Mono v={session.accountAddress} short />
+            <span className="flow-stats">
+              epoch {String(epoch)} · {deviceCount} device{deviceCount === 1 ? '' : 's'} ·{' '}
+              {grantCount} grant{grantCount === 1 ? '' : 's'}
+            </span>
+          </div>
+          <p className="flow-foot">
+            {phase === 'done' ? 'transaction landed ✓' : 'verifies the proof — rejects anything else'}
+          </p>
+        </div>
+      </div>
+      <p className="dim flow-hint">
+        Run any action — a deposit, a grant, a revocation — then watch this map: the prover lights
+        up on your machine, and only the finished proof travels to the chain.
+      </p>
+    </Panel>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+
+import { hexToBytes, bytesToHex, randomBytes32 } from '../../../src/wallet/hex.js';
+
+import { userAddressBytes } from '../lib/providers.js';
+import { ViewHeader, Panel, ActionButton, Mono, Chip, CapBar } from '../ui.js';
+import type { AppContext } from '../App.js';
+
+export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?: boolean }) {
+  const { ledger, account, mid, log, nightColor } = ctx;
+  const [cap, setCap] = useState('300');
+  const [issuedSecret, setIssuedSecret] = useState<string | null>(null);
+  const [dappSecret, setDappSecret] = useState('');
+  const [dappAmount, setDappAmount] = useState('50');
+
+  const epoch = ledger?.device_epoch ?? 0n;
+  const grants = ledger ? [...ledger.grants] : [];
+
+  return (
+    <>
+      <ViewHeader
+        numeral={revokeBeat ? '04' : '03'}
+        title={revokeBeat ? 'Revoke the grant' : 'Spend via a scoped grant'}
+        narration={
+          revokeBeat
+            ? 'One circuit call flips the grant inactive. The dApp still holds the secret — and it is now worthless. The contract, not the dApp, was always the enforcer.'
+            : 'Issue the dApp a credential scoped to operation × token colour × cumulative cap. Hand over the secret once; the contract enforces the boundary.'
+        }
+      />
+
+      <Panel
+        title="Grants on-chain"
+        sub="Live from the ledger: each grant's cumulative spend against its cap, and whether the contract still honours it."
+      >
+        <table>
+          <thead>
+            <tr>
+              <th>grant</th>
+              <th>spent / cap</th>
+              <th>status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {grants.length === 0 && (
+              <tr>
+                <td className="dim" colSpan={4}>
+                  no grants issued yet
+                </td>
+              </tr>
+            )}
+            {grants.map(([commitment, info]) => (
+              <tr key={String(commitment)}>
+                <td>
+                  <Mono v={commitment.toString(16)} short />
+                </td>
+                <td className="cell-capbar">
+                  <CapBar spent={info.spent} cap={info.cap} />
+                </td>
+                <td>
+                  {!info.active ? (
+                    <Chip tone="danger">revoked</Chip>
+                  ) : info.epoch !== epoch ? (
+                    <Chip tone="muted">stale epoch</Chip>
+                  ) : (
+                    <Chip tone="ok">active</Chip>
+                  )}
+                </td>
+                <td className="row-actions">
+                  {info.active && (
+                    <ActionButton
+                      label="revoke"
+                      busyLabel="revoking…"
+                      kind="danger"
+                      task={{ label: 'Revoking the grant', circuit: 'revoke_grant' }}
+                      onRun={async () => {
+                        const r = await account.revokeGrantByCommitment(commitment);
+                        log(`revoke_grant → tx ${r.txId}`);
+                        await ctx.refreshLedger();
+                        return r.txId;
+                      }}
+                    />
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="row controls">
+          <label className="field field-inline">
+            <span className="field-label">cap</span>
+            <input value={cap} onChange={(e) => setCap(e.target.value)} size={8} />
+          </label>
+          <ActionButton
+            label="Issue grant (Night, capped)"
+            busyLabel="issuing…"
+            task={{ label: 'Issuing a scoped grant', circuit: 'add_grant' }}
+            onRun={async () => {
+              const grantSecret = randomBytes32();
+              const r = await account.addGrant(grantSecret, nightColor, BigInt(cap));
+              setIssuedSecret(bytesToHex(grantSecret));
+              log(`add_grant cap=${cap} → tx ${r.txId}`);
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+        </div>
+        {issuedSecret && (
+          <div className="secret-callout">
+            <div className="secret-head">
+              <Chip tone="warn">grant secret — shown once</Chip>
+              <span className="dim">hand this to the dApp; it is the entire credential</span>
+            </div>
+            <Mono v={issuedSecret} />
+          </div>
+        )}
+      </Panel>
+
+      <Panel
+        title="The dApp's console"
+        sub="A separate connection holding only the grant secret — exactly what a dApp backend would hold. No device key, no recovery secret."
+        tone="dapp"
+      >
+        <div className="row controls">
+          <label className="field field-inline grow">
+            <span className="field-label">grant secret</span>
+            <input value={dappSecret} onChange={(e) => setDappSecret(e.target.value)} />
+          </label>
+          <input value={dappAmount} onChange={(e) => setDappAmount(e.target.value)} size={6} />
+          <ActionButton
+            label="Spend via grant"
+            busyLabel="spending…"
+            disabled={!dappSecret}
+            task={{ label: 'dApp spending through the grant', circuit: 'grant_withdraw_night' }}
+            onRun={async () => {
+              // A separate connection holding ONLY the grant secret — exactly
+              // what a dApp backend would hold.
+              const dapp = await ctx.reconnect({ grantSecret: hexToBytes(dappSecret.trim()) });
+              const r = await dapp.grantWithdrawNight(
+                nightColor,
+                BigInt(dappAmount),
+                userAddressBytes(mid.walletCtx),
+              );
+              log(`grant_withdraw_night ${dappAmount} → tx ${r.txId}`);
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+        </div>
+        <p className="dim">
+          Spending over the cap, or after revocation, fails in the circuit — try it.
+        </p>
+      </Panel>
+    </>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
@@ -32,60 +32,44 @@ export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?:
         title="Grants on-chain"
         sub="Live from the ledger: each grant's cumulative spend against its cap, and whether the contract still honours it."
       >
-        <table>
-          <thead>
-            <tr>
-              <th>grant</th>
-              <th>spent / cap</th>
-              <th>status</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {grants.length === 0 && (
-              <tr>
-                <td className="dim" colSpan={4}>
-                  no grants issued yet
-                </td>
-              </tr>
-            )}
-            {grants.map(([commitment, info]) => (
-              <tr key={String(commitment)}>
-                <td>
-                  <Mono v={commitment.toString(16)} short />
-                </td>
-                <td className="cell-capbar">
-                  <CapBar spent={info.spent} cap={info.cap} />
-                </td>
-                <td>
-                  {!info.active ? (
-                    <Chip tone="danger">revoked</Chip>
-                  ) : info.epoch !== epoch ? (
-                    <Chip tone="muted">stale epoch</Chip>
-                  ) : (
-                    <Chip tone="ok">active</Chip>
-                  )}
-                </td>
-                <td className="row-actions">
-                  {info.active && (
-                    <ActionButton
-                      label="revoke"
-                      busyLabel="revoking…"
-                      kind="danger"
-                      task={{ label: 'Revoking the grant', circuit: 'revoke_grant' }}
-                      onRun={async () => {
-                        const r = await account.revokeGrantByCommitment(commitment);
-                        log(`revoke_grant → tx ${r.txId}`);
-                        await ctx.refreshLedger();
-                        return r.txId;
-                      }}
-                    />
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="list">
+          {grants.length === 0 && <p className="dim">no grants issued yet</p>}
+          {grants.map(([commitment, info]) => (
+            <div className="listrow" key={String(commitment)}>
+              <div className="listrow-id">
+                <span className="docfield-k">credential</span>
+                <Mono v={commitment.toString(16)} short group />
+              </div>
+              <div className="listrow-meter">
+                <span className="docfield-k">spent / cap</span>
+                <CapBar spent={info.spent} cap={info.cap} />
+              </div>
+              <div className="listrow-side">
+                {!info.active ? (
+                  <Chip stamp tone="danger">revoked</Chip>
+                ) : info.epoch !== epoch ? (
+                  <Chip stamp tone="muted">stale epoch</Chip>
+                ) : (
+                  <Chip stamp tone="ok">active</Chip>
+                )}
+                {info.active && (
+                  <ActionButton
+                    label="revoke"
+                    busyLabel="revoking…"
+                    kind="danger"
+                    task={{ label: 'Revoking the grant', circuit: 'revoke_grant' }}
+                    onRun={async () => {
+                      const r = await account.revokeGrantByCommitment(commitment);
+                      log(`revoke_grant → tx ${r.txId}`);
+                      await ctx.refreshLedger();
+                      return r.txId;
+                    }}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
 
         <div className="row controls">
           <label className="field field-inline">

--- a/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/GrantsPanel.tsx
@@ -6,7 +6,7 @@ import { userAddressBytes } from '../lib/providers.js';
 import { ViewHeader, Panel, ActionButton, Mono, Chip, CapBar } from '../ui.js';
 import type { AppContext } from '../App.js';
 
-export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?: boolean }) {
+export function GrantsPanel({ ctx }: { ctx: AppContext }) {
   const { ledger, account, mid, log, nightColor } = ctx;
   const [cap, setCap] = useState('300');
   const [issuedSecret, setIssuedSecret] = useState<string | null>(null);
@@ -19,18 +19,14 @@ export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?:
   return (
     <>
       <ViewHeader
-        numeral={revokeBeat ? '04' : '03'}
-        title={revokeBeat ? 'Revoke the grant' : 'Spend via a scoped grant'}
-        narration={
-          revokeBeat
-            ? 'One circuit call flips the grant inactive. The dApp still holds the secret — and it is now worthless. The contract, not the dApp, was always the enforcer.'
-            : 'Issue the dApp a credential scoped to operation × token colour × cumulative cap. Hand over the secret once; the contract enforces the boundary.'
-        }
+        title="Connections"
+        narration="A connection is a scoped credential: one operation, one token colour, a cumulative cap. The dApp holds the secret; the contract — not the dApp — enforces the boundary, and revocation makes the secret worthless."
       />
 
       <Panel
         title="Grants on-chain"
         sub="Live from the ledger: each grant's cumulative spend against its cap, and whether the contract still honours it."
+        x="Each row is a scoped grant in public ledger state — operation × token colour × cumulative cap, enforced by the contract circuit at proof verification, not by the dApp's goodwill (P7). An OAuth scope the ledger itself checks."
       >
         <div className="list">
           {grants.length === 0 && <p className="dim">no grants issued yet</p>}
@@ -91,7 +87,10 @@ export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?:
           />
         </div>
         {issuedSecret && (
-          <div className="secret-callout">
+          <div
+            className="secret-callout"
+            data-x="The grant secret is the entire credential — hand it over once. The holder cannot widen its own scope (I-7.5), and on-chain revocation makes it worthless whatever the dApp still stores (I-7.6)."
+          >
             <div className="secret-head">
               <Chip tone="warn">grant secret — shown once</Chip>
               <span className="dim">hand this to the dApp; it is the entire credential</span>
@@ -105,6 +104,7 @@ export function GrantsPanel({ ctx, revokeBeat }: { ctx: AppContext; revokeBeat?:
         title="The dApp's console"
         sub="A separate connection holding only the grant secret — exactly what a dApp backend would hold. No device key, no recovery secret."
         tone="dapp"
+        x="The other side of the connection: a session holding ONLY the grant secret. Its witness structurally cannot produce device-authorised proofs — spending over the cap or after revocation fails in the circuit (C7, P7)."
       >
         <div className="row controls">
           <label className="field field-inline grow">

--- a/experiments/account-custody-prototype/app/src/views/Onboard.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Onboard.tsx
@@ -1,0 +1,232 @@
+import React, { useState } from 'react';
+
+import { PassportAccount } from '../../../src/wallet/account.js';
+import { deviceCommitment } from '../../../src/wallet/contract.js';
+import { randomBytes32 } from '../../../src/wallet/hex.js';
+
+import type { Midnight } from '../lib/midnight.js';
+import { compiledAccountContract } from '../lib/providers.js';
+import { createPasskey, deriveDeviceSecret, deriveDevModeSecret } from '../lib/passkey.js';
+import type { Session } from '../lib/session.js';
+import { ActionButton } from '../ui.js';
+
+export function OnboardView(props: {
+  mid: Midnight;
+  session: Session | null;
+  log: (m: string) => void;
+  onConnected: (s: Session, a: PassportAccount, commitment?: string) => void;
+  onReset: () => void;
+}) {
+  const { mid, session, log } = props;
+  const [label, setLabel] = useState('alice');
+  const [address, setAddress] = useState('');
+  const [devMode, setDevMode] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const deviceSecretForOnboarding = async (): Promise<{
+    secret: Uint8Array;
+    session: Omit<Session, 'accountAddress'>;
+  }> => {
+    if (devMode) {
+      if (!passphrase) throw new Error('enter a dev-mode passphrase');
+      log('dev mode: deriving device secret from passphrase (SHA-256)…');
+      return { secret: await deriveDevModeSecret(passphrase), session: { devMode: true } };
+    }
+    log('creating passkey…');
+    const ref = await createPasskey(label || 'passport-user');
+    log('passkey created — evaluating PRF for the device secret…');
+    const secret = await deriveDeviceSecret(ref);
+    log('device secret derived from WebAuthn PRF.');
+    return { secret, session: { passkey: ref } };
+  };
+
+  // Session exists but the page was reloaded: re-derive the device secret
+  // and reconnect — nothing secret survives a reload by design.
+  if (session) {
+    return (
+      <div className="onboard-grid onboard-grid-narrow">
+        <div className="onboard-copy">
+          <p className="eyebrow">Welcome back</p>
+          <h1 className="hero-title">Unlock your passport.</h1>
+          <p className="lede">
+            Account <code className="mono">{session.accountAddress.slice(0, 16)}…</code> — the
+            device secret is re-derived from your{' '}
+            {session.devMode ? 'dev-mode passphrase' : 'passkey'} on every visit. Nothing secret is
+            stored on this machine.
+          </p>
+        </div>
+        <div className="onboard-cards">
+          <div className="panel onboard-card">
+            {session.devMode && (
+              <label className="field">
+                <span className="field-label">passphrase</span>
+                <input
+                  type="password"
+                  value={passphrase}
+                  onChange={(e) => setPassphrase(e.target.value)}
+                />
+              </label>
+            )}
+            <ActionButton
+              label={session.devMode ? 'Unlock (dev mode)' : 'Unlock with passkey'}
+              busyLabel="unlocking…"
+              block
+              onError={setError}
+              onRun={async () => {
+                setError(null);
+                const secret = session.devMode
+                  ? await deriveDevModeSecret(passphrase)
+                  : await deriveDeviceSecret(session.passkey);
+                log('connecting to the account contract…');
+                const account = await PassportAccount.connect(
+                  mid.accountProviders,
+                  compiledAccountContract(),
+                  session.accountAddress,
+                  { deviceSecret: secret },
+                );
+                log(`connected to ${account.address}`);
+                props.onConnected(session, account, deviceCommitment(secret).toString());
+              }}
+            />
+            {error && <p className="error">{error}</p>}
+            <button className="linkish" onClick={props.onReset}>
+              forget this account
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="onboard-grid">
+      <div className="onboard-copy">
+        {/* Verbatim heading — the e2e harness waits for its uppercased text. */}
+        <p className="eyebrow">Create your passport</p>
+        <h1 className="hero-title">One passkey becomes an on-chain account.</h1>
+        <p className="lede">
+          No seed phrase. Your device's passkey derives the secret, and a personal Compact
+          contract on Midnight holds the assets and enforces who may move them.
+        </p>
+        <ol className="hero-steps">
+          <li>
+            <span className="hero-step-n">1</span>
+            <span>
+              A WebAuthn passkey is created; its PRF output becomes this device's secret —
+              biometric-gated, never written down.
+            </span>
+          </li>
+          <li>
+            <span className="hero-step-n">2</span>
+            <span>
+              A fresh recovery secret is split 2-of-3; the shares go on-chain (prototype
+              placeholder for PVSS).
+            </span>
+          </li>
+          <li>
+            <span className="hero-step-n">3</span>
+            <span>
+              Your account-custody contract deploys — devices, grants, and recovery are
+              enforced by the ledger, not by a server.
+            </span>
+          </li>
+        </ol>
+      </div>
+
+      <div className="onboard-cards">
+        <div className="panel onboard-card">
+          <h2 className="eyebrow">New account</h2>
+          <label className="field">
+            <span className="field-label">name</span>
+            <input value={label} onChange={(e) => setLabel(e.target.value)} placeholder="alice" />
+          </label>
+          {devMode && (
+            <label className="field">
+              <span className="field-label">passphrase</span>
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+              />
+            </label>
+          )}
+          <ActionButton
+            label={devMode ? 'Create account (dev mode)' : 'Create passkey & deploy account'}
+            busyLabel="deploying account contract…"
+            block
+            task={{ label: 'Deploying your account contract', circuit: 'deploy account' }}
+            onError={setError}
+            onRun={async () => {
+              setError(null);
+              const { secret, session: partial } = await deviceSecretForOnboarding();
+              const recoverySecret = randomBytes32();
+              log('deploying the account-custody contract…');
+              const account = await PassportAccount.deploy(
+                mid.accountProviders,
+                compiledAccountContract(),
+                { deviceSecret: secret, recoverySecret },
+              );
+              log(`account deployed @ ${account.address}`);
+              props.onConnected(
+                { accountAddress: account.address, ...partial },
+                account,
+                deviceCommitment(secret).toString(),
+              );
+            }}
+          />
+          {error && <p className="error">{error}</p>}
+          <label className="devmode-row">
+            <input
+              type="checkbox"
+              checked={devMode}
+              onChange={(e) => setDevMode(e.target.checked)}
+            />
+            dev mode — derive the device secret from a passphrase instead of a passkey
+          </label>
+        </div>
+
+        <div className="panel onboard-card onboard-card-secondary">
+          <h2 className="eyebrow">Connect to an existing account</h2>
+          <p className="panel-sub">
+            Paste an account contract address; the device secret comes from any resident passkey
+            for this origin{devMode ? ' (or the dev-mode passphrase above)' : ''}.
+          </p>
+          <div className="row">
+            <input
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="0200…"
+              className="grow"
+            />
+            <ActionButton
+              label="Connect"
+              busyLabel="connecting…"
+              kind="ghost"
+              disabled={!address}
+              onError={setError}
+              onRun={async () => {
+                setError(null);
+                const secret = devMode
+                  ? await deriveDevModeSecret(passphrase)
+                  : await deriveDeviceSecret();
+                const account = await PassportAccount.connect(
+                  mid.accountProviders,
+                  compiledAccountContract(),
+                  address.trim(),
+                  { deviceSecret: secret },
+                );
+                log(`connected to ${account.address}`);
+                props.onConnected(
+                  { accountAddress: address.trim(), devMode: devMode || undefined },
+                  account,
+                  deviceCommitment(secret).toString(),
+                );
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/Onboard.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Onboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { PassportAccount } from '../../../src/wallet/account.js';
 import { deviceCommitment } from '../../../src/wallet/contract.js';
@@ -8,7 +8,20 @@ import type { Midnight } from '../lib/midnight.js';
 import { compiledAccountContract } from '../lib/providers.js';
 import { createPasskey, deriveDeviceSecret, deriveDevModeSecret } from '../lib/passkey.js';
 import type { Session } from '../lib/session.js';
-import { ActionButton } from '../ui.js';
+import { ActionButton, Chip } from '../ui.js';
+
+/** Resolves to true iff a contract exists at `address` on the current chain.
+    Guards against connecting to a session from a reset localnet — that
+    connect would otherwise wait forever for indexer state that never comes. */
+async function contractExists(mid: Midnight, address: string): Promise<boolean> {
+  try {
+    const state = await mid.accountProviders.publicDataProvider.queryContractState(address);
+    return state != null;
+  } catch {
+    // Indexer hiccup — do not block the unlock attempt on it.
+    return true;
+  }
+}
 
 export function OnboardView(props: {
   mid: Midnight;
@@ -23,6 +36,20 @@ export function OnboardView(props: {
   const [devMode, setDevMode] = useState(false);
   const [passphrase, setPassphrase] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [sessionStale, setSessionStale] = useState(false);
+
+  // Proactively check that the remembered account still exists — a reset
+  // localnet keeps the browser session but loses the contract.
+  useEffect(() => {
+    if (!session) return;
+    let stop = false;
+    contractExists(mid, session.accountAddress).then((exists) => {
+      if (!stop && !exists) setSessionStale(true);
+    });
+    return () => {
+      stop = true;
+    };
+  }, [mid, session]);
 
   const deviceSecretForOnboarding = async (): Promise<{
     secret: Uint8Array;
@@ -58,6 +85,16 @@ export function OnboardView(props: {
         </div>
         <div className="onboard-cards">
           <div className="panel onboard-card">
+            {sessionStale && (
+              <div className="caveat">
+                <Chip tone="warn">not on this chain</Chip>
+                <p>
+                  No contract exists at this address on the current localnet — the chain was
+                  probably reset since this account was created. Forget this account below and
+                  create a new one.
+                </p>
+              </div>
+            )}
             {session.devMode && (
               <label className="field">
                 <span className="field-label">passphrase</span>
@@ -75,6 +112,11 @@ export function OnboardView(props: {
               onError={setError}
               onRun={async () => {
                 setError(null);
+                if (!(await contractExists(mid, session.accountAddress))) {
+                  throw new Error(
+                    'account contract not found on this chain — the localnet was reset; forget this account and onboard again',
+                  );
+                }
                 const secret = session.devMode
                   ? await deriveDevModeSecret(passphrase)
                   : await deriveDeviceSecret(session.passkey);
@@ -207,6 +249,9 @@ export function OnboardView(props: {
               onError={setError}
               onRun={async () => {
                 setError(null);
+                if (!(await contractExists(mid, address.trim()))) {
+                  throw new Error('no contract found at this address on the current chain');
+                }
                 const secret = devMode
                   ? await deriveDevModeSecret(passphrase)
                   : await deriveDeviceSecret();

--- a/experiments/account-custody-prototype/app/src/views/Overview.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Overview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ViewHeader, Panel, Mono, Chip, Field } from '../ui.js';
+import { ViewHeader, Mono, Chip, Field, X } from '../ui.js';
 import type { AppContext } from '../App.js';
 
 // Machine-readable-zone line: uppercase, non-alphanumerics become fillers,
@@ -12,11 +12,18 @@ function mrzLine(s: string): string {
 export function OverviewView({ ctx }: { ctx: AppContext }) {
   const { session, ledger } = ctx;
   const grants = ledger ? [...ledger.grants] : [];
-  const activeGrants = grants.filter(([, g]) => g.active).length;
-  const shares = ledger ? Number(ledger.recovery_shares.size()) : 0;
   const epoch = ledger ? ledger.device_epoch : 0n;
+  const activeGrants = grants.filter(([, g]) => g.active && g.epoch === epoch).length;
+  const shares = ledger ? Number(ledger.recovery_shares.size()) : 0;
   const holder = (session.devMode ? 'bearer' : (session.passkey?.label ?? 'bearer')).toUpperCase();
   const reissued = epoch > 0n;
+  const nightTotal = ledger
+    ? [...ledger.night_balances].reduce((acc, [, v]) => acc + v, 0n)
+    : 0n;
+  const coinCount = ledger ? [...ledger.coins].filter(([, q]) => q.value > 0n).length : 0;
+  const activeDevices = ledger
+    ? [...ledger.devices].filter(([, e]) => e === epoch).length
+    : 0;
 
   const mrz1 = mrzLine(`P<MN${holder}<<MIDNIGHT<PASSPORT`);
   const mrz2 = mrzLine(
@@ -26,9 +33,8 @@ export function OverviewView({ ctx }: { ctx: AppContext }) {
   return (
     <>
       <ViewHeader
-        numeral="01"
         title="Your account is a contract"
-        narration="Onboarding created a passkey, split a recovery secret 2-of-3, and deployed a personal Compact contract. This page reads your document live from the Midnight ledger."
+        narration="A personal Compact contract on the Midnight ledger holds this account. Everything on this page is read live from chain state — hover any dotted term for what it means."
       />
 
       <section className="doc">
@@ -36,67 +42,134 @@ export function OverviewView({ ctx }: { ctx: AppContext }) {
           <span className="doc-authority">Midnight Network · Localnet</span>
           <span className="doc-type">Passport · Account custody</span>
         </header>
-        <span className="doc-chipmark" aria-hidden="true" />
+        <span
+          className="doc-chipmark"
+          aria-hidden="true"
+          data-x="The e-passport chip mark, worn here as a badge: like a passport chip, the cryptography lives with the document — your device derives the key, the contract verifies the proof."
+        />
         <div className="doc-grid">
-          <Field k="Holder" v={holder} big />
+          <Field
+            k="Holder"
+            v={
+              <X x="The bearer of this passport. The account is operated by whoever can prove knowledge of an enrolled device secret — derived from your passkey, never stored anywhere (P1).">
+                {holder}
+              </X>
+            }
+            big
+          />
           <Field
             k="Status"
             v={
-              <Chip stamp tone={reissued ? 'warn' : 'ok'}>
-                {reissued ? `reissued · epoch ${String(epoch)}` : 'valid'}
-              </Chip>
+              <span data-x="Status derived from on-chain state. VALID means devices at the current epoch are enrolled; REISSUED means the account has been recovered and re-keyed at a new epoch.">
+                <Chip stamp tone={reissued ? 'warn' : 'ok'}>
+                  {reissued ? `reissued · epoch ${String(epoch)}` : 'valid'}
+                </Chip>
+              </span>
             }
           />
           <Field
             k="Document no. — account contract"
-            v={<Mono v={session.accountAddress} short group />}
+            v={
+              <X x="The address of your personal account contract — the passport is the contract. Anyone can verify this document against the ledger; no issuing authority is involved (P8).">
+                <Mono v={session.accountAddress} short group />
+              </X>
+            }
             wide
           />
-          <Field k="Issuing round" v={ledger ? String(ledger.round) : '…'} />
-          <Field k="Device epoch" v={String(epoch)} />
-          <Field k="Devices" v={ledger ? String(ledger.device_count) : '…'} />
-          <Field k="Active grants" v={ledger ? String(activeGrants) : '…'} />
-          <Field k="Recovery shares" v={ledger ? `${shares} — any 2 of 3` : '…'} />
+          <Field
+            k="Issuing round"
+            v={
+              <X x="The current ledger round. Every authorised operation bumps an internal round counter, so a captured transaction can never be replayed.">
+                {ledger ? String(ledger.round) : '…'}
+              </X>
+            }
+          />
+          <Field
+            k="Device epoch"
+            v={
+              <X x="Bumped by recovery: every device and grant from an earlier epoch instantly stops being honoured by the contract (P4, P5).">
+                {String(epoch)}
+              </X>
+            }
+          />
+          <Field
+            k="Devices"
+            v={
+              <X x="Devices enrolled at the current epoch. Every one is a first-class peer: any device can act, enrol another, or revoke one (P3).">
+                {ledger ? String(activeDevices) : '…'}
+              </X>
+            }
+          />
+          <Field
+            k="Active grants"
+            v={
+              <X x="Scoped credentials issued to dApps — operation × token colour × cumulative cap, enforced by the contract circuit, not by the dApp (P7).">
+                {ledger ? String(activeGrants) : '…'}
+              </X>
+            }
+          />
+          <Field
+            k="Recovery shares"
+            v={
+              <X x="The recovery secret is split 2-of-3. Any two shares reconstruct it, re-key the account, and retire every old device — total loss is survivable (P5).">
+                {ledger ? `${shares} — any 2 of 3` : '…'}
+              </X>
+            }
+          />
         </div>
-        <div className="doc-mrz" title="machine-readable zone — decorative, derived from the document">
+        <div
+          className="doc-mrz"
+          data-x="Machine-readable zone, as on a printed passport — decorative here, derived from the holder, the contract address, the epoch, and the round."
+        >
           <span>{mrz1}</span>
           <span>{mrz2}</span>
         </div>
       </section>
 
-      <Panel
-        title="How custody works here"
-        sub="Three commitments in public state; every move is a proved circuit call."
-      >
-        <div className="explain-row">
-          <div className="explain">
-            <Chip tone="ok">devices</Chip>
-            <p>
-              Each device's secret is committed on-chain. Any active device authorises moves
-              (1-of-n). A device epoch bump invalidates all of them at once.
-            </p>
-          </div>
-          <div className="explain">
-            <Chip tone="info">grants</Chip>
-            <p>
-              A grant is a scoped credential for a dApp: one operation, one token colour, a
-              cumulative cap. The contract enforces the scope — not the dApp.
-            </p>
-          </div>
-          <div className="explain">
-            <Chip tone="warn">recovery</Chip>
-            <p>
-              Losing every device is survivable: 2 of 3 shares reconstruct the recovery secret,
-              which re-keys the account and orphans everything else.
-            </p>
-          </div>
-        </div>
-        <div className="next-cue">
-          <button className="btn btn-primary" onClick={() => ctx.goToStep(2)}>
-            Next — fund the account →
-          </button>
-        </div>
-      </Panel>
+      <div className="tiles">
+        <button
+          className="tile"
+          onClick={() => ctx.goToView('assets')}
+          data-x="Assets held by your contract — custody is enforced by its circuits, not by this app. Balances are read live from the ledger."
+        >
+          <span className="tile-k">Holdings</span>
+          <span className="tile-v">
+            {ledger ? String(nightTotal) : '…'} <small>NIGHT</small>
+          </span>
+          <span className="tile-sub">
+            {coinCount > 0 ? `+ ${coinCount} shielded asset${coinCount > 1 ? 's' : ''}` : 'no shielded assets yet'}
+          </span>
+        </button>
+        <button
+          className="tile"
+          onClick={() => ctx.goToView('grants')}
+          data-x="Connections are scoped credentials handed to dApps — like OAuth scopes, except the ledger itself enforces them at proof verification (P7)."
+        >
+          <span className="tile-k">Connections</span>
+          <span className="tile-v">{ledger ? activeGrants : '…'}</span>
+          <span className="tile-sub">active scoped grants</span>
+        </button>
+        <button
+          className="tile"
+          onClick={() => ctx.goToView('devices')}
+          data-x="Every enrolled device is a first-class peer — no primary device, no backup hierarchy (P3)."
+        >
+          <span className="tile-k">Devices</span>
+          <span className="tile-v">{ledger ? activeDevices : '…'}</span>
+          <span className="tile-sub">enrolled at epoch {String(epoch)}</span>
+        </button>
+        <button
+          className="tile"
+          onClick={() => ctx.goToView('recovery')}
+          data-x="Losing every device does not lose the account: any two of the three on-chain shares restore the same account — same name, balances, and history (P5)."
+        >
+          <span className="tile-k">Recovery</span>
+          <span className="tile-v">
+            2 <small>of</small> 3
+          </span>
+          <span className="tile-sub">{shares === 3 ? 'kit ready' : `${shares} shares on-chain`}</span>
+        </button>
+      </div>
     </>
   );
 }

--- a/experiments/account-custody-prototype/app/src/views/Overview.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Overview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ViewHeader, Mono, Chip, Field, X } from '../ui.js';
+import { FlowDiagram } from './FlowDiagram.js';
 import type { AppContext } from '../App.js';
 
 // Machine-readable-zone line: uppercase, non-alphanumerics become fillers,
@@ -170,6 +171,8 @@ export function OverviewView({ ctx }: { ctx: AppContext }) {
           <span className="tile-sub">{shares === 3 ? 'kit ready' : `${shares} shares on-chain`}</span>
         </button>
       </div>
+
+      <FlowDiagram ctx={ctx} />
     </>
   );
 }

--- a/experiments/account-custody-prototype/app/src/views/Overview.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Overview.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { ViewHeader, Panel, Mono, StatTile, Chip } from '../ui.js';
+import type { AppContext } from '../App.js';
+
+export function OverviewView({ ctx }: { ctx: AppContext }) {
+  const { session, ledger } = ctx;
+  const grants = ledger ? [...ledger.grants] : [];
+  const activeGrants = grants.filter(([, g]) => g.active).length;
+  const shares = ledger ? Number(ledger.recovery_shares.size()) : 0;
+
+  return (
+    <>
+      <ViewHeader
+        numeral="01"
+        title="Your account is a contract"
+        narration="Onboarding created a passkey, split a recovery secret 2-of-3, and deployed a personal Compact contract. Everything below is read live from the Midnight ledger."
+      />
+
+      <Panel
+        title="Account contract"
+        sub="The address of your personal account-custody contract on the localnet."
+      >
+        <Mono v={session.accountAddress} className="addr-hero" />
+        <div className="stat-row">
+          <StatTile label="round" value={ledger ? String(ledger.round) : '…'} />
+          <StatTile label="device epoch" value={ledger ? String(ledger.device_epoch) : '…'} />
+          <StatTile label="devices" value={ledger ? String(ledger.device_count) : '…'} />
+          <StatTile label="active grants" value={ledger ? String(activeGrants) : '…'} />
+          <StatTile label="recovery shares" value={ledger ? String(shares) : '…'} />
+        </div>
+      </Panel>
+
+      <Panel
+        title="How custody works here"
+        sub="Three commitments in public state; every move is a proved circuit call."
+      >
+        <div className="explain-row">
+          <div className="explain">
+            <Chip tone="ok">devices</Chip>
+            <p>
+              Each device's secret is committed on-chain. Any active device authorises moves
+              (1-of-n). A device epoch bump invalidates all of them at once.
+            </p>
+          </div>
+          <div className="explain">
+            <Chip tone="info">grants</Chip>
+            <p>
+              A grant is a scoped credential for a dApp: one operation, one token colour, a
+              cumulative cap. The contract enforces the scope — not the dApp.
+            </p>
+          </div>
+          <div className="explain">
+            <Chip tone="warn">recovery</Chip>
+            <p>
+              Losing every device is survivable: 2 of 3 shares reconstruct the recovery secret,
+              which re-keys the account and orphans everything else.
+            </p>
+          </div>
+        </div>
+        <div className="next-cue">
+          <button className="btn btn-primary" onClick={() => ctx.goToStep(2)}>
+            Next — fund the account →
+          </button>
+        </div>
+      </Panel>
+    </>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/Overview.tsx
+++ b/experiments/account-custody-prototype/app/src/views/Overview.tsx
@@ -1,35 +1,68 @@
 import React from 'react';
 
-import { ViewHeader, Panel, Mono, StatTile, Chip } from '../ui.js';
+import { ViewHeader, Panel, Mono, Chip, Field } from '../ui.js';
 import type { AppContext } from '../App.js';
+
+// Machine-readable-zone line: uppercase, non-alphanumerics become fillers,
+// padded to the classic 44 characters.
+function mrzLine(s: string): string {
+  return (s.toUpperCase().replace(/[^A-Z0-9]/g, '<') + '<'.repeat(44)).slice(0, 44);
+}
 
 export function OverviewView({ ctx }: { ctx: AppContext }) {
   const { session, ledger } = ctx;
   const grants = ledger ? [...ledger.grants] : [];
   const activeGrants = grants.filter(([, g]) => g.active).length;
   const shares = ledger ? Number(ledger.recovery_shares.size()) : 0;
+  const epoch = ledger ? ledger.device_epoch : 0n;
+  const holder = (session.devMode ? 'bearer' : (session.passkey?.label ?? 'bearer')).toUpperCase();
+  const reissued = epoch > 0n;
+
+  const mrz1 = mrzLine(`P<MN${holder}<<MIDNIGHT<PASSPORT`);
+  const mrz2 = mrzLine(
+    `${session.accountAddress.slice(0, 20)}<MN<E${String(epoch)}<R${ledger ? String(ledger.round) : ''}`,
+  );
 
   return (
     <>
       <ViewHeader
         numeral="01"
         title="Your account is a contract"
-        narration="Onboarding created a passkey, split a recovery secret 2-of-3, and deployed a personal Compact contract. Everything below is read live from the Midnight ledger."
+        narration="Onboarding created a passkey, split a recovery secret 2-of-3, and deployed a personal Compact contract. This page reads your document live from the Midnight ledger."
       />
 
-      <Panel
-        title="Account contract"
-        sub="The address of your personal account-custody contract on the localnet."
-      >
-        <Mono v={session.accountAddress} className="addr-hero" />
-        <div className="stat-row">
-          <StatTile label="round" value={ledger ? String(ledger.round) : '…'} />
-          <StatTile label="device epoch" value={ledger ? String(ledger.device_epoch) : '…'} />
-          <StatTile label="devices" value={ledger ? String(ledger.device_count) : '…'} />
-          <StatTile label="active grants" value={ledger ? String(activeGrants) : '…'} />
-          <StatTile label="recovery shares" value={ledger ? String(shares) : '…'} />
+      <section className="doc">
+        <header className="doc-head">
+          <span className="doc-authority">Midnight Network · Localnet</span>
+          <span className="doc-type">Passport · Account custody</span>
+        </header>
+        <span className="doc-chipmark" aria-hidden="true" />
+        <div className="doc-grid">
+          <Field k="Holder" v={holder} big />
+          <Field
+            k="Status"
+            v={
+              <Chip stamp tone={reissued ? 'warn' : 'ok'}>
+                {reissued ? `reissued · epoch ${String(epoch)}` : 'valid'}
+              </Chip>
+            }
+          />
+          <Field
+            k="Document no. — account contract"
+            v={<Mono v={session.accountAddress} short group />}
+            wide
+          />
+          <Field k="Issuing round" v={ledger ? String(ledger.round) : '…'} />
+          <Field k="Device epoch" v={String(epoch)} />
+          <Field k="Devices" v={ledger ? String(ledger.device_count) : '…'} />
+          <Field k="Active grants" v={ledger ? String(activeGrants) : '…'} />
+          <Field k="Recovery shares" v={ledger ? `${shares} — any 2 of 3` : '…'} />
         </div>
-      </Panel>
+        <div className="doc-mrz" title="machine-readable zone — decorative, derived from the document">
+          <span>{mrz1}</span>
+          <span>{mrz2}</span>
+        </div>
+      </section>
 
       <Panel
         title="How custody works here"

--- a/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
@@ -24,14 +24,14 @@ export function RecoveryPanel(props: {
   return (
     <>
       <ViewHeader
-        numeral="05"
-        title="Recover from total loss"
-        narration="Every device is gone. Two of the three shares reconstruct the recovery secret; the recover circuit proves knowledge of it, bumps the device epoch — killing every device and grant — and registers a fresh device."
+        title="Recovery"
+        narration="If every device is gone, two of the three shares reconstruct the recovery secret; the recover circuit proves knowledge of it, bumps the device epoch — retiring every device and grant — and registers a fresh device."
       />
 
       <Panel
         title="Recovery shares"
         sub="The recovery secret is split 2-of-3 at onboarding; any two shares reconstruct it."
+        x="The recovery secret is split 2-of-3 over GF(256) (Shamir): any two shares reconstruct it; any single share is information-theoretically useless (I-6.4). Recovery re-keys the account — same name, balances, and history (I-5.3)."
       >
         <div className="share-row">
           {[1, 2, 3].map((i) => (

--- a/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+
+import { PassportAccount } from '../../../src/wallet/account.js';
+import { reconstruct } from '../../../src/wallet/shamir.js';
+import { randomBytes32 } from '../../../src/wallet/hex.js';
+import { recoveryCommitment, deviceCommitment } from '../../../src/wallet/contract.js';
+
+import { createPasskey, deriveDeviceSecret, deriveDevModeSecret } from '../lib/passkey.js';
+import type { Session } from '../lib/session.js';
+import { ViewHeader, Panel, ActionButton, Chip, StatTile } from '../ui.js';
+import type { AppContext } from '../App.js';
+
+export function RecoveryPanel(props: {
+  ctx: AppContext;
+  onRecovered: (s: Session, a: PassportAccount, commitment?: string) => void;
+}) {
+  const { ctx } = props;
+  const { ledger, log, session } = ctx;
+  const [devMode, setDevMode] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+
+  const shareCount = ledger ? Number(ledger.recovery_shares.size()) : 0;
+
+  return (
+    <>
+      <ViewHeader
+        numeral="05"
+        title="Recover from total loss"
+        narration="Every device is gone. Two of the three shares reconstruct the recovery secret; the recover circuit proves knowledge of it, bumps the device epoch — killing every device and grant — and registers a fresh device."
+      />
+
+      <Panel
+        title="Recovery shares"
+        sub="The recovery secret is split 2-of-3 at onboarding; any two shares reconstruct it."
+      >
+        <div className="share-row">
+          {[1, 2, 3].map((i) => (
+            <div className={`share-slot ${i <= shareCount ? 'share-live' : ''}`} key={i}>
+              <span className="share-n">{i}</span>
+              <span className="share-k">share</span>
+              <span className="share-v">{i <= shareCount ? 'on-chain' : '—'}</span>
+            </div>
+          ))}
+          <div className="share-meta">
+            <StatTile label="threshold" value="2 of 3" />
+            <StatTile label="device epoch" value={ledger ? String(ledger.device_epoch) : '…'} />
+          </div>
+        </div>
+        <div className="caveat">
+          <Chip tone="warn">TODO(PVSS)</Chip>
+          <p>
+            In this prototype the shares sit in <em>plaintext public ledger state</em> — anyone
+            can reconstruct the recovery secret. The target design encrypts each share to a
+            recovery helper and publishes correctness proofs instead. Do not ship this.
+          </p>
+        </div>
+      </Panel>
+
+      <Panel
+        title="Simulate the disaster"
+        sub="Pretend every device is lost: reconstruct the secret from on-chain shares 1 and 2, prove it, re-key the account."
+      >
+        <label className="devmode-row">
+          <input
+            type="checkbox"
+            checked={devMode}
+            onChange={(e) => setDevMode(e.target.checked)}
+          />
+          dev mode — recover with a passphrase instead of a passkey
+        </label>
+        {devMode && (
+          <label className="field">
+            <span className="field-label">new passphrase</span>
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+            />
+          </label>
+        )}
+        <ActionButton
+          label="Simulate total loss & recover"
+          busyLabel="recovering…"
+          kind="danger"
+          block
+          task={{ label: 'Recovering the account', circuit: 'recover' }}
+          onRun={async () => {
+            if (!ledger) throw new Error('ledger not loaded yet');
+
+            log('TOTAL LOSS — reconstructing the recovery secret from on-chain shares 1+2…');
+            const secret = reconstruct([
+              { index: 1, value: ledger.recovery_shares.lookup(1n) },
+              { index: 2, value: ledger.recovery_shares.lookup(2n) },
+            ]);
+            if (recoveryCommitment(secret) !== ledger.recovery) {
+              throw new Error('reconstructed secret does not match the on-chain commitment');
+            }
+            log('reconstructed secret matches the on-chain commitment.');
+
+            let newDeviceSecret: Uint8Array;
+            let newSession: Session;
+            if (devMode) {
+              if (!passphrase) throw new Error('enter a new dev-mode passphrase');
+              newDeviceSecret = await deriveDevModeSecret(passphrase);
+              newSession = { accountAddress: session.accountAddress, devMode: true };
+            } else {
+              const ref = await createPasskey('recovered-device');
+              newDeviceSecret = await deriveDeviceSecret(ref);
+              newSession = { accountAddress: session.accountAddress, passkey: ref };
+            }
+
+            const newRecoverySecret = randomBytes32();
+            const recoverer = await ctx.reconnect({ recoverySecret: secret });
+            const r = await recoverer.recover(newDeviceSecret, newRecoverySecret);
+            log(`recover → tx ${r.txId} — old devices and grants are now dead.`);
+
+            const account = await ctx.reconnect({ deviceSecret: newDeviceSecret });
+            props.onRecovered(newSession, account, deviceCommitment(newDeviceSecret).toString());
+            await ctx.refreshLedger();
+            return r.txId;
+          }}
+        />
+      </Panel>
+    </>
+  );
+}

--- a/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
@@ -32,12 +32,15 @@ export function WalletPanel({ ctx }: { ctx: AppContext }) {
   return (
     <>
       <ViewHeader
-        numeral="02"
-        title="Fund the account"
-        narration="Assets are held by the contract, not by a key. Night moves with an on-ledger balance mirror; shielded coins follow the OZ Map⟨colour, QSCI⟩ pattern — values public, an accepted prototype trade-off."
+        title="Holdings"
+        narration="Assets are held by your contract, not by a key. Night moves with an on-ledger balance mirror; shielded coins follow the OZ Map⟨colour, QSCI⟩ pattern — values public, an accepted prototype trade-off."
       />
 
-      <Panel title="Night — unshielded" sub="Custodied by the contract; the balance is public ledger state.">
+      <Panel
+        title="Night — unshielded"
+        sub="Custodied by the contract; the balance is public ledger state."
+        x="Night sits in your contract, not at a key-derived address. The contract keeps an on-ledger balance mirror, which is what makes balances readable from the indexer (C4)."
+      >
         <table className="table-tight">
           <thead>
             <tr>
@@ -100,6 +103,7 @@ export function WalletPanel({ ctx }: { ctx: AppContext }) {
       <Panel
         title="Shielded — contract-held"
         sub="Coins sit in the contract keyed by colour; the QSCI keeps values public in this prototype."
+        x="Shielded coins held by the contract, keyed by colour (the OZ Map⟨colour, QSCI⟩ pattern). Contract-held coin values are public ledger state — the documented C4 trade-off, accepted for this prototype."
       >
         <table>
           <thead>
@@ -157,6 +161,7 @@ export function WalletPanel({ ctx }: { ctx: AppContext }) {
         title="Faucet — localnet scaffolding"
         sub="Mints shielded test tokens to the fee wallet so they can be deposited; not part of the custody design."
         tone="scaffold"
+        x="Test scaffolding only: a faucet contract that mints shielded tokens on the localnet so the custody flows above have something to hold. Nothing like this exists in the real design."
       >
         <div className="row controls">
           <label className="field field-inline grow">

--- a/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
@@ -38,7 +38,7 @@ export function WalletPanel({ ctx }: { ctx: AppContext }) {
       />
 
       <Panel title="Night — unshielded" sub="Custodied by the contract; the balance is public ledger state.">
-        <table>
+        <table className="table-tight">
           <thead>
             <tr>
               <th>colour</th>

--- a/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/WalletPanel.tsx
@@ -1,0 +1,233 @@
+import React, { useState } from 'react';
+import { firstValueFrom } from 'rxjs';
+import { rawTokenType, encodeRawTokenType } from '@midnight-ntwrk/ledger-v8';
+
+import { randomBytes32, hexToBytes32, hexToBytes, bytesToHex } from '../../../src/wallet/hex.js';
+
+import { getFaucet } from '../lib/midnight.js';
+import { userAddressBytes, coinPublicKeyBytes } from '../lib/providers.js';
+import { ViewHeader, Panel, ActionButton, Mono, Chip } from '../ui.js';
+import type { AppContext } from '../App.js';
+
+interface PendingNote {
+  nonceHex: string;
+  colorHex: string;
+  value: bigint;
+}
+
+const FAUCET_DOMESTIC_COLOR = hexToBytes32('06');
+
+export function WalletPanel({ ctx }: { ctx: AppContext }) {
+  const { ledger, account, mid, log, nightColor } = ctx;
+  const [depositAmt, setDepositAmt] = useState('1000');
+  const [withdrawAmt, setWithdrawAmt] = useState('100');
+  const [mintAmt, setMintAmt] = useState('500');
+  const [shieldedWithdrawAmt, setShieldedWithdrawAmt] = useState('100');
+  const [faucetAddr, setFaucetAddr] = useState(mid.faucetAddress);
+  const [pendingNotes, setPendingNotes] = useState<PendingNote[]>([]);
+
+  const nights = ledger ? [...ledger.night_balances] : [];
+  const coins = ledger ? [...ledger.coins] : [];
+
+  return (
+    <>
+      <ViewHeader
+        numeral="02"
+        title="Fund the account"
+        narration="Assets are held by the contract, not by a key. Night moves with an on-ledger balance mirror; shielded coins follow the OZ Map⟨colour, QSCI⟩ pattern — values public, an accepted prototype trade-off."
+      />
+
+      <Panel title="Night — unshielded" sub="Custodied by the contract; the balance is public ledger state.">
+        <table>
+          <thead>
+            <tr>
+              <th>colour</th>
+              <th className="num">balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {nights.length === 0 && (
+              <tr>
+                <td className="dim" colSpan={2}>
+                  no Night held by the account yet — deposit from the fee wallet below
+                </td>
+              </tr>
+            )}
+            {nights.map(([color, value]) => (
+              <tr key={bytesToHex(color)}>
+                <td>
+                  <Mono v={bytesToHex(color)} short />
+                </td>
+                <td className="num num-big">{String(value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="row controls">
+          <input value={depositAmt} onChange={(e) => setDepositAmt(e.target.value)} size={8} />
+          <ActionButton
+            label="Deposit Night"
+            busyLabel="depositing…"
+            task={{ label: 'Depositing Night into the account', circuit: 'deposit_night' }}
+            onRun={async () => {
+              const r = await account.depositNight(nightColor, BigInt(depositAmt));
+              log(`deposit_night ${depositAmt} → tx ${r.txId}`);
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+          <span className="ctrl-gap" />
+          <input value={withdrawAmt} onChange={(e) => setWithdrawAmt(e.target.value)} size={8} />
+          <ActionButton
+            label="Withdraw Night"
+            busyLabel="withdrawing…"
+            kind="ghost"
+            task={{ label: 'Withdrawing Night to the user wallet', circuit: 'withdraw_night' }}
+            onRun={async () => {
+              const r = await account.withdrawNight(
+                nightColor,
+                BigInt(withdrawAmt),
+                userAddressBytes(mid.walletCtx),
+              );
+              log(`withdraw_night ${withdrawAmt} → tx ${r.txId}`);
+              await ctx.refreshLedger();
+              return r.txId;
+            }}
+          />
+        </div>
+      </Panel>
+
+      <Panel
+        title="Shielded — contract-held"
+        sub="Coins sit in the contract keyed by colour; the QSCI keeps values public in this prototype."
+      >
+        <table>
+          <thead>
+            <tr>
+              <th>colour</th>
+              <th className="num">value</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {coins.length === 0 && (
+              <tr>
+                <td className="dim" colSpan={3}>
+                  no shielded coins held by the account yet — mint from the faucet below
+                </td>
+              </tr>
+            )}
+            {coins.map(([color, qsci]) => (
+              <tr key={bytesToHex(color)}>
+                <td>
+                  <Mono v={bytesToHex(color)} short />
+                </td>
+                <td className="num num-big">{String(qsci.value)}</td>
+                <td className="row-actions">
+                  <input
+                    value={shieldedWithdrawAmt}
+                    onChange={(e) => setShieldedWithdrawAmt(e.target.value)}
+                    size={6}
+                  />
+                  <ActionButton
+                    label="Withdraw"
+                    busyLabel="withdrawing…"
+                    kind="ghost"
+                    task={{ label: 'Withdrawing shielded coins', circuit: 'withdraw_shielded' }}
+                    onRun={async () => {
+                      const state: any = await firstValueFrom(mid.walletCtx.wallet.state());
+                      const r = await account.withdrawShielded(
+                        coinPublicKeyBytes(state),
+                        color,
+                        BigInt(shieldedWithdrawAmt),
+                      );
+                      log(`withdraw_shielded ${shieldedWithdrawAmt} → tx ${r.txId}`);
+                      await ctx.refreshLedger();
+                      return r.txId;
+                    }}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Panel>
+
+      <Panel
+        title="Faucet — localnet scaffolding"
+        sub="Mints shielded test tokens to the fee wallet so they can be deposited; not part of the custody design."
+        tone="scaffold"
+      >
+        <div className="row controls">
+          <label className="field field-inline grow">
+            <span className="field-label">faucet contract</span>
+            <input
+              value={faucetAddr}
+              onChange={(e) => setFaucetAddr(e.target.value)}
+              placeholder="deploy with: npm run deploy"
+            />
+          </label>
+          <input value={mintAmt} onChange={(e) => setMintAmt(e.target.value)} size={8} />
+          <ActionButton
+            label="Mint shielded to wallet"
+            busyLabel="minting…"
+            kind="ghost"
+            disabled={!faucetAddr}
+            task={{ label: 'Minting shielded test tokens', circuit: 'mint_shielded' }}
+            onRun={async () => {
+              const faucet = await getFaucet(mid, faucetAddr.trim());
+              const state: any = await firstValueFrom(mid.walletCtx.wallet.state());
+              const nonce = randomBytes32();
+              const r = await faucet.callTx.mint_shielded(
+                FAUCET_DOMESTIC_COLOR,
+                BigInt(mintAmt),
+                nonce,
+                { bytes: coinPublicKeyBytes(state) },
+              );
+              const txId = r?.public?.txId ?? r?.public?.transactionHash;
+              const derived = encodeRawTokenType(
+                rawTokenType(FAUCET_DOMESTIC_COLOR, faucetAddr.trim()),
+              );
+              setPendingNotes((p) => [
+                ...p,
+                {
+                  nonceHex: bytesToHex(nonce),
+                  colorHex: bytesToHex(derived),
+                  value: BigInt(mintAmt),
+                },
+              ]);
+              log(`faucet minted ${mintAmt} shielded → tx ${txId} (wait ~15s before depositing)`);
+              return txId;
+            }}
+          />
+        </div>
+        {pendingNotes.map((note, i) => (
+          <div className="note-row" key={note.nonceHex}>
+            <Chip tone="warn">pending note</Chip>
+            <span className="dim">
+              {String(note.value)} of <Mono v={note.colorHex} short /> · nonce{' '}
+              {note.nonceHex.slice(0, 10)}…
+            </span>
+            <span className="provedock-spacer" />
+            <ActionButton
+              label="Deposit into account"
+              busyLabel="depositing…"
+              task={{ label: 'Depositing the shielded note', circuit: 'deposit_shielded' }}
+              onRun={async () => {
+                const r = await account.depositShielded({
+                  nonce: hexToBytes(note.nonceHex),
+                  color: hexToBytes(note.colorHex),
+                  value: note.value,
+                });
+                log(`deposit_shielded ${note.value} → tx ${r.txId}`);
+                setPendingNotes((p) => p.filter((_, j) => j !== i));
+                await ctx.refreshLedger();
+                return r.txId;
+              }}
+            />
+          </div>
+        ))}
+      </Panel>
+    </>
+  );
+}

--- a/experiments/account-custody-prototype/app/tsconfig.json
+++ b/experiments/account-custody-prototype/app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts", "../src/wallet"]
+}

--- a/experiments/account-custody-prototype/app/vite.config.ts
+++ b/experiments/account-custody-prototype/app/vite.config.ts
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const managedDir = path.resolve(__dirname, '..', 'contracts', 'managed');
+
+// Serve the compiled contract artefacts (prover/verifier keys, zkir) at /zk
+// so FetchZkConfigProvider can pull them: /zk/account/keys/<circuit>.prover …
+function serveZkAssets(): Plugin {
+  return {
+    name: 'serve-zk-assets',
+    configureServer(server) {
+      server.middlewares.use('/zk', (req, res, next) => {
+        const rel = decodeURIComponent((req.url ?? '').split('?')[0]);
+        const filePath = path.join(managedDir, rel);
+        if (!filePath.startsWith(managedDir)) return next();
+        fs.stat(filePath, (err, st) => {
+          if (err || !st.isFile()) return next();
+          res.setHeader('Content-Type', 'application/octet-stream');
+          fs.createReadStream(filePath).pipe(res);
+        });
+      });
+    },
+  };
+}
+
+// Inline the faucet address if src/tests/deploy.ts has been run.
+function faucetAddress(): string {
+  const p = path.resolve(__dirname, '..', 'faucet-deployment.json');
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8')).faucetAddress ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export default defineConfig({
+  plugins: [react(), wasm(), topLevelAwait(), serveZkAssets()],
+  define: {
+    __FAUCET_ADDRESS__: JSON.stringify(faucetAddress()),
+  },
+  resolve: {
+    alias: {
+      'isomorphic-ws': path.resolve(__dirname, 'src/lib/ws-shim.ts'),
+      // Userland Buffer for wallet-SDK imports of node's `buffer` module —
+      // applies to deps served from the parent tree too.
+      buffer: path.resolve(__dirname, 'node_modules/buffer/index.js'),
+      'node:buffer': path.resolve(__dirname, 'node_modules/buffer/index.js'),
+    },
+    // The shared ../src/wallet code would otherwise resolve @midnight-ntwrk
+    // packages from the PARENT node_modules — a second physical module
+    // instance, so setNetworkId() lands in a different module state than
+    // the one midnight-js-contracts reads. Dedupe forces one copy.
+    dedupe: [
+      '@midnight-ntwrk/compact-js',
+      '@midnight-ntwrk/compact-runtime',
+      '@midnight-ntwrk/ledger-v8',
+      '@midnight-ntwrk/onchain-runtime-v3',
+      '@midnight-ntwrk/midnight-js-contracts',
+      '@midnight-ntwrk/midnight-js-network-id',
+      '@midnight-ntwrk/midnight-js-types',
+      '@midnight-ntwrk/midnight-js-indexer-public-data-provider',
+      '@midnight-ntwrk/midnight-js-http-client-proof-provider',
+      '@midnight-ntwrk/midnight-js-fetch-zk-config-provider',
+      'rxjs',
+    ],
+  },
+  server: {
+    port: 5173,
+    fs: { allow: [path.resolve(__dirname, '..')] },
+    proxy: {
+      '/indexer': {
+        target: 'http://localhost:8088',
+        changeOrigin: true,
+        ws: true,
+        rewrite: (p) => p.replace(/^\/indexer/, ''),
+      },
+      // Note: not `/node` — that prefix would swallow /node_modules requests.
+      '/rpc': {
+        target: 'http://localhost:9944',
+        changeOrigin: true,
+        ws: true,
+        rewrite: (p) => p.replace(/^\/rpc/, ''),
+      },
+    },
+  },
+  optimizeDeps: {
+    exclude: [
+      '@midnight-ntwrk/ledger-v8',
+      '@midnight-ntwrk/onchain-runtime-v3',
+      '@midnight-ntwrk/compact-runtime',
+      '@midnight-ntwrk/zswap',
+    ],
+    // CJS dependencies of the excluded (WASM) packages still need the
+    // ESM-interop pre-bundle.
+    include: ['object-inspect'],
+  },
+  build: {
+    target: 'esnext',
+  },
+});

--- a/experiments/account-custody-prototype/app/vite.config.ts
+++ b/experiments/account-custody-prototype/app/vite.config.ts
@@ -101,6 +101,11 @@ export default defineConfig({
     // ESM-interop pre-bundle.
     include: ['object-inspect'],
   },
+  // The proof worker (src/lib/proofWorker.ts) imports the zkir-v2 wasm.
+  worker: {
+    format: 'es',
+    plugins: () => [wasm(), topLevelAwait()],
+  },
   build: {
     target: 'esnext',
   },

--- a/experiments/account-custody-prototype/app/vite.config.ts
+++ b/experiments/account-custody-prototype/app/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
       '@midnight-ntwrk/onchain-runtime-v3',
       '@midnight-ntwrk/compact-runtime',
       '@midnight-ntwrk/zswap',
+      '@midnight-ntwrk/zkir-v2',
     ],
     // CJS dependencies of the excluded (WASM) packages still need the
     // ESM-interop pre-bundle.

--- a/experiments/account-custody-prototype/app/vite.config.ts
+++ b/experiments/account-custody-prototype/app/vite.config.ts
@@ -72,6 +72,10 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    // Tunnel hostnames for phone demos (see BROWSER-PROVING-SCOPE.md):
+    // WebAuthn needs HTTPS + a real hostname, so the phone reaches the dev
+    // server through e.g. `cloudflared tunnel --url http://localhost:5173`.
+    allowedHosts: ['.trycloudflare.com', '.ngrok-free.app', '.ts.net'],
     fs: { allow: [path.resolve(__dirname, '..')] },
     proxy: {
       '/indexer': {

--- a/experiments/account-custody-prototype/contracts/account.compact
+++ b/experiments/account-custody-prototype/contracts/account.compact
@@ -1,4 +1,4 @@
-pragma language_version 0.22;
+pragma language_version 0.23;
 
 import CompactStandardLibrary;
 

--- a/experiments/account-custody-prototype/contracts/account.compact
+++ b/experiments/account-custody-prototype/contracts/account.compact
@@ -1,0 +1,406 @@
+pragma language_version 0.22;
+
+import CompactStandardLibrary;
+
+// ---------------------------------------------------------------------------
+// Passport account-custody contract — prototype (C1 + C4 + C10 + C14).
+//
+// One contract instance per Passport account (C1 alternative A). The contract
+// custodies Midnight-native assets (C4 alternative A): Night via the
+// receive/sendUnshielded pair with an explicit ledger balance mirror, and
+// shielded tokens via the OpenZeppelin Map<color, QualifiedShieldedCoinInfo>
+// pattern proven by contract-custody-feasibility S4/S6.
+//
+// Authentication (C1 authentication alternative A — prototype decision):
+// hash-preimage witness. A device holds a 32-byte secret (derived from the
+// passkey WebAuthn PRF in the demo app); the ledger stores
+// transientHash(tag, secret); every gated circuit proves preimage knowledge.
+// JubJub Schnorr (C5 alternative A) is deliberately deferred — the witness
+// pipeline (C7) and the circuit surface are designed so the auth check is a
+// single helper circuit that a Schnorr verifier can replace later.
+//
+// Hashing (prototype decision): transientHash (Poseidon) everywhere, not
+// persistentHash. Known caveat: transientHash output is not guaranteed
+// stable across Compact language versions, so commitments stored in the
+// ledger would not survive a toolchain upgrade. Accepted for a prototype;
+// the C8 registry decision will revisit this.
+//
+// Device revocation and recovery use an epoch counter instead of map
+// iteration (Compact ledger maps cannot be cleared in-circuit): a device or
+// grant is valid only if its recorded epoch equals the current device_epoch.
+// recover() bumps the epoch, instantly invalidating every device and grant.
+//
+// Recovery (C14 — prototype decision): the ledger stores a commitment to a
+// recovery secret plus three Shamir shares (2-of-3) of that secret.
+// TODO(PVSS): the shares are currently stored in plaintext in public ledger
+// state, which means anyone can reconstruct the recovery secret. This is a
+// placeholder for a publicly verifiable secret sharing scheme in which each
+// share is encrypted to a helper's public key and accompanied by a proof of
+// correct sharing (C15 territory). Do not ship.
+//
+// Known privacy trade-offs accepted for the prototype (record in C4):
+//   - QSCI publicity: contract-held shielded coin values/colours are public.
+//   - Device-commitment linkability: each authorised call discloses the
+//     calling device's commitment, linking calls by device. A Merkle-tree
+//     membership proof would hide this; deferred.
+// ---------------------------------------------------------------------------
+
+// ── Domain-separated commitment derivations (C8 — ad-hoc v0 tags) ──────────
+//
+// Exported pure circuits so TypeScript derives identical commitments via
+// pureCircuits without reimplementing Poseidon (same trick as
+// redjubjub-wallet's compute_withdraw_challenge).
+
+export pure circuit derive_device_commitment(secret: Bytes<32>): Field {
+  return transientHash<[Bytes<32>, Bytes<32>]>(
+    [pad(32, "midnight:passport:device:v0"), secret]
+  );
+}
+
+export pure circuit derive_grant_commitment(secret: Bytes<32>): Field {
+  return transientHash<[Bytes<32>, Bytes<32>]>(
+    [pad(32, "midnight:passport:grant:v0"), secret]
+  );
+}
+
+export pure circuit derive_recovery_commitment(secret: Bytes<32>): Field {
+  return transientHash<[Bytes<32>, Bytes<32>]>(
+    [pad(32, "midnight:passport:recovery:v0"), secret]
+  );
+}
+
+// ── Witnesses (C7) ──────────────────────────────────────────────────────────
+//
+// Key material enters proof generation through these three witness functions,
+// implemented client-side over the wallet's private state (C16 stand-in).
+// The secrets never appear in any public output; only their commitments are
+// disclosed (as ledger-map keys).
+
+witness device_secret(): Bytes<32>;
+witness grant_secret(): Bytes<32>;
+witness recovery_secret(): Bytes<32>;
+
+// ── Public ledger state ─────────────────────────────────────────────────────
+
+struct GrantInfo {
+  epoch: Uint<32>;
+  color: Bytes<32>;
+  cap: Uint<128>;
+  spent: Uint<128>;
+  active: Boolean;
+}
+
+export ledger round: Uint<64>;
+// Bumped by every authorised circuit. Guarantees every authorised call
+// changes contract state (replay defence) and gives tests a post-condition.
+
+export ledger device_epoch: Uint<32>;
+// Bumped by recover(). Devices and grants are valid only in the epoch they
+// were registered in.
+
+export ledger devices: Map<Field, Uint<32>>;
+// device commitment → epoch it was registered in.
+
+export ledger device_count: Uint<8>;
+// Active devices in the current epoch. Guards against removing the last one.
+
+export ledger recovery: Field;
+// Commitment to the recovery secret (derive_recovery_commitment).
+
+export ledger recovery_shares: Map<Uint<8>, Bytes<32>>;
+// Shamir shares (2-of-3) of the recovery secret, keyed by share index 1..3.
+// TODO(PVSS): plaintext shares in public state — see header comment.
+
+export ledger grants: Map<Field, GrantInfo>;
+// grant commitment → scope (C10: operation is fixed to "withdraw", object
+// scope is the token colour, quantitative bound is a cumulative value cap).
+
+export ledger night_balances: Map<Bytes<32>, Uint<128>>;
+// Explicit mirror of the contract's Night holdings per colour. Night balances
+// of a contract are not part of contract ledger state, so without this
+// mirror neither the indexer-decoded ledger nor the simulator could report
+// balances. Deposits that bypass deposit_night are invisible to the mirror —
+// accepted for the prototype.
+
+export ledger coins: Map<Bytes<32>, QualifiedShieldedCoinInfo>;
+// OZ pattern: contract-held shielded coins, one entry per colour, qualified
+// with the Merkle-tree index allocated in the depositing transaction.
+
+// ── Constructor ─────────────────────────────────────────────────────────────
+//
+// Deployed per account at onboarding. The deploying client derives the
+// commitments via the pure circuits above and splits the recovery secret
+// client-side (src/wallet/shamir.ts).
+
+constructor(
+  initial_device_commitment: Field,
+  recovery_commitment: Field,
+  share_1: Bytes<32>,
+  share_2: Bytes<32>,
+  share_3: Bytes<32>,
+) {
+  round        = 0 as Uint<64>;
+  device_epoch = 0 as Uint<32>;
+  devices.insert(disclose(initial_device_commitment), 0 as Uint<32>);
+  device_count = 1 as Uint<8>;
+  recovery     = disclose(recovery_commitment);
+  recovery_shares.insert(1 as Uint<8>, disclose(share_1));
+  recovery_shares.insert(2 as Uint<8>, disclose(share_2));
+  recovery_shares.insert(3 as Uint<8>, disclose(share_3));
+}
+
+// ── Authentication helpers ──────────────────────────────────────────────────
+//
+// C5's future in-circuit Schnorr verifier replaces the body of
+// require_device; everything downstream is agnostic to the auth scheme.
+
+circuit require_device(): [] {
+  const c = disclose(derive_device_commitment(device_secret()));
+  assert(devices.member(c), "unknown device");
+  assert(devices.lookup(c) == device_epoch, "device of revoked epoch");
+  round = ((round + (1 as Uint<64>)) as Uint<64>);
+}
+
+// Scope enforcement for grant-authorised withdrawals (C10/C12): colour must
+// match, cumulative spend must stay under the cap, grant must be active and
+// from the current epoch.
+circuit require_grant(color: Bytes<32>, amount: Uint<128>): [] {
+  const g = disclose(derive_grant_commitment(grant_secret()));
+  assert(grants.member(g), "unknown grant");
+  const info = grants.lookup(g);
+  assert(info.active, "grant revoked");
+  assert(info.epoch == device_epoch, "grant of revoked epoch");
+  assert(info.color == color, "colour outside grant scope");
+  const new_spent = ((info.spent + amount) as Uint<128>);
+  assert(new_spent <= info.cap, "grant cap exceeded");
+  grants.insert(g, GrantInfo {
+    epoch:  info.epoch,
+    color:  info.color,
+    cap:    info.cap,
+    spent:  new_spent,
+    active: true,
+  });
+  round = ((round + (1 as Uint<64>)) as Uint<64>);
+}
+
+// Night balance-mirror bookkeeping.
+
+circuit credit_night(color: Bytes<32>, amount: Uint<128>): [] {
+  if (night_balances.member(color)) {
+    night_balances.insert(
+      color,
+      ((night_balances.lookup(color) + amount) as Uint<128>)
+    );
+  } else {
+    night_balances.insert(color, amount);
+  }
+}
+
+circuit debit_night(color: Bytes<32>, amount: Uint<128>): [] {
+  assert(night_balances.member(color), "no balance for colour");
+  const bal = night_balances.lookup(color);
+  assert(bal >= amount, "insufficient balance");
+  night_balances.insert(color, ((bal - amount) as Uint<128>));
+}
+
+// ── Night custody (C4 — U1/U3-proven paths) ─────────────────────────────────
+
+// Permissionless deposit: anyone may fund the account.
+export circuit deposit_night(color: Bytes<32>, amount: Uint<128>): [] {
+  const c = disclose(color);
+  const a = disclose(amount);
+  receiveUnshielded(c, a);
+  credit_night(c, a);
+}
+
+// Device-authorised withdrawal to a user address.
+export circuit withdraw_night(
+  color:     Bytes<32>,
+  amount:    Uint<128>,
+  recipient: UserAddress,
+): [] {
+  require_device();
+  const c = disclose(color);
+  const a = disclose(amount);
+  debit_night(c, a);
+  sendUnshielded(c, a, right<ContractAddress, UserAddress>(disclose(recipient)));
+}
+
+// Grant-authorised withdrawal (the dApp spend path, C10).
+export circuit grant_withdraw_night(
+  color:     Bytes<32>,
+  amount:    Uint<128>,
+  recipient: UserAddress,
+): [] {
+  const c = disclose(color);
+  const a = disclose(amount);
+  require_grant(c, a);
+  debit_night(c, a);
+  sendUnshielded(c, a, right<ContractAddress, UserAddress>(disclose(recipient)));
+}
+
+// ── Shielded custody (C4 — S4/S6-proven OZ pattern) ─────────────────────────
+
+// Permissionless deposit. receiveShielded allocates the Merkle position in
+// this transaction; insertCoin persists the qualified coin for later spends.
+export circuit deposit_shielded(coin: ShieldedCoinInfo): [] {
+  receiveShielded(disclose(coin));
+  const c = disclose(coin.color);
+  if (coins.member(c)) {
+    const merged = mergeCoinImmediate(coins.lookup(c), disclose(coin));
+    coins.insertCoin(
+      c,
+      disclose(merged),
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+    );
+  } else {
+    coins.insertCoin(
+      c,
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+    );
+  }
+}
+
+// Device-authorised shielded withdrawal to a user's Zswap key.
+export circuit withdraw_shielded(
+  recipient: ZswapCoinPublicKey,
+  color:     Bytes<32>,
+  amount:    Uint<128>,
+): [] {
+  require_device();
+  const coin = coins.lookup(disclose(color));
+  const result = sendShielded(
+    disclose(coin),
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(amount),
+  );
+  if (disclose(result.change.is_some)) {
+    sendImmediateShielded(
+      disclose(result.change.value),
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+      disclose(result.change.value.value),
+    );
+    coins.insertCoin(
+      disclose(color),
+      result.change.value,
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+    );
+  } else {
+    coins.remove(disclose(color));
+  }
+}
+
+// Grant-authorised shielded withdrawal. Same OZ body as withdraw_shielded,
+// gated by the grant scope instead of a device.
+export circuit grant_withdraw_shielded(
+  recipient: ZswapCoinPublicKey,
+  color:     Bytes<32>,
+  amount:    Uint<128>,
+): [] {
+  require_grant(disclose(color), disclose(amount));
+  const coin = coins.lookup(disclose(color));
+  const result = sendShielded(
+    disclose(coin),
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(amount),
+  );
+  if (disclose(result.change.is_some)) {
+    sendImmediateShielded(
+      disclose(result.change.value),
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+      disclose(result.change.value.value),
+    );
+    coins.insertCoin(
+      disclose(color),
+      result.change.value,
+      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
+    );
+  } else {
+    coins.remove(disclose(color));
+  }
+}
+
+// ── Device management (C9-facing surface) ───────────────────────────────────
+//
+// Any active device is an admin (1-of-n). Lost-device recovery (P4) is
+// remove_device called from a surviving device.
+
+export circuit add_device(new_device: Field): [] {
+  require_device();
+  const d = disclose(new_device);
+  if (devices.member(d)) {
+    assert(devices.lookup(d) != device_epoch, "device already active");
+  }
+  devices.insert(d, device_epoch);
+  device_count = ((device_count + (1 as Uint<8>)) as Uint<8>);
+}
+
+export circuit remove_device(device: Field): [] {
+  require_device();
+  const d = disclose(device);
+  assert(device_count > (1 as Uint<8>), "cannot remove last device");
+  assert(devices.member(d), "unknown device");
+  assert(devices.lookup(d) == device_epoch, "device not active");
+  devices.remove(d);
+  device_count = ((device_count - (1 as Uint<8>)) as Uint<8>);
+}
+
+// ── Grant management (C11 lifecycle: issue / revoke) ────────────────────────
+
+export circuit add_grant(grant: Field, color: Bytes<32>, cap: Uint<128>): [] {
+  require_device();
+  const g = disclose(grant);
+  if (grants.member(g)) {
+    const old = grants.lookup(g);
+    assert(!old.active || old.epoch != device_epoch, "grant already active");
+  }
+  grants.insert(g, GrantInfo {
+    epoch:  device_epoch,
+    color:  disclose(color),
+    cap:    disclose(cap),
+    spent:  0 as Uint<128>,
+    active: true,
+  });
+}
+
+export circuit revoke_grant(grant: Field): [] {
+  require_device();
+  const g = disclose(grant);
+  assert(grants.member(g), "unknown grant");
+  const old = grants.lookup(g);
+  grants.insert(g, GrantInfo {
+    epoch:  old.epoch,
+    color:  old.color,
+    cap:    old.cap,
+    spent:  old.spent,
+    active: false,
+  });
+}
+
+// ── Total-loss recovery (C14) ───────────────────────────────────────────────
+//
+// Proves knowledge of the recovery secret, bumps the device epoch (which
+// invalidates every device and grant in one step), registers the fresh
+// device, and rotates the recovery secret. Assets stay where they are:
+// recovered account ↔ recovered assets (I-5.3) holds by construction under
+// contract-custody.
+
+export circuit recover(
+  new_device_commitment:   Field,
+  new_recovery_commitment: Field,
+  new_share_1: Bytes<32>,
+  new_share_2: Bytes<32>,
+  new_share_3: Bytes<32>,
+): [] {
+  const c = derive_recovery_commitment(recovery_secret());
+  assert(c == recovery, "invalid recovery secret");
+  device_epoch = ((device_epoch + (1 as Uint<32>)) as Uint<32>);
+  devices.insert(disclose(new_device_commitment), device_epoch);
+  device_count = 1 as Uint<8>;
+  recovery = disclose(new_recovery_commitment);
+  recovery_shares.insert(1 as Uint<8>, disclose(new_share_1));
+  recovery_shares.insert(2 as Uint<8>, disclose(new_share_2));
+  recovery_shares.insert(3 as Uint<8>, disclose(new_share_3));
+  round = ((round + (1 as Uint<64>)) as Uint<64>);
+}

--- a/experiments/account-custody-prototype/contracts/faucet.compact
+++ b/experiments/account-custody-prototype/contracts/faucet.compact
@@ -1,4 +1,4 @@
-pragma language_version 0.22;
+pragma language_version 0.23;
 
 import CompactStandardLibrary;
 

--- a/experiments/account-custody-prototype/contracts/faucet.compact
+++ b/experiments/account-custody-prototype/contracts/faucet.compact
@@ -1,0 +1,27 @@
+pragma language_version 0.22;
+
+import CompactStandardLibrary;
+
+// ---------------------------------------------------------------------------
+// Test-scaffolding faucet — NOT part of the custody design.
+//
+// Shielded tokens on a fresh localnet can only originate from a contract
+// mint (`mintShieldedToken`), so the integration tests and the demo app use
+// this faucet to hand the user a shielded note that can then be deposited
+// into the account-custody contract. Mirrors the S2 mint_and_send recipe
+// from contract-custody-feasibility.
+// ---------------------------------------------------------------------------
+
+export circuit mint_shielded(
+  color:     Bytes<32>,
+  amount:    Uint<64>,
+  nonce:     Bytes<32>,
+  recipient: ZswapCoinPublicKey,
+): [] {
+  mintShieldedToken(
+    disclose(color),
+    disclose(amount),
+    disclose(nonce),
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+  );
+}

--- a/experiments/account-custody-prototype/infra/docker-compose.macos.yml
+++ b/experiments/account-custody-prototype/infra/docker-compose.macos.yml
@@ -1,0 +1,35 @@
+# macOS override — bridge networking with port mappings.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+
+services:
+  node:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "9944:9944"
+      - "30333:30333"
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9944/health']
+
+  indexer:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "8088:8088"
+    environment:
+      APP__INFRA__NODE__URL: 'ws://node:9944'
+    depends_on:
+      node:
+        condition: service_healthy
+
+  proof-server:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "6300:6300"
+
+networks:
+  midnight:
+    driver: bridge

--- a/experiments/account-custody-prototype/infra/docker-compose.macos.yml
+++ b/experiments/account-custody-prototype/infra/docker-compose.macos.yml
@@ -20,6 +20,10 @@ services:
       - "8088:8088"
     environment:
       APP__INFRA__NODE__URL: 'ws://node:9944'
+      # indexer ≥4.3 runs a second (SPO) node connection with its own URL;
+      # without this it dials localhost inside the bridge network and the
+      # whole indexer exits once its reconnect budget runs out (~5 min).
+      APP__INFRA__SPO_NODE__URL: 'ws://node:9944'
     depends_on:
       node:
         condition: service_healthy

--- a/experiments/account-custody-prototype/infra/docker-compose.yml
+++ b/experiments/account-custody-prototype/infra/docker-compose.yml
@@ -12,7 +12,7 @@ name: account-custody-prototype
 
 services:
   node:
-    image: 'midnightntwrk/midnight-node:0.22.5'
+    image: 'midnightntwrk/midnight-node:1.0.0'
     network_mode: host
     cap_drop:
       - ALL
@@ -33,7 +33,7 @@ services:
       SIDECHAIN_BLOCK_BENEFICIARY: '04bcf7ad3be7a5c790460be82a713af570f22e0f801f6659ab8e84a52be6969e'
 
   indexer:
-    image: 'midnightntwrk/indexer-standalone:4.2.1'
+    image: 'midnightntwrk/indexer-standalone:4.3.3'
     network_mode: host
     cap_drop:
       - ALL
@@ -47,6 +47,9 @@ services:
       RUST_LOG: 'indexer=info,chain_indexer=info,indexer_api=info,info'
       APP__INFRA__NODE__URL: 'ws://localhost:9944'
       APP__APPLICATION__NETWORK_ID: 'undeployed'
+      # Required non-empty since indexer 4.3.x; SPO features are unused on
+      # the localnet, any placeholder is accepted (see the image's config.yaml).
+      APP__INFRA__SPO_NODE__BLOCKFROST_ID: 'dummy-not-using-spo'
     healthcheck:
       test: ['CMD-SHELL', 'cat /var/run/indexer-standalone/running']
       interval: 5s
@@ -58,7 +61,7 @@ services:
         condition: service_healthy
 
   proof-server:
-    image: 'midnightntwrk/proof-server:8.0.3'
+    image: 'midnightntwrk/proof-server:8.1.0'
     network_mode: host
     cap_drop:
       - ALL

--- a/experiments/account-custody-prototype/infra/docker-compose.yml
+++ b/experiments/account-custody-prototype/infra/docker-compose.yml
@@ -1,0 +1,75 @@
+# Midnight local devnet — node + indexer + proof-server.
+# Run: docker compose up -d
+# macOS: docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+#
+# Image versions are pinned to those used by experiments/redjubjub-wallet/.
+#
+# The explicit project name keeps this stack's containers and volumes
+# separate from other experiments whose compose dir is also named `infra`
+# (a shared default project name means a shared — and stale — chain volume).
+
+name: account-custody-prototype
+
+services:
+  node:
+    image: 'midnightntwrk/midnight-node:0.22.5'
+    network_mode: host
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+    volumes:
+      - node-data:/data
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9944/health']
+      interval: 2s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    environment:
+      CFG_PRESET: 'dev'
+      SIDECHAIN_BLOCK_BENEFICIARY: '04bcf7ad3be7a5c790460be82a713af570f22e0f801f6659ab8e84a52be6969e'
+
+  indexer:
+    image: 'midnightntwrk/indexer-standalone:4.2.1'
+    network_mode: host
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - indexer-data:/data
+    env_file:
+      - .env
+    environment:
+      RUST_LOG: 'indexer=info,chain_indexer=info,indexer_api=info,info'
+      APP__INFRA__NODE__URL: 'ws://localhost:9944'
+      APP__APPLICATION__NETWORK_ID: 'undeployed'
+    healthcheck:
+      test: ['CMD-SHELL', 'cat /var/run/indexer-standalone/running']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+    depends_on:
+      node:
+        condition: service_healthy
+
+  proof-server:
+    image: 'midnightntwrk/proof-server:8.0.3'
+    network_mode: host
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      disable: true
+    environment:
+      RUST_BACKTRACE: 'full'
+      EXTRA_ARGS: -v
+
+volumes:
+  node-data:
+  indexer-data:

--- a/experiments/account-custody-prototype/package-lock.json
+++ b/experiments/account-custody-prototype/package-lock.json
@@ -1,0 +1,4462 @@
+{
+  "name": "account-custody-prototype",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "account-custody-prototype",
+      "version": "0.1.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-runtime": "^0.15.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+        "@midnight-ntwrk/wallet-api": "^5.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+        "@midnight-ntwrk/zswap": "^4.0.0",
+        "bip39": "^3.1.0",
+        "rxjs": "^7.8.2",
+        "ws": "^8.19.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.3.tgz",
+      "integrity": "sha512-+auRYBXow2v7cT+wKzvjyMyyEojq+G7Sf80vIR57rtEPcxRFuMXuU9IKjwxZ3muclUgdGKwZXNeuki+g0GabgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0 || ^17.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
+      "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.4",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@midnight-ntwrk/compact-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.1.tgz",
+      "integrity": "sha512-UO0+tDiRadYFO2kaUu9PIhAOISvDKvmiyh9vSOyKEZLj3AUAY1qmmHm/oQrzPqrkiWHO0Rnln/j/zZ5dvc5vxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/platform-js": "^2.2.4",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-js/node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
+      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.15.0.tgz",
+      "integrity": "sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/ledger-v8": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger-v8/-/ledger-v8-8.1.0.tgz",
+      "integrity": "sha512-rwOVP5kBwACpYmmY6+oLeaiM3e5gHscRMjbZUOntOC5QdtqLdpeep6eQW1OngI+sxjjdVoGg2eE16sLf+DAHmQ=="
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-contracts": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-contracts/-/midnight-js-contracts-4.1.1.tgz",
+      "integrity": "sha512-vHeKyaj9RXTx+Cep3YpIRgg2EWkzibO4gxI7k/rYpXmGXc3waetrR5sb9FPR7v9SUX00/zf/sYbLp1NZhwZbjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-http-client-proof-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-http-client-proof-provider/-/midnight-js-http-client-proof-provider-4.1.1.tgz",
+      "integrity": "sha512-Q2VNRTvuWlf3MbjV7C3asuLHeFwtZMdh6t5Z+u8c8RDpejW9GhKaSjlJ2zgJII5ckE8/cocPEDwt3GKBebGHWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "cross-fetch": "^4.1.0",
+        "fetch-retry": "^6.0.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-indexer-public-data-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-indexer-public-data-provider/-/midnight-js-indexer-public-data-provider-4.1.1.tgz",
+      "integrity": "sha512-50CjiYqw/msRintyfkuNrJl1v4Zj+AaBFmV2uLjY/zpkPop4VBFH4QZSrtKsG1ljT9vzWsxU7Eo4Tn1tgKkPlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apollo/client": "^4.2.0",
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^4.1.0",
+        "graphql": "^16.14.0",
+        "graphql-ws": "^6.0.8",
+        "isomorphic-ws": "^5.0.0",
+        "rxjs": "^7.8.2",
+        "ws": "^8.20.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-level-private-state-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-level-private-state-provider/-/midnight-js-level-private-state-provider-4.1.1.tgz",
+      "integrity": "sha512-i+1lXJ4rcRGERnOPXHc3/Oh5ef7X/yb6p51bOAUjITazdPPcuU8qTeTeFgX+lPhWTGxROb9/pgrrVPH9G0FxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "abstract-level": "^3.1.1",
+        "buffer": "^6.0.3",
+        "level": "^10.0.0",
+        "superjson": "^2.2.6"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-network-id": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-4.1.1.tgz",
+      "integrity": "sha512-g49IBK0In1Jt2wKgi18rUvoy1ShGVrfb/VvgWALkc9Noc6+4MX5NTLVg5zqu+CyO2waIGb5lqDPnAhTD9wPAOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-node-zk-config-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-node-zk-config-provider/-/midnight-js-node-zk-config-provider-4.1.1.tgz",
+      "integrity": "sha512-fbBhLBhU/BjrQRnRJCcmKkhYRLlSqJyXEhq72vMS6vlKXprmDmAjlVV62+bn1aiAlNY9FXl1rrrMUFKQUmuZFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-protocol": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-protocol/-/midnight-js-protocol-4.1.1.tgz",
+      "integrity": "sha512-JH1010ir3YrawKsA4C08aIXWpFGHrCrAaBkZFbn+xh+iwOX5Ss0WU4//mDSEnHvQN0wD6GTc2JwUfKYFaS2CcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-js": "2.5.1",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "8.1.0",
+        "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+        "@midnight-ntwrk/platform-js": "2.2.4"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-protocol/node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
+      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-types/-/midnight-js-types-4.1.1.tgz",
+      "integrity": "sha512-MPT7YToXN2EsDtOOVSJonYZSZ4eqmdVgftBfH56w+tmZM0sZt9u+Mq18uuBQl9ebpTXnp8o7WqeISbgPMxTBcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "effect": "^3.20.0",
+        "pino": "^10.3.1",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-utils/-/midnight-js-utils-4.1.1.tgz",
+      "integrity": "sha512-b65QADd2FaZbWXe9D3fe9mSGmPlP1DTRMGSruJqhl9fOTNxBhQIzIKs0j/eL9Kv77dVeGDYgQdbV+JkDj3j5Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/onchain-runtime-v3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/onchain-runtime-v3/-/onchain-runtime-v3-3.0.0.tgz",
+      "integrity": "sha512-HbFbUOsvgpEFy1OT0Ni2LMFk4jnMQS1em+H+Mof/B3DpnNKl0Lkx5QiulKOc6pyU4KPEagOqx4fYNyVXFwgZ7g=="
+    },
+    "node_modules/@midnight-ntwrk/platform-js": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/platform-js/-/platform-js-2.2.4.tgz",
+      "integrity": "sha512-6mrYKSSE8kPgn/5rQ2xofDJk1yAZZRdLOO6Yelweuh5GOnOGz7Qw4venDG/c4TRqtV9ouFp+F5j7ta8aprMinw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-api/-/wallet-api-5.0.0.tgz",
+      "integrity": "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/zswap": "^4.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "7.x"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-abstractions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-abstractions/-/wallet-sdk-abstractions-2.1.0.tgz",
+      "integrity": "sha512-mMcHFBrNxlZhurknS9J979HhrHQ0EsKdm6Kwaq7SAk/tStLOU2/sAoQzLUzzxr8Y60PcilTJdIKhaCgaydPATg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-address-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-3.1.2.tgz",
+      "integrity": "sha512-SRkgwmKFOZSUR25iurAB8U7kTKF7AljSl+tMkuuj8Pthc/l0yIg+/q1rFSozJ0Nz9FJRhshazDyrL0l84fOabg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@scure/base": "^2.0.0",
+        "@subsquid/scale-codec": "^4.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-capabilities": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-3.3.1.tgz",
+      "integrity": "sha512-V//D0wEKN0++XE+pKsXy6U5aH5/1+AoLdCl7Zp1RZilrdABffiywbJ0ZER/ePiTCG93ltDTz7L73WDyEJy6wPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-node-client": "^1.1.2",
+        "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-dust-wallet/-/wallet-sdk-dust-wallet-4.1.0.tgz",
+      "integrity": "sha512-RA+Zvb3a4LmyxMFOuHJUZ2I7WbtDHLyKVk1++4q/w3WH/G9dMMyv0H/dxsxjSnIlX9km1Ibf6dxYN4I3fmG9XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-facade": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-facade/-/wallet-sdk-facade-4.0.1.tgz",
+      "integrity": "sha512-m1AgeoS+jQrj2h5jQRIKv4UT61sWBF5S5PtzGi8/gweug3XYqPlkxJBZKZzS2078QDi9ToH/epWQeoUEqzKhvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.1",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.1.0",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-hd": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-hd/-/wallet-sdk-hd-3.0.2.tgz",
+      "integrity": "sha512-GdzZsfURF4WBh+bmSiimwOnj2vLjtd1pvMUJjRtY3OOnnr1mSesuX9//UPzb0fCjU1ZMCNb6UK7M2YcI4Gef4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-indexer-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-indexer-client/-/wallet-sdk-indexer-client-1.2.2.tgz",
+      "integrity": "sha512-GokfgV1lOhF1h341cuglp1VoTT/+yEDuYIbiPex29JJkFrjOXdJfCKPoROySBtyIyI65lnEBAXBT0+AOBjPzhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "graphql": "^16.13.0",
+        "graphql-http": "^1.22.4",
+        "graphql-ws": "^6.0.7"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-node-client": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-node-client/-/wallet-sdk-node-client-1.1.2.tgz",
+      "integrity": "sha512-nV6lg1M0QQOGss9JiofwO3+bcI+kQIoGV36F+KwyDMgUjAH2nT2/m3SbhLDGizwvJwgniWMuZQV6k/YZ7nCcWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@polkadot/api": "^16.5.4",
+        "@polkadot/types": "^16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@types/bn.js": "^5.2.0",
+        "bn.js": "^5.2.3",
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-prover-client/-/wallet-sdk-prover-client-1.2.2.tgz",
+      "integrity": "sha512-Xbniz3S/ab1uxiEJd3OaBxLkDfygPIAWgNZfApwAeac/U8yUVUjrqJ9aWyruztMY2MZHN7QxUjlcAWDK84hX3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.96.0",
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "web-worker": "^1.5.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client/node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-runtime": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-runtime/-/wallet-sdk-runtime-1.0.4.tgz",
+      "integrity": "sha512-Sc3mAkiCCNSI/BCrOtPoQDb+1rZlcr/Is9w90hRJJ8XT/7kdcmoekoctupXBLtc5UCeDX1FqUs2hz60CnwLoZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-shielded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-shielded/-/wallet-sdk-shielded-3.0.1.tgz",
+      "integrity": "sha512-/jNIXz1T4JvJNG67s1tODTPqb2lnBAZ2TuocZQmFj9N0hG2LYtA35Tm6sFUpy68HfPnxdyEWarK27Wj0VRbEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-unshielded-wallet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-unshielded-wallet/-/wallet-sdk-unshielded-wallet-3.1.0.tgz",
+      "integrity": "sha512-GujzejaxF7Z1Pqmfp2uyz2mmtLb4ImIoL4njeh+3XLeSfJLedpizXi2WrHmcINO/z4x3pXTw3qU98dF04j97eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-utilities": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-utilities/-/wallet-sdk-utilities-1.2.0.tgz",
+      "integrity": "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/zkir-v2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zkir-v2/-/zkir-v2-2.1.0.tgz",
+      "integrity": "sha512-UDMujjzCt0SA89uqOFWUL4LZTkxVAS8JjvOaYMAgxlSrWfN7m5th1R1qGlpDJuSH39rbWt6WwtuK3k08Mta6LA=="
+    },
+    "node_modules/@midnight-ntwrk/zswap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zswap/-/zswap-4.0.0.tgz",
+      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@subsquid/scale-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.1.tgz",
+      "integrity": "sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2"
+      }
+    },
+    "node_modules/@subsquid/util-internal-hex": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==",
+      "license": "GPL-3.0-or-later"
+    },
+    "node_modules/@subsquid/util-internal-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.3.tgz",
+      "integrity": "sha512-H5qW5kG20IzVMpb7GhPbVRxGuACEf1DPIXE1+LNXYxt8t/GX4zQREQWHRvCB3lck+RORLJD3WJbQUtxN5UYB3Q==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/abstract-level": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-3.1.1.tgz",
+      "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^6.2.0",
+        "level-transcoder": "^1.0.1",
+        "maybe-combine-errors": "^1.0.0",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/browser-level": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-3.0.0.tgz",
+      "integrity": "sha512-kGXtLh29jMwqKaskz5xeDLtCtN1KBz/DbQSqmvH7QdJiyGRC7RAM8PPg6gvUiNMa+wVnaxS9eSmEtP/f5ajOVw==",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-3.0.0.tgz",
+      "integrity": "sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+      "integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
+      "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/level": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-10.0.0.tgz",
+      "integrity": "sha512-aZJvdfRr/f0VBbSRF5C81FHON47ZsC2TkGxbBezXpGGXAUEL/s6+GP73nnhAYRSCIqUNsmJjfeOF4lzRDKbUig==",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0",
+        "browser-level": "^3.0.0",
+        "classic-level": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-6.2.0.tgz",
+      "integrity": "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maybe-combine-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
+      "integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "license": "MIT"
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/experiments/account-custody-prototype/package-lock.json
+++ b/experiments/account-custody-prototype/package-lock.json
@@ -8,7 +8,7 @@
       "name": "account-custody-prototype",
       "version": "0.1.0",
       "dependencies": {
-        "@midnight-ntwrk/compact-runtime": "^0.15.0",
+        "@midnight-ntwrk/compact-runtime": "^0.16.0",
         "@midnight-ntwrk/ledger-v8": "^8.0.3",
         "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
         "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
@@ -560,21 +560,10 @@
         "tslib": "^2.8.1"
       }
     },
-    "node_modules/@midnight-ntwrk/compact-js/node_modules/@midnight-ntwrk/compact-runtime": {
+    "node_modules/@midnight-ntwrk/compact-runtime": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
       "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
-        "@types/object-inspect": "^1.8.1",
-        "object-inspect": "^1.12.3"
-      }
-    },
-    "node_modules/@midnight-ntwrk/compact-runtime": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.15.0.tgz",
-      "integrity": "sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
@@ -679,17 +668,6 @@
         "@midnight-ntwrk/ledger-v8": "8.1.0",
         "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
         "@midnight-ntwrk/platform-js": "2.2.4"
-      }
-    },
-    "node_modules/@midnight-ntwrk/midnight-js-protocol/node_modules/@midnight-ntwrk/compact-runtime": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
-      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
-        "@types/object-inspect": "^1.8.1",
-        "object-inspect": "^1.12.3"
       }
     },
     "node_modules/@midnight-ntwrk/midnight-js-types": {

--- a/experiments/account-custody-prototype/package.json
+++ b/experiments/account-custody-prototype/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "account-custody-prototype",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Prototype of the Passport account-custody contract (C1/C4) with hash-preimage device auth, scoped grants (C10), and PVSS-placeholder recovery (C14).",
+  "scripts": {
+    "compile": "compact compile contracts/account.compact contracts/managed/account && compact compile contracts/faucet.compact contracts/managed/faucet",
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "deploy": "tsx src/tests/deploy.ts",
+    "test:lifecycle": "tsx src/tests/lifecycle-night.ts",
+    "test:shielded": "tsx src/tests/lifecycle-shielded.ts",
+    "test:grants": "tsx src/tests/lifecycle-grants.ts",
+    "test:recovery": "tsx src/tests/lifecycle-recovery.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "@midnight-ntwrk/compact-runtime": "^0.15.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0",
+    "bip39": "^3.1.0",
+    "rxjs": "^7.8.2",
+    "ws": "^8.19.0"
+  }
+}

--- a/experiments/account-custody-prototype/package.json
+++ b/experiments/account-custody-prototype/package.json
@@ -23,7 +23,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-runtime": "^0.15.0",
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
     "@midnight-ntwrk/ledger-v8": "^8.0.3",
     "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
     "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",

--- a/experiments/account-custody-prototype/run-all.sh
+++ b/experiments/account-custody-prototype/run-all.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# run-all.sh — bring up the localnet, compile, unit-test, and run every
+# integration lifecycle scenario.
+#
+# Prerequisites: Docker, Node.js >= 22, `compact` on PATH, openssl.
+#
+# Usage:
+#   ./run-all.sh                       # everything
+#   ./run-all.sh --fresh               # reset chain state first
+#   ./run-all.sh --tests night,grants  # subset of integration scenarios
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$SCRIPT_DIR/infra"
+
+FRESH=false
+TESTS=""
+for arg in "${@:-}"; do
+  case $arg in
+    --fresh) FRESH=true ;;
+    --tests=*) TESTS="${arg#--tests=}" ;;
+    --tests) shift; TESTS="${1:-}";;
+  esac
+done
+
+ALL_TESTS=(night grants shielded recovery)
+if [[ -n "$TESTS" ]]; then
+  IFS=',' read -r -a SELECTED <<< "$TESTS"
+else
+  SELECTED=("${ALL_TESTS[@]}")
+fi
+
+check_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found"; exit 1; }; }
+check_cmd docker
+check_cmd node
+check_cmd openssl
+check_cmd compact
+
+# ── infra/.env ──────────────────────────────────────────────────────────────
+
+if [[ ! -f "$INFRA_DIR/.env" ]]; then
+  SECRET=$(openssl rand -hex 32)
+  sed "s/^APP__INFRA__SECRET=$/APP__INFRA__SECRET=$SECRET/" "$SCRIPT_DIR/.env.example" > "$INFRA_DIR/.env"
+  echo "infra/.env created (APP__INFRA__SECRET generated)"
+fi
+
+set -a
+source "$INFRA_DIR/.env"
+set +a
+export MIDNIGHT_NETWORK=local
+
+# ── Build ───────────────────────────────────────────────────────────────────
+
+cd "$SCRIPT_DIR"
+echo "Installing npm dependencies..."
+npm install --silent
+
+echo "Compiling Compact contracts..."
+npm run compile
+
+# ── Compose ─────────────────────────────────────────────────────────────────
+
+COMPOSE_FILES="-f $INFRA_DIR/docker-compose.yml"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  COMPOSE_FILES="$COMPOSE_FILES -f $INFRA_DIR/docker-compose.macos.yml"
+fi
+
+if $FRESH; then
+  echo "Resetting chain state..."
+  docker compose $COMPOSE_FILES down -v || true
+fi
+
+echo "Starting localnet..."
+docker compose $COMPOSE_FILES up -d --wait
+
+# ── Unit tests ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Running unit tests (simulator)..."
+npx vitest run
+
+# ── Integration scenarios ───────────────────────────────────────────────────
+
+FAILED=()
+for t in "${SELECTED[@]}"; do
+  echo ""
+  echo "Running lifecycle-$t..."
+  npx tsx "src/tests/lifecycle-$t.ts" || FAILED+=("$t")
+done
+
+echo ""
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "FAILED scenarios: ${FAILED[*]}"
+  exit 1
+fi
+echo "All scenarios passed."

--- a/experiments/account-custody-prototype/src/node/setup.ts
+++ b/experiments/account-custody-prototype/src/node/setup.ts
@@ -1,0 +1,117 @@
+// Deploy-or-connect helpers for the integration tests.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CompiledContract } from '@midnight-ntwrk/compact-js';
+import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+
+import * as FaucetModule from '../../contracts/managed/faucet/contract/index.js';
+import { Contract } from '../wallet/contract.js';
+import { makeWitnesses } from '../wallet/witnesses.js';
+import { PassportAccount, type AccountSecrets } from '../wallet/account.js';
+import {
+  createWallet,
+  createProviders,
+  syncWallet,
+  zkConfigPath,
+  faucetZkConfigPath,
+  type WalletContext,
+} from './wallet.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEPLOYMENT_FILE = path.resolve(__dirname, '..', '..', 'deployment.json');
+
+export function compiledAccountContract() {
+  return CompiledContract.make('account', Contract).pipe(
+    CompiledContract.withWitnesses(makeWitnesses()),
+    CompiledContract.withCompiledFileAssets(zkConfigPath),
+  );
+}
+
+export interface TestContext {
+  walletCtx: WalletContext;
+  providers: any;
+}
+
+export async function setupWallet(seed?: string): Promise<TestContext> {
+  const walletSeed = seed ?? process.env.WALLET_SEED;
+  if (!walletSeed) throw new Error('WALLET_SEED env var required');
+  if (!fs.existsSync(path.join(zkConfigPath, 'contract', 'index.js'))) {
+    throw new Error('Contract not compiled. Run: npm run compile');
+  }
+  const walletCtx = await createWallet(walletSeed);
+  await syncWallet(walletCtx, 'funding-wallet');
+  const providers = await createProviders(walletCtx);
+  return { walletCtx, providers };
+}
+
+export async function deployAccount(
+  ctx: TestContext,
+  secrets: { deviceSecret: Uint8Array; recoverySecret: Uint8Array },
+): Promise<PassportAccount> {
+  const account = await PassportAccount.deploy(ctx.providers, compiledAccountContract(), secrets);
+  fs.writeFileSync(
+    DEPLOYMENT_FILE,
+    JSON.stringify(
+      { contractAddress: account.address, deployedAt: new Date().toISOString() },
+      null,
+      2,
+    ),
+  );
+  return account;
+}
+
+export async function connectAccount(
+  ctx: TestContext,
+  address: string,
+  secrets: AccountSecrets,
+): Promise<PassportAccount> {
+  return PassportAccount.connect(ctx.providers, compiledAccountContract(), address, secrets);
+}
+
+export function savedDeploymentAddress(): string | null {
+  if (!fs.existsSync(DEPLOYMENT_FILE)) return null;
+  return JSON.parse(fs.readFileSync(DEPLOYMENT_FILE, 'utf-8')).contractAddress;
+}
+
+// ── Faucet (test scaffolding — shielded-token origin on localnet) ───────────
+
+export function compiledFaucetContract() {
+  return CompiledContract.make('faucet', (FaucetModule as any).Contract).pipe(
+    CompiledContract.withVacantWitnesses,
+    CompiledContract.withCompiledFileAssets(faucetZkConfigPath),
+  );
+}
+
+export interface FaucetHandle {
+  address: string;
+  providers: any;
+  mint: (
+    color: Uint8Array,
+    amount: bigint,
+    nonce: Uint8Array,
+    recipientCoinPublicKey: Uint8Array,
+  ) => Promise<string>;
+}
+
+export async function deployFaucet(walletCtx: WalletContext): Promise<FaucetHandle> {
+  const providers = await createProviders(walletCtx, faucetZkConfigPath);
+  const deployed = await deployContract(providers, {
+    compiledContract: compiledFaucetContract(),
+    privateStateId: 'faucet',
+    initialPrivateState: {},
+  } as any);
+  const address = deployed.deployTxData.public.contractAddress;
+  return {
+    address,
+    providers,
+    mint: async (color, amount, nonce, recipientCoinPublicKey) => {
+      const r = await (deployed as any).callTx.mint_shielded(color, amount, nonce, {
+        bytes: recipientCoinPublicKey,
+      });
+      return r?.public?.txId ?? r?.public?.transactionHash;
+    },
+  };
+}

--- a/experiments/account-custody-prototype/src/node/wallet.ts
+++ b/experiments/account-custody-prototype/src/node/wallet.ts
@@ -1,0 +1,219 @@
+// Node-side provider and wallet plumbing — adapted from
+// experiments/contract-custody-feasibility/src/{utils,common}.ts.
+//
+// The funding wallet (genesis-seeded on the local devnet) pays Dust fees and
+// supplies Night for deposits. Fee handling is explicitly out of scope for
+// the custody prototype (C24).
+
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { WebSocket } from 'ws';
+import * as Rx from 'rxjs';
+import { Buffer } from 'node:buffer';
+
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { setNetworkId, getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
+import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  PublicKey,
+  UnshieldedWallet,
+} from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+
+// InMemoryTransactionHistoryStorage was removed from
+// @midnight-ntwrk/wallet-sdk-unshielded-wallet@3; supply a no-op stub.
+const NoopTxHistoryStorage = {
+  upsert: async (..._args: unknown[]) => undefined,
+  get: async (..._args: unknown[]) => null,
+  delete: async (..._args: unknown[]) => undefined,
+  list: async (..._args: unknown[]) => [] as unknown[],
+  clear: async (..._args: unknown[]) => undefined,
+};
+
+// Workaround for ledger-v8 bug: MerkleTree::collapse panics on non-empty
+// trees when producing shielded outputs. Inherited from redjubjub-wallet /
+// contract-custody-feasibility; drop when verified fixed upstream.
+const _origTryApply = (ledger.ZswapChainState.prototype as any).tryApply;
+(ledger.ZswapChainState.prototype as any).tryApply = function (...args: unknown[]) {
+  try {
+    return _origTryApply.apply(this, args as any);
+  } catch {
+    return [this, new Map()];
+  }
+};
+
+// Enable WebSocket for GraphQL subscriptions.
+// @ts-expect-error required for wallet sync
+globalThis.WebSocket = WebSocket;
+
+const NETWORK = process.env.MIDNIGHT_NETWORK ?? 'local';
+
+const CONFIGS: Record<
+  string,
+  { networkId: string; indexer: string; indexerWS: string; node: string; proofServer: string }
+> = {
+  local: {
+    networkId: 'undeployed',
+    indexer: 'http://localhost:8088/api/v4/graphql',
+    indexerWS: 'ws://localhost:8088/api/v4/graphql/ws',
+    node: 'http://localhost:9944',
+    proofServer: 'http://127.0.0.1:6300',
+  },
+};
+
+export const CONFIG = CONFIGS[NETWORK] ?? CONFIGS.local;
+setNetworkId(CONFIG.networkId as any);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const managedPath = path.resolve(__dirname, '..', '..', 'contracts', 'managed');
+export const zkConfigPath = path.join(managedPath, 'account');
+export const faucetZkConfigPath = path.join(managedPath, 'faucet');
+
+export function deriveKeys(seed: string) {
+  const hdWallet = HDWallet.fromSeed(Buffer.from(seed, 'hex'));
+  if (hdWallet.type !== 'seedOk') throw new Error('Invalid seed');
+
+  const result = hdWallet.hdWallet
+    .selectAccount(0)
+    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
+    .deriveKeysAt(0);
+
+  if (result.type !== 'keysDerived') throw new Error('Key derivation failed');
+
+  hdWallet.hdWallet.clear();
+  return result.keys;
+}
+
+export async function createWallet(seed: string) {
+  const keys = deriveKeys(seed);
+  const networkId = getNetworkId();
+
+  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(keys[Roles.Zswap]);
+  const dustSecretKey = ledger.DustSecretKey.fromSeed(keys[Roles.Dust]);
+  const unshieldedKeystore = createKeystore(keys[Roles.NightExternal], networkId);
+
+  const feeBlocksMargin = Number(process.env.FEE_BLOCKS_MARGIN ?? '100');
+
+  const configuration = {
+    networkId,
+    indexerClientConnection: {
+      indexerHttpUrl: CONFIG.indexer,
+      indexerWsUrl: CONFIG.indexerWS,
+    },
+    provingServerUrl: new URL(CONFIG.proofServer),
+    relayURL: new URL(CONFIG.node.replace(/^http/, 'ws')),
+    costParameters: {
+      feeBlocksMargin,
+    },
+    txHistoryStorage: NoopTxHistoryStorage,
+  };
+
+  const wallet: WalletFacade = await (WalletFacade as any).init({
+    configuration,
+    shielded: (config: any) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    unshielded: (config: any) =>
+      UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: (config: any) =>
+      DustWallet(config).startWithSecretKey(
+        dustSecretKey,
+        ledger.LedgerParameters.initialParameters().dust,
+      ),
+  });
+
+  await wallet.start(shieldedSecretKeys, dustSecretKey);
+
+  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+}
+
+export type WalletContext = Awaited<ReturnType<typeof createWallet>>;
+
+export async function syncWallet(walletCtx: WalletContext, label: string): Promise<void> {
+  process.stdout.write(`Syncing ${label} to network`);
+  await Rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(
+      Rx.throttleTime(5_000),
+      Rx.tap(() => process.stdout.write(' .')),
+      Rx.filter((state) => state.isSynced === true),
+    ),
+  );
+  console.log('\nWallet synced.');
+}
+
+export async function createProviders(walletCtx: WalletContext, contractZkPath: string = zkConfigPath) {
+  const state = await Rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(Rx.filter((s) => s.isSynced)),
+  );
+
+  const signFn = (payload: Uint8Array) => walletCtx.unshieldedKeystore.signData(payload);
+
+  const walletProvider = {
+    getCoinPublicKey: () => state.shielded.coinPublicKey.toHexString(),
+    getEncryptionPublicKey: () => state.shielded.encryptionPublicKey.toHexString(),
+    async balanceTx(tx: any, ttl?: Date) {
+      const recipe = await walletCtx.wallet.balanceUnboundTransaction(
+        tx,
+        {
+          shieldedSecretKeys: walletCtx.shieldedSecretKeys,
+          dustSecretKey: walletCtx.dustSecretKey,
+        },
+        { ttl: ttl ?? new Date(Date.now() + 30 * 60 * 1000) },
+      );
+
+      const signed = await walletCtx.wallet.signRecipe(recipe, signFn);
+      return walletCtx.wallet.finalizeRecipe(signed);
+    },
+    submitTx: (tx: any) => walletCtx.wallet.submitTransaction(tx) as any,
+  };
+
+  const zkConfigProvider = new NodeZkConfigProvider(contractZkPath);
+
+  return {
+    privateStateProvider: levelPrivateStateProvider({
+      midnightDbName: `midnight-level-db`,
+      privateStateStoreName: 'account-custody-prototype',
+      privateStoragePasswordProvider: () => 'AccountCustody!prototype',
+      accountId: state.shielded.encryptionPublicKey.toHexString().slice(0, 16),
+    }),
+    publicDataProvider: indexerPublicDataProvider(CONFIG.indexer, CONFIG.indexerWS),
+    zkConfigProvider,
+    proofProvider: httpClientProofProvider(CONFIG.proofServer, zkConfigProvider),
+    walletProvider,
+    midnightProvider: walletProvider,
+  };
+}
+
+// The user's 32-byte unshielded address bytes, as the contract's
+// UserAddress argument expects them.
+export function userAddressBytes(walletCtx: WalletContext): Uint8Array {
+  const pk: any = walletCtx.unshieldedKeystore.getPublicKey();
+  const hex: string =
+    typeof pk?.toHexString === 'function'
+      ? pk.toHexString()
+      : typeof pk?.bytes === 'string'
+        ? pk.bytes
+        : pk?.bytes instanceof Uint8Array
+          ? Buffer.from(pk.bytes).toString('hex')
+          : String(pk);
+  const clean = hex.replace(/^0x/, '');
+  const out = new Uint8Array(32);
+  out.set(Buffer.from(clean, 'hex').subarray(0, 32));
+  return out;
+}
+
+// The user's Zswap coin public key bytes, as ZswapCoinPublicKey expects.
+export function coinPublicKeyBytes(state: any): Uint8Array {
+  const cpk = state.shielded.coinPublicKey;
+  const hex: string =
+    typeof cpk?.toHexString === 'function' ? cpk.toHexString() : String(cpk?.bytes ?? cpk);
+  const clean = hex.replace(/^0x/, '');
+  const out = new Uint8Array(32);
+  out.set(Buffer.from(clean, 'hex').subarray(0, 32));
+  return out;
+}

--- a/experiments/account-custody-prototype/src/tests/deploy.ts
+++ b/experiments/account-custody-prototype/src/tests/deploy.ts
@@ -1,0 +1,31 @@
+// Deploy the shared faucet for the demo app and save its address.
+// The demo app deploys account contracts itself at onboarding; the faucet
+// is the only piece of pre-deployed scaffolding it needs.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { setupWallet, deployFaucet } from '../node/setup.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FAUCET_FILE = path.resolve(__dirname, '..', '..', 'faucet-deployment.json');
+
+async function main() {
+  const ctx = await setupWallet();
+  console.log('Deploying faucet...');
+  const faucet = await deployFaucet(ctx.walletCtx);
+  fs.writeFileSync(
+    FAUCET_FILE,
+    JSON.stringify({ faucetAddress: faucet.address, deployedAt: new Date().toISOString() }, null, 2),
+  );
+  console.log(`Faucet deployed @ ${faucet.address}`);
+  console.log(`Saved to ${FAUCET_FILE}`);
+  await ctx.walletCtx.wallet.stop();
+  setTimeout(() => process.exit(0), 100).unref();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/experiments/account-custody-prototype/src/tests/lifecycle-grants.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-grants.ts
@@ -1,0 +1,70 @@
+// Scoped-grant lifecycle on localnet (C10/C11):
+//   issue grant (colour + cap) → grant-only client withdraws within cap →
+//   cumulative cap enforcement → revocation enforcement.
+
+import { firstValueFrom } from 'rxjs';
+
+import { runScenario, step, expectFailure, waitForLedger } from './runner.js';
+import { setupWallet, deployAccount, connectAccount } from '../node/setup.js';
+import { userAddressBytes } from '../node/wallet.js';
+import { randomBytes32, hexToBytes32 } from '../wallet/hex.js';
+import { grantCommitment } from '../wallet/contract.js';
+
+await runScenario('lifecycle-grants', async () => {
+  const ctx = await setupWallet();
+  const state: any = await firstValueFrom(ctx.walletCtx.wallet.state());
+  const held = Object.entries(state.unshielded.balances as Record<string, bigint>);
+  if (held.length === 0) throw new Error('funding wallet has no Night — genesis seed wrong?');
+  const [colorHex] = held[0];
+  const color = hexToBytes32(colorHex);
+  const recipient = userAddressBytes(ctx.walletCtx);
+
+  const device = randomBytes32();
+  const recovery = randomBytes32();
+  const grantSecret = randomBytes32();
+  const gc = grantCommitment(grantSecret);
+
+  step('deploy account + deposit 1000 Night');
+  const account = await deployAccount(ctx, { deviceSecret: device, recoverySecret: recovery });
+  console.log(`  account @ ${account.address}`);
+  await account.depositNight(color, 1000n);
+  await waitForLedger(account, 'deposit landed', (l) =>
+    l.night_balances.member(color) && l.night_balances.lookup(color) === 1000n,
+  );
+
+  step('issue grant: colour-scoped, cap 300');
+  await account.addGrant(grantSecret, color, 300n);
+  await waitForLedger(account, 'grant active', (l) => l.grants.member(gc) && l.grants.lookup(gc).active);
+
+  step('grant-only client withdraws 100 (within cap)');
+  const dapp = await connectAccount(ctx, account.address, { grantSecret });
+  await dapp.grantWithdrawNight(color, 100n, recipient);
+  await waitForLedger(account, 'spent = 100', (l) => l.grants.lookup(gc).spent === 100n);
+
+  step('cumulative cap: withdrawing 250 more must fail (100 + 250 > 300)');
+  await expectFailure(
+    'over-cap grant withdraw',
+    dapp.grantWithdrawNight(color, 250n, recipient),
+    /grant cap exceeded/,
+  );
+
+  step('grant cannot manage devices or grants');
+  await expectFailure(
+    'grant adding a grant',
+    dapp.addGrant(randomBytes32(), color, 50n),
+    /device_secret requested/,
+  );
+
+  step('revoke grant (device-authorised), further spends must fail');
+  await account.revokeGrantByCommitment(gc);
+  await waitForLedger(account, 'grant revoked', (l) => !l.grants.lookup(gc).active);
+  await expectFailure(
+    'revoked grant withdraw',
+    dapp.grantWithdrawNight(color, 10n, recipient),
+    /grant revoked/,
+  );
+
+  const final = await account.ledgerState();
+  console.log(`  final: balance ${final.night_balances.lookup(color)}, spent ${final.grants.lookup(gc).spent}`);
+  await ctx.walletCtx.wallet.stop();
+});

--- a/experiments/account-custody-prototype/src/tests/lifecycle-night.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-night.ts
@@ -1,0 +1,66 @@
+// Night custody lifecycle on localnet:
+//   deposit → withdraw (device A) → wrong-device rejection →
+//   add device B → withdraw from device B (P3 multi-device).
+
+import { firstValueFrom } from 'rxjs';
+
+import { runScenario, step, expectFailure, waitForLedger } from './runner.js';
+import { setupWallet, deployAccount, connectAccount } from '../node/setup.js';
+import { userAddressBytes } from '../node/wallet.js';
+import { randomBytes32, hexToBytes32 } from '../wallet/hex.js';
+import { deviceCommitment } from '../wallet/contract.js';
+
+await runScenario('lifecycle-night', async () => {
+  const ctx = await setupWallet();
+  const state: any = await firstValueFrom(ctx.walletCtx.wallet.state());
+  const held = Object.entries(state.unshielded.balances as Record<string, bigint>);
+  if (held.length === 0) throw new Error('funding wallet has no Night — genesis seed wrong?');
+  const [colorHex] = held[0];
+  const color = hexToBytes32(colorHex);
+  const recipient = userAddressBytes(ctx.walletCtx);
+
+  const deviceA = randomBytes32();
+  const recovery = randomBytes32();
+
+  step('deploy account');
+  const account = await deployAccount(ctx, { deviceSecret: deviceA, recoverySecret: recovery });
+  console.log(`  account @ ${account.address}`);
+
+  step('deposit 1000 Night');
+  await account.depositNight(color, 1000n);
+  await waitForLedger(account, 'night_balances = 1000', (l) =>
+    l.night_balances.member(color) && l.night_balances.lookup(color) === 1000n,
+  );
+
+  step('withdraw 400 Night (device A)');
+  await account.withdrawNight(color, 400n, recipient);
+  await waitForLedger(account, 'night_balances = 600', (l) =>
+    l.night_balances.lookup(color) === 600n,
+  );
+
+  step('withdraw with an unregistered device secret must fail');
+  const rogue = await connectAccount(ctx, account.address, { deviceSecret: randomBytes32() });
+  await expectFailure(
+    'rogue withdraw',
+    rogue.withdrawNight(color, 100n, recipient),
+    /unknown device/,
+  );
+
+  step('add device B (authorised by device A)');
+  const deviceB = randomBytes32();
+  await account.addDevice(deviceB);
+  await waitForLedger(account, 'device B registered', (l) =>
+    l.devices.member(deviceCommitment(deviceB)) && l.device_count === 2n,
+  );
+
+  step('withdraw 100 Night from device B');
+  const clientB = await connectAccount(ctx, account.address, { deviceSecret: deviceB });
+  await clientB.withdrawNight(color, 100n, recipient);
+  await waitForLedger(account, 'night_balances = 500', (l) =>
+    l.night_balances.lookup(color) === 500n,
+  );
+
+  const final = await account.ledgerState();
+  console.log(`  final round = ${final.round}, devices = ${final.device_count}`);
+  await ctx.walletCtx.wallet.stop();
+});

--- a/experiments/account-custody-prototype/src/tests/lifecycle-recovery.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-recovery.ts
@@ -1,0 +1,82 @@
+// Total-loss recovery lifecycle on localnet (C14):
+//   deploy → deposit → reconstruct the recovery secret from two of the
+//   three ON-CHAIN shares (TODO(PVSS): plaintext shares, prototype only) →
+//   recover with a fresh device → fresh device controls the assets →
+//   the lost device is locked out by the epoch bump.
+
+import { firstValueFrom } from 'rxjs';
+
+import { runScenario, step, expectFailure, waitForLedger } from './runner.js';
+import { setupWallet, deployAccount, connectAccount } from '../node/setup.js';
+import { userAddressBytes } from '../node/wallet.js';
+import { randomBytes32, hexToBytes32, bytesToHex } from '../wallet/hex.js';
+import { recoveryCommitment } from '../wallet/contract.js';
+import { reconstruct } from '../wallet/shamir.js';
+
+await runScenario('lifecycle-recovery', async () => {
+  const ctx = await setupWallet();
+  const state: any = await firstValueFrom(ctx.walletCtx.wallet.state());
+  const held = Object.entries(state.unshielded.balances as Record<string, bigint>);
+  if (held.length === 0) throw new Error('funding wallet has no Night — genesis seed wrong?');
+  const [colorHex] = held[0];
+  const color = hexToBytes32(colorHex);
+  const recipient = userAddressBytes(ctx.walletCtx);
+
+  const lostDevice = randomBytes32();
+  const recoverySecret = randomBytes32();
+
+  step('deploy account + deposit 500 Night');
+  const account = await deployAccount(ctx, { deviceSecret: lostDevice, recoverySecret });
+  console.log(`  account @ ${account.address}`);
+  await account.depositNight(color, 500n);
+  await waitForLedger(account, 'deposit landed', (l) =>
+    l.night_balances.member(color) && l.night_balances.lookup(color) === 500n,
+  );
+
+  step('TOTAL LOSS — reconstruct the recovery secret from on-chain shares 1 + 3');
+  const l = await account.ledgerState();
+  const reconstructed = reconstruct([
+    { index: 1, value: l.recovery_shares.lookup(1n) },
+    { index: 3, value: l.recovery_shares.lookup(3n) },
+  ]);
+  if (recoveryCommitment(reconstructed) !== l.recovery) {
+    throw new Error('reconstructed secret does not match the on-chain recovery commitment');
+  }
+  console.log(`  ✓ reconstructed secret matches commitment (${bytesToHex(reconstructed).slice(0, 12)}…)`);
+
+  step('recover with a fresh device + rotated recovery secret');
+  const freshDevice = randomBytes32();
+  const newRecoverySecret = randomBytes32();
+  const recoverer = await connectAccount(ctx, account.address, {
+    recoverySecret: reconstructed,
+  });
+  await recoverer.recover(freshDevice, newRecoverySecret);
+  await waitForLedger(account, 'device_epoch = 1', (l2) => l2.device_epoch === 1n);
+
+  step('fresh device controls the recovered account (assets followed, I-5.3)');
+  const recovered = await connectAccount(ctx, account.address, { deviceSecret: freshDevice });
+  await recovered.withdrawNight(color, 100n, recipient);
+  await waitForLedger(account, 'night_balances = 400', (l2) =>
+    l2.night_balances.lookup(color) === 400n,
+  );
+
+  step('the lost device is locked out');
+  const lost = await connectAccount(ctx, account.address, { deviceSecret: lostDevice });
+  await expectFailure(
+    'lost-device withdraw',
+    lost.withdrawNight(color, 10n, recipient),
+    /device of revoked epoch/,
+  );
+
+  step('old recovery secret no longer recovers');
+  const replayRecoverer = await connectAccount(ctx, account.address, {
+    recoverySecret: reconstructed,
+  });
+  await expectFailure(
+    'stale recovery',
+    replayRecoverer.recover(randomBytes32(), randomBytes32()),
+    /invalid recovery secret/,
+  );
+
+  await ctx.walletCtx.wallet.stop();
+});

--- a/experiments/account-custody-prototype/src/tests/lifecycle-shielded.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-shielded.ts
@@ -1,0 +1,58 @@
+// Shielded custody lifecycle on localnet (C4 — S4/S6-proven OZ pattern):
+//   faucet mints a shielded note to the user → user deposits it into the
+//   account contract → partial withdrawal (exercises the change path:
+//   sendShielded + sendImmediateShielded + insertCoin of the change).
+
+import { firstValueFrom } from 'rxjs';
+import { rawTokenType, encodeRawTokenType } from '@midnight-ntwrk/ledger-v8';
+
+import { runScenario, step, waitForLedger, sleep } from './runner.js';
+import { setupWallet, deployAccount, deployFaucet } from '../node/setup.js';
+import { coinPublicKeyBytes } from '../node/wallet.js';
+import { randomBytes32, hexToBytes32, bytesToHex } from '../wallet/hex.js';
+
+await runScenario('lifecycle-shielded', async () => {
+  const ctx = await setupWallet();
+  const state: any = await firstValueFrom(ctx.walletCtx.wallet.state());
+  const userCpk = coinPublicKeyBytes(state);
+
+  const domesticColor = hexToBytes32('06');
+  const amount = 500n;
+  const mintNonce = randomBytes32();
+
+  step('deploy faucet and mint 500 shielded to the user');
+  const faucet = await deployFaucet(ctx.walletCtx);
+  console.log(`  faucet @ ${faucet.address}`);
+  const mintTx = await faucet.mint(domesticColor, amount, mintNonce, userCpk);
+  console.log(`  mintTx = ${mintTx}`);
+
+  // On-chain colour: rawTokenType(domesticColor, faucetAddress) — the token
+  // type is bound to the minting contract.
+  const derivedRawHex = rawTokenType(domesticColor, faucet.address);
+  const color = encodeRawTokenType(derivedRawHex);
+  console.log(`  on-chain colour 0x${bytesToHex(color)}`);
+
+  console.log('  waiting 15s for the wallet to index the minted note...');
+  await sleep(15_000);
+
+  step('deploy account and deposit the shielded note');
+  const account = await deployAccount(ctx, {
+    deviceSecret: randomBytes32(),
+    recoverySecret: randomBytes32(),
+  });
+  console.log(`  account @ ${account.address}`);
+  await account.depositShielded({ nonce: mintNonce, color, value: amount });
+  await waitForLedger(account, 'contract holds the coin (value 500)', (l) =>
+    l.coins.member(color) && l.coins.lookup(color).value === 500n,
+  );
+
+  step('withdraw 200 shielded back to the user (change path)');
+  await account.withdrawShielded(userCpk, color, 200n);
+  await waitForLedger(account, 'change re-registered (value 300)', (l) =>
+    l.coins.member(color) && l.coins.lookup(color).value === 300n,
+  );
+
+  const final = await account.ledgerState();
+  console.log(`  final contract-held shielded value: ${final.coins.lookup(color).value}`);
+  await ctx.walletCtx.wallet.stop();
+});

--- a/experiments/account-custody-prototype/src/tests/runner.ts
+++ b/experiments/account-custody-prototype/src/tests/runner.ts
@@ -1,0 +1,84 @@
+// Minimal scenario runner for the localnet integration tests.
+
+import { PassportAccount } from '../wallet/account.js';
+import type { Ledger } from '../wallet/contract.js';
+
+export async function runScenario(name: string, fn: () => Promise<void>): Promise<void> {
+  console.log(`\n━━━ ${name} ━━━`);
+  let code = 0;
+  try {
+    await fn();
+    console.log(`\n◆ ${name}: PASS`);
+  } catch (e: any) {
+    console.error(e);
+    console.log(`\n◆ ${name}: FAIL — ${e?.message ?? e}`);
+    code = 1;
+  }
+  // Wallet/indexer subscriptions keep the event loop alive; force exit the
+  // same way contract-custody-feasibility's runner does.
+  setTimeout(() => process.exit(code), 100).unref();
+}
+
+export function step(label: string): void {
+  console.log(`\n── ${label}`);
+}
+
+/** Collect messages along the error cause chain for robust matching. */
+function errorText(e: any): string {
+  const parts: string[] = [];
+  let cur: any = e;
+  let guard = 0;
+  while (cur && guard++ < 8) {
+    parts.push(String(cur?.message ?? cur));
+    cur = cur?.cause;
+  }
+  return parts.join(' | ');
+}
+
+/** Await a call that MUST fail, with a message matching `pattern`. */
+export async function expectFailure(
+  label: string,
+  p: Promise<unknown>,
+  pattern: RegExp,
+): Promise<void> {
+  try {
+    await p;
+  } catch (e: any) {
+    const text = errorText(e);
+    if (pattern.test(text)) {
+      console.log(`  ✓ ${label}: rejected as expected (${pattern})`);
+      return;
+    }
+    throw new Error(`${label}: failed with unexpected error: ${text}`);
+  }
+  throw new Error(`${label}: expected failure but the call succeeded`);
+}
+
+/** Poll the account's ledger until `predicate` holds. */
+export async function waitForLedger(
+  account: PassportAccount,
+  label: string,
+  predicate: (l: Ledger) => boolean,
+  timeoutMs = 120_000,
+): Promise<Ledger> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      const l = await account.ledgerState();
+      if (predicate(l)) {
+        console.log(`  ✓ ledger: ${label}`);
+        return l;
+      }
+    } catch {
+      // contract state may not be indexed yet
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for ledger condition: ${label}`);
+    }
+    await sleep(3_000);
+  }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/experiments/account-custody-prototype/src/wallet/account.ts
+++ b/experiments/account-custody-prototype/src/wallet/account.ts
@@ -1,0 +1,190 @@
+// PassportAccount — the high-level client API over a deployed
+// account-custody contract instance. Platform-neutral: the caller supplies
+// providers and a CompiledContract prepared for its platform (Node file
+// assets vs browser fetch assets).
+
+import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+
+import { deviceCommitment, grantCommitment, recoveryCommitment, ledger, type Ledger } from './contract.js';
+import { privateStateFromSecrets, type AccountPrivateState } from './witnesses.js';
+import { split, type Share } from './shamir.js';
+import { bytesToHex } from './hex.js';
+
+export interface AccountSecrets {
+  deviceSecret?: Uint8Array;
+  grantSecret?: Uint8Array;
+  recoverySecret?: Uint8Array;
+}
+
+export interface TxResult {
+  txId: string;
+}
+
+export interface ShieldedCoin {
+  nonce: Uint8Array;
+  color: Uint8Array;
+  value: bigint;
+}
+
+function txResult(r: any): TxResult {
+  const txId = r?.public?.txId ?? r?.public?.transactionHash;
+  if (!txId) throw new Error('contract call returned without a transaction id');
+  return { txId };
+}
+
+export class PassportAccount {
+  private constructor(
+    readonly address: string,
+    readonly providers: any,
+    private readonly handle: any,
+  ) {}
+
+  /**
+   * Deploy a fresh account contract: derives the device and recovery
+   * commitments, splits the recovery secret 2-of-3 (TODO(PVSS) — shares land
+   * in public ledger state), and submits the deployment.
+   */
+  static async deploy(
+    providers: any,
+    compiledContract: any,
+    opts: {
+      deviceSecret: Uint8Array;
+      recoverySecret: Uint8Array;
+      privateStateId?: string;
+    },
+  ): Promise<PassportAccount> {
+    const shares: Share[] = split(opts.recoverySecret, 2, 3);
+    const deployed = await deployContract(providers, {
+      compiledContract,
+      privateStateId: opts.privateStateId ?? freshPrivateStateId(),
+      initialPrivateState: privateStateFromSecrets(opts),
+      args: [
+        deviceCommitment(opts.deviceSecret),
+        recoveryCommitment(opts.recoverySecret),
+        shares[0].value,
+        shares[1].value,
+        shares[2].value,
+      ],
+    } as any);
+    const address = deployed.deployTxData.public.contractAddress;
+    return new PassportAccount(address, providers, deployed);
+  }
+
+  /**
+   * Connect to an existing account contract with whatever secrets this
+   * client holds. A fresh privateStateId is used per connection so the
+   * supplied secrets always win over previously persisted private state.
+   */
+  static async connect(
+    providers: any,
+    compiledContract: any,
+    address: string,
+    secrets: AccountSecrets = {},
+    privateStateId?: string,
+  ): Promise<PassportAccount> {
+    const found = await (findDeployedContract as any)(providers, {
+      contractAddress: address,
+      compiledContract,
+      privateStateId: privateStateId ?? freshPrivateStateId(),
+      initialPrivateState: privateStateFromSecrets(secrets),
+    });
+    return new PassportAccount(address, providers, found);
+  }
+
+  // ── Ledger reads ──────────────────────────────────────────────────────────
+
+  async ledgerState(): Promise<Ledger> {
+    const state = await this.providers.publicDataProvider.queryContractState(this.address);
+    if (!state) throw new Error(`no contract state found at ${this.address}`);
+    return ledger(state.data);
+  }
+
+  // ── Night custody ─────────────────────────────────────────────────────────
+
+  depositNight(color: Uint8Array, amount: bigint): Promise<TxResult> {
+    return this.call('deposit_night', color, amount);
+  }
+
+  withdrawNight(color: Uint8Array, amount: bigint, recipient: Uint8Array): Promise<TxResult> {
+    return this.call('withdraw_night', color, amount, { bytes: recipient });
+  }
+
+  grantWithdrawNight(color: Uint8Array, amount: bigint, recipient: Uint8Array): Promise<TxResult> {
+    return this.call('grant_withdraw_night', color, amount, { bytes: recipient });
+  }
+
+  // ── Shielded custody (OZ pattern) ─────────────────────────────────────────
+
+  depositShielded(coin: ShieldedCoin): Promise<TxResult> {
+    return this.call('deposit_shielded', coin);
+  }
+
+  withdrawShielded(recipientCoinPublicKey: Uint8Array, color: Uint8Array, amount: bigint): Promise<TxResult> {
+    return this.call('withdraw_shielded', { bytes: recipientCoinPublicKey }, color, amount);
+  }
+
+  grantWithdrawShielded(recipientCoinPublicKey: Uint8Array, color: Uint8Array, amount: bigint): Promise<TxResult> {
+    return this.call('grant_withdraw_shielded', { bytes: recipientCoinPublicKey }, color, amount);
+  }
+
+  // ── Device management ─────────────────────────────────────────────────────
+
+  addDevice(newDeviceSecret: Uint8Array): Promise<TxResult> {
+    return this.call('add_device', deviceCommitment(newDeviceSecret));
+  }
+
+  addDeviceByCommitment(commitment: bigint): Promise<TxResult> {
+    return this.call('add_device', commitment);
+  }
+
+  removeDeviceByCommitment(commitment: bigint): Promise<TxResult> {
+    return this.call('remove_device', commitment);
+  }
+
+  // ── Grants (C10 / C11) ────────────────────────────────────────────────────
+
+  addGrant(grantSecret: Uint8Array, color: Uint8Array, cap: bigint): Promise<TxResult> {
+    return this.call('add_grant', grantCommitment(grantSecret), color, cap);
+  }
+
+  addGrantByCommitment(commitment: bigint, color: Uint8Array, cap: bigint): Promise<TxResult> {
+    return this.call('add_grant', commitment, color, cap);
+  }
+
+  revokeGrantByCommitment(commitment: bigint): Promise<TxResult> {
+    return this.call('revoke_grant', commitment);
+  }
+
+  // ── Recovery (C14) ────────────────────────────────────────────────────────
+
+  /**
+   * Total-loss recovery. The connected client must hold the recovery secret
+   * in its private state. Bumps the device epoch (invalidating all devices
+   * and grants), registers the new device, rotates the recovery secret, and
+   * stores fresh shares. Reconnect with the new device secret afterwards.
+   */
+  recover(newDeviceSecret: Uint8Array, newRecoverySecret: Uint8Array): Promise<TxResult> {
+    const shares = split(newRecoverySecret, 2, 3);
+    return this.call(
+      'recover',
+      deviceCommitment(newDeviceSecret),
+      recoveryCommitment(newRecoverySecret),
+      shares[0].value,
+      shares[1].value,
+      shares[2].value,
+    );
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────────────
+
+  private async call(circuit: string, ...args: unknown[]): Promise<TxResult> {
+    const r = await this.handle.callTx[circuit](...args);
+    return txResult(r);
+  }
+}
+
+function freshPrivateStateId(): string {
+  const rand = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(rand);
+  return `account-${bytesToHex(rand)}`;
+}

--- a/experiments/account-custody-prototype/src/wallet/contract.ts
+++ b/experiments/account-custody-prototype/src/wallet/contract.ts
@@ -1,0 +1,26 @@
+// Re-export of the compiled contract module plus commitment derivation
+// helpers. Keeping the generated-module import in one place means the
+// Node tests and the browser app share a single import path.
+
+import * as AccountModule from '../../contracts/managed/account/contract/index.js';
+import type { Ledger } from '../../contracts/managed/account/contract/index.js';
+
+export const { Contract, ledger, pureCircuits } = AccountModule;
+export type { Ledger };
+export type { Witnesses } from '../../contracts/managed/account/contract/index.js';
+
+// Commitments are Field elements (bigint on the TS side), derived through
+// the contract's own exported pure circuits so client and circuit can never
+// disagree on the Poseidon parameters or the domain-separation tags.
+
+export function deviceCommitment(secret: Uint8Array): bigint {
+  return AccountModule.pureCircuits.derive_device_commitment(secret);
+}
+
+export function grantCommitment(secret: Uint8Array): bigint {
+  return AccountModule.pureCircuits.derive_grant_commitment(secret);
+}
+
+export function recoveryCommitment(secret: Uint8Array): bigint {
+  return AccountModule.pureCircuits.derive_recovery_commitment(secret);
+}

--- a/experiments/account-custody-prototype/src/wallet/hex.ts
+++ b/experiments/account-custody-prototype/src/wallet/hex.ts
@@ -1,0 +1,34 @@
+// Hex helpers — platform-neutral (no node:buffer) so the same code runs in
+// Node integration tests and the Vite demo app.
+
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.replace(/^0x/, '');
+  if (clean.length % 2 !== 0) throw new Error(`odd-length hex: ${hex}`);
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+// Left-aligned 32-byte buffer, zero-padded on the right — matches the
+// hexToBytes32 recipe the contract-custody-feasibility tests used for
+// token colours and user addresses.
+export function hexToBytes32(hex: string): Uint8Array {
+  const bytes = hexToBytes(hex);
+  const out = new Uint8Array(32);
+  out.set(bytes.subarray(0, Math.min(32, bytes.length)));
+  return out;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += b.toString(16).padStart(2, '0');
+  return s;
+}
+
+export function randomBytes32(): Uint8Array {
+  const out = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(out);
+  return out;
+}

--- a/experiments/account-custody-prototype/src/wallet/shamir.ts
+++ b/experiments/account-custody-prototype/src/wallet/shamir.ts
@@ -1,0 +1,109 @@
+// Byte-wise Shamir secret sharing over GF(256), threshold k of n.
+//
+// Used by the C14 recovery flow: the recovery secret is split 2-of-3 at
+// onboarding and the share values are stored in the account contract's
+// public ledger state, keyed by share index.
+//
+// TODO(PVSS): this is a placeholder for a publicly verifiable secret
+// sharing scheme. Plain Shamir shares stored in public ledger state mean
+// ANYONE can take two of them and reconstruct the recovery secret. The
+// target design encrypts each share to a recovery helper's public key and
+// publishes a proof of correct sharing instead (C15 helper protocol).
+// Do not ship this version.
+//
+// GF(256) arithmetic uses the AES polynomial x^8 + x^4 + x^3 + x + 1
+// (0x11b) with generator 3 — the same construction as HashiCorp Vault's
+// shamir package and ssss.
+
+const EXP = new Uint8Array(512);
+const LOG = new Uint8Array(256);
+
+(() => {
+  let x = 1;
+  for (let i = 0; i < 255; i++) {
+    EXP[i] = x;
+    LOG[x] = i;
+    // multiply x by the generator 3 = x ^ (x << 1) in GF(256)
+    x ^= (x << 1) ^ (x & 0x80 ? 0x11b : 0);
+  }
+  for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255];
+})();
+
+function gfMul(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return EXP[LOG[a] + LOG[b]];
+}
+
+function gfDiv(a: number, b: number): number {
+  if (b === 0) throw new Error('division by zero in GF(256)');
+  if (a === 0) return 0;
+  return EXP[(LOG[a] - LOG[b] + 255) % 255];
+}
+
+export interface Share {
+  /** The x-coordinate, 1..255. Doubles as the ledger map key. */
+  index: number;
+  /** The y-coordinates, one byte per secret byte. */
+  value: Uint8Array;
+}
+
+/** Split `secret` into `n` shares such that any `k` reconstruct it. */
+export function split(secret: Uint8Array, k: number, n: number): Share[] {
+  if (k < 2 || k > n) throw new Error(`invalid threshold ${k} of ${n}`);
+  if (n > 255) throw new Error('at most 255 shares');
+
+  // One random polynomial of degree k-1 per secret byte; constant term is
+  // the secret byte itself.
+  const coefficients: Uint8Array[] = [];
+  for (let j = 0; j < secret.length; j++) {
+    const coeff = new Uint8Array(k);
+    coeff[0] = secret[j];
+    const rand = new Uint8Array(k - 1);
+    globalThis.crypto.getRandomValues(rand);
+    coeff.set(rand, 1);
+    coefficients.push(coeff);
+  }
+
+  const shares: Share[] = [];
+  for (let x = 1; x <= n; x++) {
+    const value = new Uint8Array(secret.length);
+    for (let j = 0; j < secret.length; j++) {
+      // Horner evaluation of the polynomial at x.
+      let y = 0;
+      for (let c = k - 1; c >= 0; c--) {
+        y = gfMul(y, x) ^ coefficients[j][c];
+      }
+      value[j] = y;
+    }
+    shares.push({ index: x, value });
+  }
+  return shares;
+}
+
+/** Reconstruct the secret from at least k shares (Lagrange at x = 0). */
+export function reconstruct(shares: Share[]): Uint8Array {
+  if (shares.length < 2) throw new Error('need at least two shares');
+  const length = shares[0].value.length;
+  const indices = shares.map((s) => s.index);
+  if (new Set(indices).size !== indices.length) {
+    throw new Error('duplicate share indices');
+  }
+
+  const secret = new Uint8Array(length);
+  for (let j = 0; j < length; j++) {
+    let acc = 0;
+    for (let i = 0; i < shares.length; i++) {
+      // Lagrange basis polynomial evaluated at 0.
+      let num = 1;
+      let den = 1;
+      for (let m = 0; m < shares.length; m++) {
+        if (m === i) continue;
+        num = gfMul(num, shares[m].index);
+        den = gfMul(den, shares[m].index ^ shares[i].index);
+      }
+      acc ^= gfMul(shares[i].value[j], gfDiv(num, den));
+    }
+    secret[j] = acc;
+  }
+  return secret;
+}

--- a/experiments/account-custody-prototype/src/wallet/witnesses.ts
+++ b/experiments/account-custody-prototype/src/wallet/witnesses.ts
@@ -1,0 +1,60 @@
+// Witness handling (C7) — the pipeline by which key material flows from
+// storage into proof generation.
+//
+// The private state holds at most three secrets, stored as hex strings so
+// every private-state provider (level, in-memory, browser) serialises them
+// without corruption. A witness throws when its secret is absent: a wallet
+// connected without a device secret simply cannot produce device-authorised
+// proofs.
+//
+// C7 notes for the decision record:
+//   - The secrets only ever travel from here into the local proof pipeline
+//     (in-process witness evaluation; proofs via the local proof server).
+//     Nothing in this module can serialise a secret into a transaction.
+//   - Zeroisation discipline and mlock are NOT implemented — JS runtimes
+//     give no such guarantees. Recorded as a known limitation, not solved.
+
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import type { Ledger } from './contract.js';
+import { hexToBytes, bytesToHex } from './hex.js';
+
+export interface AccountPrivateState {
+  deviceSecretHex: string | null;
+  grantSecretHex: string | null;
+  recoverySecretHex: string | null;
+}
+
+export function privateStateFromSecrets(secrets: {
+  deviceSecret?: Uint8Array;
+  grantSecret?: Uint8Array;
+  recoverySecret?: Uint8Array;
+}): AccountPrivateState {
+  return {
+    deviceSecretHex: secrets.deviceSecret ? bytesToHex(secrets.deviceSecret) : null,
+    grantSecretHex: secrets.grantSecret ? bytesToHex(secrets.grantSecret) : null,
+    recoverySecretHex: secrets.recoverySecret ? bytesToHex(secrets.recoverySecret) : null,
+  };
+}
+
+type Ctx = WitnessContext<Ledger, AccountPrivateState>;
+
+function requireSecret(hex: string | null, name: string): Uint8Array {
+  if (!hex) {
+    throw new Error(`witness ${name} requested but the secret is not in the private state`);
+  }
+  return hexToBytes(hex);
+}
+
+export function makeWitnesses() {
+  return {
+    device_secret(ctx: Ctx): [AccountPrivateState, Uint8Array] {
+      return [ctx.privateState, requireSecret(ctx.privateState.deviceSecretHex, 'device_secret')];
+    },
+    grant_secret(ctx: Ctx): [AccountPrivateState, Uint8Array] {
+      return [ctx.privateState, requireSecret(ctx.privateState.grantSecretHex, 'grant_secret')];
+    },
+    recovery_secret(ctx: Ctx): [AccountPrivateState, Uint8Array] {
+      return [ctx.privateState, requireSecret(ctx.privateState.recoverySecretHex, 'recovery_secret')];
+    },
+  };
+}

--- a/experiments/account-custody-prototype/test/account.test.ts
+++ b/experiments/account-custody-prototype/test/account.test.ts
@@ -1,0 +1,258 @@
+// Contract-logic unit tests over the in-process simulator. These cover the
+// authorisation, device, grant, and recovery semantics; the token-flow
+// circuits are exercised end-to-end by the localnet integration tests.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { AccountSimulator } from './simulator.js';
+import { deviceCommitment, grantCommitment, recoveryCommitment } from '../src/wallet/contract.js';
+import { reconstruct } from '../src/wallet/shamir.js';
+import { randomBytes32, hexToBytes32 } from '../src/wallet/hex.js';
+
+const NIGHT = hexToBytes32('01');
+const OTHER_COLOR = hexToBytes32('02');
+const RECIPIENT = { bytes: hexToBytes32('aabbcc') };
+
+let deviceSecret: Uint8Array;
+let recoverySecret: Uint8Array;
+let sim: AccountSimulator;
+
+beforeEach(() => {
+  deviceSecret = randomBytes32();
+  recoverySecret = randomBytes32();
+  sim = new AccountSimulator({ deviceSecret, recoverySecret });
+});
+
+describe('constructor', () => {
+  it('registers the initial device in epoch 0', () => {
+    const l = sim.ledger();
+    expect(l.devices.member(deviceCommitment(deviceSecret))).toBe(true);
+    expect(l.devices.lookup(deviceCommitment(deviceSecret))).toBe(0n);
+    expect(l.device_epoch).toBe(0n);
+    expect(l.device_count).toBe(1n);
+    expect(l.round).toBe(0n);
+  });
+
+  it('stores the recovery commitment and three shares', () => {
+    const l = sim.ledger();
+    expect(l.recovery).toBe(recoveryCommitment(recoverySecret));
+    expect(l.recovery_shares.size()).toBe(3n);
+    for (const index of [1n, 2n, 3n]) {
+      expect(l.recovery_shares.member(index)).toBe(true);
+    }
+  });
+});
+
+describe('night custody', () => {
+  it('mirrors deposits and withdrawals in night_balances', () => {
+    sim.call('deposit_night', NIGHT, 1000n);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(1000n);
+
+    sim.call('withdraw_night', NIGHT, 400n, RECIPIENT);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(600n);
+    expect(sim.ledger().round).toBe(1n);
+  });
+
+  it('rejects over-withdrawal', () => {
+    sim.call('deposit_night', NIGHT, 100n);
+    expect(() => sim.call('withdraw_night', NIGHT, 200n, RECIPIENT)).toThrow(
+      /insufficient balance/,
+    );
+  });
+
+  it('rejects withdrawal from an unknown device', () => {
+    sim.call('deposit_night', NIGHT, 100n);
+    sim.as({ deviceSecret: randomBytes32() });
+    expect(() => sim.call('withdraw_night', NIGHT, 50n, RECIPIENT)).toThrow(/unknown device/);
+  });
+
+  it('rejects withdrawal when no device secret is present', () => {
+    sim.call('deposit_night', NIGHT, 100n);
+    sim.as({});
+    expect(() => sim.call('withdraw_night', NIGHT, 50n, RECIPIENT)).toThrow(
+      /device_secret requested/,
+    );
+  });
+});
+
+describe('device management', () => {
+  it('adds a second device that can then withdraw', () => {
+    const second = randomBytes32();
+    sim.call('add_device', deviceCommitment(second));
+    expect(sim.ledger().device_count).toBe(2n);
+
+    sim.call('deposit_night', NIGHT, 100n);
+    sim.as({ deviceSecret: second });
+    sim.call('withdraw_night', NIGHT, 50n, RECIPIENT);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(50n);
+  });
+
+  it('rejects adding an already-active device', () => {
+    expect(() => sim.call('add_device', deviceCommitment(deviceSecret))).toThrow(
+      /device already active/,
+    );
+  });
+
+  it('removes a device, which then cannot act', () => {
+    const second = randomBytes32();
+    sim.call('add_device', deviceCommitment(second));
+    sim.call('remove_device', deviceCommitment(second));
+    expect(sim.ledger().device_count).toBe(1n);
+
+    sim.call('deposit_night', NIGHT, 100n);
+    sim.as({ deviceSecret: second });
+    expect(() => sim.call('withdraw_night', NIGHT, 50n, RECIPIENT)).toThrow(/unknown device/);
+  });
+
+  it('refuses to remove the last device', () => {
+    expect(() => sim.call('remove_device', deviceCommitment(deviceSecret))).toThrow(
+      /cannot remove last device/,
+    );
+  });
+});
+
+describe('scoped grants', () => {
+  let grantSecret: Uint8Array;
+
+  beforeEach(() => {
+    grantSecret = randomBytes32();
+    sim.call('deposit_night', NIGHT, 1000n);
+    sim.call('add_grant', grantCommitment(grantSecret), NIGHT, 300n);
+  });
+
+  it('allows withdrawals within the cap and tracks cumulative spend', () => {
+    sim.as({ grantSecret });
+    sim.call('grant_withdraw_night', NIGHT, 100n, RECIPIENT);
+    sim.call('grant_withdraw_night', NIGHT, 200n, RECIPIENT);
+
+    const info = sim.ledger().grants.lookup(grantCommitment(grantSecret));
+    expect(info.spent).toBe(300n);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(700n);
+  });
+
+  it('rejects a withdrawal that exceeds the cap cumulatively', () => {
+    sim.as({ grantSecret });
+    sim.call('grant_withdraw_night', NIGHT, 250n, RECIPIENT);
+    expect(() => sim.call('grant_withdraw_night', NIGHT, 100n, RECIPIENT)).toThrow(
+      /grant cap exceeded/,
+    );
+  });
+
+  it('rejects a withdrawal outside the granted colour', () => {
+    sim.as({ grantSecret });
+    expect(() => sim.call('grant_withdraw_night', OTHER_COLOR, 10n, RECIPIENT)).toThrow(
+      /colour outside grant scope/,
+    );
+  });
+
+  it('rejects an unknown grant secret', () => {
+    sim.as({ grantSecret: randomBytes32() });
+    expect(() => sim.call('grant_withdraw_night', NIGHT, 10n, RECIPIENT)).toThrow(
+      /unknown grant/,
+    );
+  });
+
+  it('rejects a revoked grant', () => {
+    sim.call('revoke_grant', grantCommitment(grantSecret));
+    sim.as({ grantSecret });
+    expect(() => sim.call('grant_withdraw_night', NIGHT, 10n, RECIPIENT)).toThrow(
+      /grant revoked/,
+    );
+  });
+
+  it('only devices may issue or revoke grants', () => {
+    sim.as({ grantSecret });
+    expect(() => sim.call('add_grant', grantCommitment(randomBytes32()), NIGHT, 10n)).toThrow(
+      /device_secret requested/,
+    );
+  });
+});
+
+describe('total-loss recovery', () => {
+  it('rejects an invalid recovery secret', () => {
+    sim.as({ recoverySecret: randomBytes32() });
+    expect(() =>
+      sim.call(
+        'recover',
+        deviceCommitment(randomBytes32()),
+        recoveryCommitment(randomBytes32()),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+      ),
+    ).toThrow(/invalid recovery secret/);
+  });
+
+  it('resets the device set, invalidates grants, and rotates the recovery secret', () => {
+    const grantSecret = randomBytes32();
+    sim.call('deposit_night', NIGHT, 500n);
+    sim.call('add_grant', grantCommitment(grantSecret), NIGHT, 100n);
+
+    // Total loss: the user reconstructs the recovery secret from two of the
+    // three on-chain shares (TODO(PVSS): plaintext shares — see shamir.ts).
+    const l = sim.ledger();
+    const reconstructed = reconstruct([
+      { index: 1, value: l.recovery_shares.lookup(1n) },
+      { index: 3, value: l.recovery_shares.lookup(3n) },
+    ]);
+    expect(recoveryCommitment(reconstructed)).toBe(l.recovery);
+
+    const newDevice = randomBytes32();
+    const newRecovery = randomBytes32();
+    sim.as({ recoverySecret: reconstructed });
+    sim.call(
+      'recover',
+      deviceCommitment(newDevice),
+      recoveryCommitment(newRecovery),
+      randomBytes32(),
+      randomBytes32(),
+      randomBytes32(),
+    );
+
+    const after = sim.ledger();
+    expect(after.device_epoch).toBe(1n);
+    expect(after.device_count).toBe(1n);
+    expect(after.recovery).toBe(recoveryCommitment(newRecovery));
+
+    // The recovered device controls the account — and the assets followed it.
+    sim.as({ deviceSecret: newDevice });
+    sim.call('withdraw_night', NIGHT, 100n, RECIPIENT);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(400n);
+
+    // The lost device is locked out by the epoch bump.
+    sim.as({ deviceSecret });
+    expect(() => sim.call('withdraw_night', NIGHT, 10n, RECIPIENT)).toThrow(
+      /device of revoked epoch/,
+    );
+
+    // Grants issued before recovery are dead too.
+    sim.as({ grantSecret });
+    expect(() => sim.call('grant_withdraw_night', NIGHT, 10n, RECIPIENT)).toThrow(
+      /grant of revoked epoch/,
+    );
+  });
+
+  it('old recovery secret stops working after rotation', () => {
+    const newDevice = randomBytes32();
+    const newRecovery = randomBytes32();
+    sim.call(
+      'recover',
+      deviceCommitment(newDevice),
+      recoveryCommitment(newRecovery),
+      randomBytes32(),
+      randomBytes32(),
+      randomBytes32(),
+    );
+    // Same (old) recovery secret again — the commitment has rotated.
+    expect(() =>
+      sim.call(
+        'recover',
+        deviceCommitment(randomBytes32()),
+        recoveryCommitment(randomBytes32()),
+        randomBytes32(),
+        randomBytes32(),
+        randomBytes32(),
+      ),
+    ).toThrow(/invalid recovery secret/);
+  });
+});

--- a/experiments/account-custody-prototype/test/shamir.test.ts
+++ b/experiments/account-custody-prototype/test/shamir.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { split, reconstruct } from '../src/wallet/shamir.js';
+import { randomBytes32, bytesToHex } from '../src/wallet/hex.js';
+
+describe('Shamir 2-of-3 over GF(256)', () => {
+  it('reconstructs from every pair of shares', () => {
+    for (let round = 0; round < 10; round++) {
+      const secret = randomBytes32();
+      const shares = split(secret, 2, 3);
+      const pairs = [
+        [shares[0], shares[1]],
+        [shares[0], shares[2]],
+        [shares[1], shares[2]],
+      ];
+      for (const pair of pairs) {
+        expect(bytesToHex(reconstruct(pair))).toBe(bytesToHex(secret));
+      }
+    }
+  });
+
+  it('reconstructs from all three shares', () => {
+    const secret = randomBytes32();
+    const shares = split(secret, 2, 3);
+    expect(bytesToHex(reconstruct(shares))).toBe(bytesToHex(secret));
+  });
+
+  it('rejects duplicate share indices', () => {
+    const secret = randomBytes32();
+    const shares = split(secret, 2, 3);
+    expect(() => reconstruct([shares[0], shares[0]])).toThrow(/duplicate/);
+  });
+
+  it('a single share does not equal the secret', () => {
+    const secret = randomBytes32();
+    const shares = split(secret, 2, 3);
+    for (const share of shares) {
+      expect(bytesToHex(share.value)).not.toBe(bytesToHex(secret));
+    }
+  });
+});

--- a/experiments/account-custody-prototype/test/simulator.ts
+++ b/experiments/account-custody-prototype/test/simulator.ts
@@ -1,0 +1,85 @@
+// In-process contract simulator over @midnight-ntwrk/compact-runtime.
+// Executes circuits (including witness evaluation) against a local
+// QueryContext — no node, indexer, or proof server required. Token
+// operations record their effects but are not settled; balance-mirror
+// ledger fields make the outcomes observable anyway.
+
+import {
+  createConstructorContext,
+  createCircuitContext,
+  sampleContractAddress,
+  type CircuitContext,
+} from '@midnight-ntwrk/compact-runtime';
+
+import {
+  Contract,
+  ledger,
+  deviceCommitment,
+  recoveryCommitment,
+  type Ledger,
+} from '../src/wallet/contract.js';
+import {
+  makeWitnesses,
+  privateStateFromSecrets,
+  type AccountPrivateState,
+} from '../src/wallet/witnesses.js';
+import { split, type Share } from '../src/wallet/shamir.js';
+
+const COIN_PUBLIC_KEY = '00'.repeat(32);
+
+export interface SimulatorSecrets {
+  deviceSecret?: Uint8Array;
+  grantSecret?: Uint8Array;
+  recoverySecret?: Uint8Array;
+}
+
+export class AccountSimulator {
+  readonly contract: any;
+  readonly address = sampleContractAddress();
+  readonly initialShares: Share[];
+  ctx: CircuitContext<AccountPrivateState>;
+
+  constructor(opts: { deviceSecret: Uint8Array; recoverySecret: Uint8Array }) {
+    this.contract = new (Contract as any)(makeWitnesses());
+    this.initialShares = split(opts.recoverySecret, 2, 3);
+    const constructorCtx = createConstructorContext(
+      privateStateFromSecrets(opts),
+      COIN_PUBLIC_KEY,
+    );
+    const { currentContractState, currentPrivateState, currentZswapLocalState } =
+      this.contract.initialState(
+        constructorCtx,
+        deviceCommitment(opts.deviceSecret),
+        recoveryCommitment(opts.recoverySecret),
+        this.initialShares[0].value,
+        this.initialShares[1].value,
+        this.initialShares[2].value,
+      );
+    this.ctx = createCircuitContext(
+      this.address,
+      currentZswapLocalState,
+      currentContractState,
+      currentPrivateState,
+    );
+  }
+
+  /** Switch the acting client: subsequent calls use these secrets. */
+  as(secrets: SimulatorSecrets): this {
+    this.ctx = {
+      ...this.ctx,
+      currentPrivateState: privateStateFromSecrets(secrets),
+    };
+    return this;
+  }
+
+  /** Call an impure circuit; commits the resulting context on success. */
+  call(circuit: string, ...args: unknown[]): unknown {
+    const r = this.contract.impureCircuits[circuit](this.ctx, ...args);
+    this.ctx = r.context;
+    return r.result;
+  }
+
+  ledger(): Ledger {
+    return ledger(this.ctx.currentQueryContext.state);
+  }
+}

--- a/experiments/account-custody-prototype/tsconfig.json
+++ b/experiments/account-custody-prototype/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules", "app"]
+}


### PR DESCRIPTION
## Summary

Working evidence for the account-custody design: a per-account Compact contract (C1) holding Night and shielded assets (C4), with scoped grants (C10/C11) and total-loss recovery (C14) built in, plus a passkey-rooted wallet app that exercises the whole lifecycle on a `localnet` with every zero-knowledge proof computed in the browser tab.

Each open question this prototype answers is recorded as a revisitable decision in `experiments/account-custody-prototype/DECISIONS.md`, mapped to the component canvases.

## What is inside

- **Contract and wallet core.** One contract per account; hash-preimage device auth behind a single `require_device()` seam (the C5 JubJub Schnorr verifier replaces one circuit later); replay defence via a round counter; epoch bump for O(1) device and grant invalidation; grants scoped operation × colour × cumulative cap; recovery secret split 2-of-3. 23/23 simulator unit tests and all four localnet lifecycle scenarios (night, grants, recovery, shielded) pass.
- **Demo app.** Passkey onboarding (WebAuthn PRF → device secret, no seed phrase), an app shell (Overview, Holdings, Connections, Devices, and Recovery), the passport-card identity surface, hover explainers mapped to the v1.0 promises, and a live custody flow map: bearer → biometrics → device → zero-knowledge proof → contract, with the prover box lighting up while the real prove phase runs on the user's machine.
- **On-device proving by default.** Contract circuits, zswap, and dust balancing all prove in-tab via the zkir-v2 wasm prover; no proof server is on the path (`?prover=server` opts back into the Docker server).
- **Verification harness.** `scripts/smoke.mjs`, `scripts/e2e-devmode.mjs`, and desktop plus mobile screenshot journeys; all pass on a fresh chain.

## Known caveats (deliberate, do not ship)

- Recovery shares sit in plaintext public ledger state; placeholder for PVSS to recovery helpers (flagged `TODO(PVSS)` in code and UI).
- Contract-held shielded coin values are public (the documented QSCI trade-off, accepted for the prototype).
- `transientHash` commitments are not stable across Compact versions; revisit when the C8 registry ratifies hash usage.
- Hash-preimage auth does not compose with MPC custody; it is the stand-in until C5 ratification.

## Finding worth reporting upstream

After roughly twenty fee-paying transactions from the genesis wallet on a day-old localnet, the wallet SDK's dust balancing path fails with a Rust `unreachable!()` wasm panic surfaced as an opaque client error. A fresh chain does not reproduce it. Candidate bug report for the wallet-sdk and ledger teams.

## Running it

```
cd experiments/account-custody-prototype/infra
docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d --wait
cd .. && WALLET_SEED=…01 npm run deploy
cd app && npm run dev          # http://localhost:5173
```