### PR TITLE
feat(experiments): dust-sponsorship feasibility — wallet-level sponsorship lands on v1 (F1–F6)

### DIFF
--- a/experiments/dust-sponsorship-feasibility/.env.example
+++ b/experiments/dust-sponsorship-feasibility/.env.example
@@ -1,0 +1,12 @@
+# Generate with: openssl rand -hex 32
+APP__INFRA__SECRET=
+
+# Sponsor wallet seed (do not use in production).
+# The dev node genesis gives Night tokens — and Dust generation — to this
+# wallet. It plays the sponsor in every test except F5.
+WALLET_SEED=0000000000000000000000000000000000000000000000000000000000000001
+
+# Optional pins. When unset, each run generates fresh random seeds for the
+# user (and F5's broke sponsor) and records them in evidence/.
+# USER_SEED=
+# BROKE_SPONSOR_SEED=

--- a/experiments/dust-sponsorship-feasibility/.gitignore
+++ b/experiments/dust-sponsorship-feasibility/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+midnight-level-db/
+contracts/managed/
+deployment.json
+infra/.env

--- a/experiments/dust-sponsorship-feasibility/EXPERIMENT_GUIDELINE.md
+++ b/experiments/dust-sponsorship-feasibility/EXPERIMENT_GUIDELINE.md
@@ -1,0 +1,247 @@
+# Experiment Brief — DUST Sponsorship Feasibility on Midnight v1
+
+**Date scoped:** 2026/04/30
+**Owner:** _to be assigned_
+**Target location:** `experiments/dust-sponsorship-feasibility/`
+
+---
+
+## Goal
+
+Empirically determine, on the latest Midnight v1 SDK and devnet node,
+whether the wallet-level DUST fee sponsorship pattern — where a sponsor
+wallet pays the DUST fees of a user's transaction via
+`tokenKindsToBalance` splitting — lands successfully on
+`midnight-node:0.22.5`.
+
+The deliverable is a strict, reproducible statement of what works, what
+fails, and what only partially works on v1 today. Every finding must be
+backed by a transaction hash or a specific node error code.
+
+## Why this matters
+
+The Passport v1.0 fee model
+([`.planning/concrete-plan.md` § C24](../../.planning/concrete-plan.md))
+hinges on whether a fresh-account user with zero NIGHT and zero DUST can
+transact. The neighbouring experiment
+[`../contract-custody-feasibility/`](../contract-custody-feasibility/)
+confirmed (D1, D2 FAIL) that **contract-paymaster** — a Passport
+contract paying its own or a user's fee branch — is not implementable
+on v1. A third-party tutorial (see References) describes a
+**wallet-level** sponsorship flow using existing SDK surfaces with no
+contract-paymaster involvement.
+
+The pattern has been verified at the type level: `TokenKindsToBalance`,
+`balanceUnboundTransaction`, and `balanceFinalizedTransaction` are
+present in `@midnight-ntwrk/wallet-api: ^5.0.0` and
+`@midnight-ntwrk/wallet-sdk-facade` (see References for exact file
+paths). What is **not** verified is whether the resulting two-balanced
+transaction is accepted by the node. This experiment closes that gap.
+
+The result determines whether **alternative A** in C24 (wallet-level
+fee splitting) is the v1.0 path forward, or whether we fall back to
+**B** (NIGHT airdrop, slower bootstrap), **C** (hybrid), or **D**
+(user pre-funds NIGHT externally).
+
+## Pattern summary
+
+Per the third-party tutorial, the sponsorship flow is:
+
+1. **User phase.** User wallet calls
+   `balanceUnboundTransaction(tx, secretKeys, { ttl, tokenKindsToBalance: ['shielded', 'unshielded'] })`,
+   then `signRecipe()`, then `finalizeRecipe()`. The user balances
+   their own shielded and unshielded tokens but **excludes DUST**.
+
+2. **Sponsor phase.** Sponsor wallet receives the partially-balanced
+   transaction, calls
+   `balanceFinalizedTransaction(tx, secretKeys, { ttl, tokenKindsToBalance: ['dust'] })`,
+   then `signRecipe()`, `finalizeRecipe()`, and `submitTransaction()`.
+   The sponsor adds DUST balancing from its own DUST capacity, signs,
+   and submits.
+
+The result is a single fully-balanced transaction with both parties'
+contributions baked in. No contract-paymaster fee branch is involved.
+
+## In scope — test cases
+
+Each test must produce either a successful transaction hash plus
+on-chain state delta, or a specific node error code plus the captured
+response.
+
+### F1 — Happy path
+
+User wallet (holds NIGHT, has zero or near-zero DUST) initiates a
+trivial Night transfer. User calls
+`balanceUnboundTransaction(..., { tokenKindsToBalance: ['shielded', 'unshielded'] })`
+and finalises. Sponsor wallet (separate seed, holds NIGHT-derived DUST
+capacity) calls
+`balanceFinalizedTransaction(..., { tokenKindsToBalance: ['dust'] })`,
+signs, and submits.
+
+**Pass criterion.** Transaction hash returned; indexer confirms
+inclusion; user's Night balance reflects the transfer; sponsor's DUST
+capacity reflects the fee deduction.
+
+### F2 — True zero-NIGHT, zero-DUST onboarding
+
+Same as F1 but the user wallet has **zero NIGHT** *and* **zero DUST**
+at start. The user's only on-chain action is a name registration or a
+trivial circuit call that does not require a Night spend — i.e., the
+fee is the only economic component of the transaction.
+
+**Pass criterion.** Transaction lands successfully despite the user
+holding no fee-paying capacity. If F1 passes but F2 fails, the
+implication is that the user must hold *some* NIGHT for the
+sponsorship to work — material for the bootstrap UX, since the sponsor
+would need to airdrop NIGHT separately and then wallet-level-sponsor
+the user's first NIGHT-spending transaction.
+
+### F3 — Re-balance corruption (negative)
+
+Sponsor incorrectly calls `balanceFinalizedTransaction` with
+`tokenKindsToBalance: 'all'` instead of `['dust']`, attempting to
+re-balance the user's already-balanced shielded/unshielded portion.
+
+**Pass criterion.** Failure observed and characterised. Confirms (or
+refutes) the tutorial's "double-spending errors" warning. The error
+shape — local exception or post-submission rejection, error code,
+recovery path — is itself the deliverable.
+
+### F4 — TTL expiry across the round-trip
+
+User signs and finalises with a short TTL (e.g., 30 seconds). Sponsor
+deliberately delays processing past TTL, then attempts submission.
+
+**Pass criterion.** Failure observed; node returns a specific
+TTL-related error code. Establishes the latency budget the sponsor
+service has between receiving a user's finalised transaction and
+submitting the dual-balanced result.
+
+### F5 — Sponsor with insufficient DUST (negative)
+
+Sponsor wallet has DUST capacity below the fee required for the user's
+transaction.
+
+**Pass criterion.** Sponsor's `balanceFinalizedTransaction` call fails
+locally, before submission, with a clear error indicating insufficient
+DUST. Confirms the failure mode is detectable client-side, not silent
+or post-submission.
+
+### F6 — Sponsored contract deployment
+
+Same two-phase flow as F2, but the user's transaction is a **contract
+deployment** rather than a circuit call. The user wallet has zero NIGHT
+and zero DUST. A minimal contract (the same counter contract F2 uses)
+is deployed via `midnight-js` `deployContract`, with the deploy
+transaction balanced in two phases: the user balances
+`['shielded', 'unshielded']` (a no-op for a fresh wallet) and signs;
+the sponsor balances `['dust']`, signs, and submits.
+
+**Why this is in scope.** A Passport onboarding's *first* transaction
+is the per-account contract deployment
+(see [`../account-custody-prototype/`](../account-custody-prototype/)).
+F1–F5 cover transfers and circuit calls only; if sponsorship does not
+extend to deployment transactions, a fresh user cannot create their
+account contract without pre-funding, and alternative A fails for the
+onboarding flow specifically — the single most important transaction
+in the Passport lifecycle.
+
+**Pass criterion.** Deployment lands; the contract address is
+queryable on the indexer; the user wallet spent nothing and holds
+nothing; the sponsor's DUST capacity reflects the fee deduction.
+
+## Out of scope
+
+- Contract-paymaster patterns. Already covered (negatively) by D1, D2
+  in `contract-custody-feasibility/`.
+- Multi-sponsor fallback or sponsor directory behaviour. The experiment
+  uses a single sponsor wallet; directory behaviour is a sponsor-service
+  architecture concern, not a node-acceptance concern.
+- Sponsor-service abuse mitigation (rate limits, proof-of-personhood) —
+  out of node-acceptance scope.
+- Performance benchmarking, except where an operation is so slow it is
+  effectively unusable.
+
+## Setup
+
+- **Language**: TypeScript only. The pattern lives in
+  `@midnight-ntwrk/wallet-api`, exercised via
+  `@midnight-ntwrk/wallet-sdk-facade`.
+- **Reference TS infrastructure**: mirror the harness from
+  [`../contract-custody-feasibility/`](../contract-custody-feasibility/).
+  Reuse the devnet docker config, the TypeScript package layout, and the
+  build/run scripts. Replace the test contracts with whatever minimal
+  Compact contract is needed for F2 (a trivial counter or
+  name-registration circuit). F1 needs no contract — a plain Night
+  transfer is enough.
+- **SDK**: pin to the same `@midnight-ntwrk/wallet-api: ^5.0.0` and
+  `@midnight-ntwrk/wallet-sdk-facade` versions as
+  `contract-custody-feasibility/`. Pin exact published versions in
+  `FINDINGS.md` at run time.
+- **Node**: `midnightntwrk/midnight-node:0.22.5` (same as
+  `contract-custody-feasibility/`). Pin in `FINDINGS.md`.
+- **Wallets**: two separate seed phrases, two separate wallet
+  instances. Sponsor wallet must be funded with sufficient NIGHT to
+  generate the DUST capacity required by the test plan.
+
+## Deliverables
+
+1. **`experiments/dust-sponsorship-feasibility/`** — the experiment
+   directory with the devnet harness, any minimal contracts, and the
+   TypeScript test runner.
+2. **`experiments/dust-sponsorship-feasibility/FINDINGS.md`** with:
+   - **Header**: SDK package versions, node version, date the experiment
+     was run, devnet commit/tag.
+   - **Per-test-case results table**:
+     `test name | status (PASS / FAIL / PARTIAL) | tx hash or error code | one-line note`.
+   - **Verdict** — exactly one of:
+     - *Wallet-level DUST sponsorship is feasible on v1; alternative A
+       in C24 is the path forward.*
+     - *Wallet-level DUST sponsorship is partially feasible; specific
+       conditions {list}.*
+     - *Wallet-level DUST sponsorship is not feasible on v1; fall back
+       to alternative B, C, or D in C24.*
+   - **Implications for the Passport fee model (C24)** — one paragraph
+     stating which alternative path is on the table given the result,
+     feeding back into
+     [`.planning/concrete-plan.md` § C24](../../.planning/concrete-plan.md).
+3. **`experiments/dust-sponsorship-feasibility/evidence/`** — per-test
+   JSON files capturing request, response, transaction hash (or error
+   code + node response), and relevant node logs.
+4. **Reproducibility**: a single command (e.g., `./run-all.sh`) that
+   brings up the local devnet, runs every test, and writes the evidence
+   files. Anyone with the pinned SDK installed must be able to reproduce
+   the findings end-to-end on a clean checkout.
+
+## Acceptance criteria
+
+- Every test case in the In Scope list has a definitive result backed
+  by an evidence file.
+- The verdict in `FINDINGS.md` is one of the three above, justified by
+  the per-test results.
+- The reproducibility command runs end-to-end on a fresh checkout.
+- SDK and node versions are pinned and documented.
+
+## References
+
+- **Tutorial (third-party):**
+  https://gist.githubusercontent.com/wilsonhoe/df6e272e892b19404b93d564796feff6/raw/06c9d91ade4d4d2c33733fa791a7b80cc3869e30/TUTORIAL.md
+- **API verification (local SDK source):**
+  - `@midnight-ntwrk/wallet-sdk-facade/dist/index.d.ts:13–14` —
+    `TokenKindsToBalance` type definition.
+  - `@midnight-ntwrk/wallet-sdk-facade/dist/index.d.ts:144–149` —
+    `balanceFinalizedTransaction(..., { tokenKindsToBalance })` signature.
+  - `@midnight-ntwrk/wallet-sdk-facade/dist/index.d.ts:151–156` —
+    `balanceUnboundTransaction(..., { tokenKindsToBalance })` signature.
+  - `@midnight-ntwrk/wallet-sdk-facade/README.md` lines 72–125 — usage
+    example with `tokenKindsToBalance: ['shielded', 'dust']`.
+- **Plan tracking:**
+  [`.planning/concrete-plan.md` § C24](../../.planning/concrete-plan.md)
+  (Fee model).
+- **Related experiment:**
+  [`../contract-custody-feasibility/`](../contract-custody-feasibility/)
+  — established that contract-paymaster (D1, D2) is not feasible on v1;
+  this experiment tests the alternative wallet-level path.
+- **Design doc context:**
+  [`docs/reference/.../secure-onboarding-design.md` § 5.6](../../docs/reference/machine-investigation/key-flows/secure-onboarding-design.md)
+  — DUST Fee Model.

--- a/experiments/dust-sponsorship-feasibility/FINDINGS.md
+++ b/experiments/dust-sponsorship-feasibility/FINDINGS.md
@@ -1,0 +1,156 @@
+# DUST Sponsorship Feasibility — Findings
+
+> **Status: executed 2026/06/11 on a fresh, isolated localnet.** All six
+> tests have definitive results: five PASS, one PARTIAL whose "failure"
+> is the refutation of a third-party warning. The headline: wallet-level
+> DUST sponsorship lands end-to-end, including for the transaction shape
+> Passport onboarding needs most — a zero-token user deploying a
+> contract. The results table is regenerated mechanically from
+> `evidence/*.json` by `src/compose-findings.ts`.
+
+## Header
+
+| Field | Value |
+| --- | --- |
+| Run date | 2026/06/11 |
+| Node | `midnightntwrk/midnight-node:1.0.0` |
+| Indexer | `midnightntwrk/indexer-standalone:4.3.3` |
+| Proof server | `midnightntwrk/proof-server:8.1.0` |
+| Compact compiler | 0.31.0 |
+| Key SDK resolutions | `wallet-sdk-facade` 4.0.1 · `wallet-api` 5.0.0 · `ledger-v8` 8.1.0 · `midnight-js-*` 4.1.1 |
+| Network | fresh localnet (`CFG_PRESET: dev`), isolated compose project (macOS host ports 19944/18088/16300) |
+
+The brief pinned `midnight-node:0.22.5` when it was scoped. Per its own
+instruction to bump on the day of the run, the experiment executed on the
+repository's current stable stack (the same image set as
+`../account-custody-prototype/`), which also matches where the public
+networks are heading (Preview runs node 1.0.0 today).
+
+## Headline findings
+
+1. **Wallet-level DUST sponsorship works on this stack, end-to-end.**
+   The two-phase flow from the brief is exactly what the SDK supports:
+   the user balances `['shielded', 'unshielded']` (or builds a transfer
+   with `payFees: false`), signs, and finalises; the sponsor calls
+   `balanceFinalizedTransaction(tx, keys, { ttl, tokenKindsToBalance:
+   ['dust'] })`, signs, finalises, and submits. The node accepts the
+   two-balanced result (F1). Balances settle exactly: the user paid
+   tokens and zero fees, the sponsor received the transfer and paid the
+   fee from its DUST capacity.
+
+2. **True zero-start onboarding works — including contract deployment.**
+   A user holding zero NIGHT and zero DUST landed a sponsored circuit
+   call (F2) and, decisively for Passport, a sponsored **contract
+   deployment** (F6): the deploy transaction of a fresh account is
+   sponsorable. The brief's contingency (F1 passes but F2 fails,
+   forcing a NIGHT airdrop before sponsorship) did not materialise; no
+   NIGHT prerequisite exists. The sponsored-provider seam is small: a
+   midnight-js `walletProvider.balanceTx` that runs the user phase then
+   the sponsor phase (`src/sponsorship.ts`), which is the sponsor
+   service in miniature.
+
+3. **The failure modes are operable from the sponsor side.**
+   - *Insufficient sponsor DUST (F5)*: fails locally, inside
+     `balanceFinalizedTransaction`, with `Insufficient Funds: could not
+     balance dust` — before anything reaches the node. A sponsor
+     service can detect capacity exhaustion client-side.
+   - *TTL expiry (F4)*: a user transaction finalised with a 30 s TTL
+     and processed by the sponsor 90 s later is rejected by the node at
+     submission (`1010: Invalid Transaction: Custom error: 182`). The
+     sponsor balancing with a fresh TTL does not resurrect an expired
+     base transaction: the user's TTL is the sponsor service's hard
+     latency budget.
+
+4. **The tutorial's corruption warning is refuted on this stack (F3).**
+   A sponsor that wrongly balances with `tokenKindsToBalance: 'all'`
+   does not corrupt the transaction: with the user's unshielded section
+   already balanced, the call degrades gracefully to dust-only
+   balancing, the node accepts, and the user's change output survives
+   intact (post-hoc re-sync of the user wallet settled at exactly the
+   F1 outcome; see `postHocCheck` in the F3 evidence). The warning
+   presumably described an older SDK. Recommendation unchanged: a
+   sponsor should still pass `['dust']` explicitly — it states intent
+   and guards against regressions in coin selection.
+
+5. **A sponsor must not balance against its own unsettled state.**
+   Discovered during harness bring-up: building a second sponsored
+   transaction before the sponsor wallet has observed its previous
+   spend re-spends the same dust coin, and the node rejects with
+   `DustDoubleSpend(DustNullifier(...))`. A production sponsor service
+   must serialise its balancing per wallet (or track pending dust
+   spends); the harness settles by waiting for the prior transaction to
+   appear in the sponsor's synced state.
+
+## Observed fee magnitudes
+
+Sponsor DUST deltas per sponsored transaction, net of the sponsor's
+concurrent dust regeneration (indicative magnitudes, not precise fees):
+
+| Transaction | Sponsor DUST delta |
+| --- | --- |
+| Night transfer (F1) | ≈ 1.5 × 10¹⁹ |
+| Counter circuit call (F2) | ≈ 3.9 × 10¹⁵ |
+| Counter contract deployment (F6) | ≈ 8.7 × 10¹⁸ |
+
+The genesis sponsor's capacity (≈ 1.25 × 10²⁴) covered the whole suite
+without noticeable depletion. For a public-testnet sponsor bootstrapped
+from the faucet, these magnitudes plus the regeneration rate and cap
+define the throughput envelope; measuring that envelope is sponsor-
+service work, out of scope here.
+
+## Notes for a wire-level sponsor service
+
+The harness hands the finalised transaction from user to sponsor
+in-process. As a bonus observation, `FinalizedTransaction.serialize()`
+produced compact payloads (0.6–3.4 kB across F1, F2, and F6); the
+probe's argument-less `deserialize` call fails, so a real service must
+use the ledger's typed deserialize signature (marker arguments). Node
+acceptance is unaffected by the handoff mechanism.
+
+A harness-level caveat for whoever ports this: `findDeployedContract`
+against a chain with days of history ground at full CPU with unbounded
+wasm memory growth; against a fresh chain it returns immediately. Worth
+knowing before pointing the flow at a long-lived public network.
+
+## Per-test results
+
+<!-- BEGIN-RESULTS-TABLE -->
+
+| Test | Status  | Tx hash / error code | Note                                         |
+| ---- | ------- | -------------------- | -------------------------------------------- |
+| F1   | PASS    | 0030d3c2...d6117af   | Two-balanced tx accepted: user paid tokens,  |
+| F2   | PASS    | 000125b4...18917ae   | User with zero NIGHT and zero DUST landed a  |
+| F3   | PARTIAL | 00836fe6...7b707af   | Sponsor 'all' re-balance degraded gracefully |
+| F4   | PASS    | ledger-182           | TTL-expired round-trip rejected at stage 'su |
+| F5   | PASS    | insufficient-dust    | Broke sponsor failed locally at balanceFinal |
+| F6   | PASS    | 0086c65c...3e5d455   | Zero-token user deployed a contract; sponsor |
+
+<!-- END-RESULTS-TABLE -->
+
+## Verdict
+
+**Wallet-level DUST sponsorship is feasible on v1; alternative A in C24
+is the path forward.** Every test produced a definitive result backed
+by a transaction hash or a captured error; the negative tests failed in
+ways a sponsor service can detect and handle.
+
+## Implications for the Passport fee model (C24)
+
+Alternative A (wallet-level fee splitting) moves from open question to
+working evidence, and it covers the one transaction the other
+alternatives handle worst: the account-contract deployment that begins
+every Passport onboarding (F6). A fresh user needs no NIGHT, no DUST,
+and no waiting for dust generation; the fee model can promise
+zero-token onboarding outright, with NIGHT airdrop (B) demoted to an
+optional follow-up that gives users long-term self-sufficiency rather
+than a bootstrap prerequisite. The protocol surface is already public
+SDK API; no contract-paymaster and no upstream changes are required.
+What C24 must now specify is the sponsor service contract: sequential
+dust accounting per sponsor wallet (finding 5), client-side capacity
+detection (F5), the user-TTL latency budget (F4), explicit
+`['dust']` balancing (F3), and the privacy trade-off that the sponsor
+sees the user's finalised transaction before submission and can link
+its dust spends to user activity. On the public networks the sponsor
+bootstraps from the faucet and regenerates DUST from held NIGHT, so a
+single funded wallet is a renewable fee source whose throughput
+envelope follows from the magnitudes above.

--- a/experiments/dust-sponsorship-feasibility/README.md
+++ b/experiments/dust-sponsorship-feasibility/README.md
@@ -1,0 +1,77 @@
+# DUST Sponsorship Feasibility — Experiment
+
+This experiment empirically determines whether the wallet-level DUST fee
+sponsorship pattern — where a sponsor wallet pays the DUST fees on a
+user's transaction via `tokenKindsToBalance` splitting — actually lands
+on the Midnight node end-to-end.
+
+It is a strict feasibility check: every result is backed by a
+reproducible transaction hash or a specific node error code, no
+theoretical analysis.
+
+## Status
+
+**Executed 2026/06/11** against `midnight-node:1.0.0` (the repository's
+current stable stack; the brief's original 0.22.5 pin was bumped on the
+day of the run, per the brief's own instruction). Verdict:
+**wallet-level DUST sponsorship is feasible on v1; alternative A in C24
+is the path forward.** Five tests PASS with on-chain transaction
+hashes; F3 is PARTIAL because the tutorial's corruption warning did not
+reproduce (the wrong `'all'` re-balance degrades gracefully) — itself a
+finding. Decisively for Passport, F6 shows a **zero-NIGHT, zero-DUST
+user deploying a contract** with the sponsor paying the fee: the
+onboarding transaction shape is sponsorable. See
+[`FINDINGS.md`](./FINDINGS.md) for the results table, fee magnitudes,
+sponsor-service requirements, and the C24 implications.
+
+## Why this matters
+
+The Passport v1.0 fee model
+([`.planning/concrete-plan.md` § C24](../../.planning/concrete-plan.md))
+hinges on whether a fresh-account user with zero NIGHT and zero DUST can
+transact at all. The neighbouring experiment
+[`../contract-custody-feasibility/`](../contract-custody-feasibility/)
+established that **contract-paymaster** (a contract paying its own or a
+user's fee branch) is not implementable on v1 (D1, D2 FAIL).
+
+A community-published tutorial describes a **wallet-level** alternative
+using existing SDK surfaces. The relevant APIs
+(`balanceUnboundTransaction`, `balanceFinalizedTransaction`,
+`tokenKindsToBalance`) are confirmed present in
+`@midnight-ntwrk/wallet-api: ^5.0.0` and `@midnight-ntwrk/wallet-sdk-facade`.
+What is **not** confirmed is whether the resulting two-balanced
+transaction is accepted by the node. This experiment closes that gap.
+
+## Where to start reading
+
+| File                       | Purpose                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `EXPERIMENT_GUIDELINE.md`  | The brief — goal, in-scope tests (F1–F6), setup, deliverables, acceptance |
+| `FINDINGS.md`              | The spike report: results table, verdict, C24 implications               |
+| `src/tests/`               | One TypeScript runner per test case                                      |
+| `src/sponsorship.ts`       | The two-party flow under test, plus sponsored midnight-js providers      |
+| `evidence/`                | Per-test JSON: balances, tx hash or error code, node-side notes          |
+
+## Running it
+
+```sh
+./run-all.sh           # localnet up + compile + all six tests + FINDINGS table
+./run-all.sh --fresh   # reset chain state first
+./run-all.sh --tests f1,f6
+```
+
+The harness mirrors
+[`../contract-custody-feasibility/`](../contract-custody-feasibility/)
+(same TypeScript layout, same SDK package family) with images bumped to
+the [`../account-custody-prototype/`](../account-custody-prototype/)
+stack. On macOS the localnet binds host ports 19944/18088/16300 so it
+runs beside the prototype's stack (9944/8088/6300) — sharing a chain
+means sharing its history, and `findDeployedContract` grinds on aged
+chains. Exact SDK resolutions are pinned in every evidence file.
+
+The six tests — F1 happy path, F2 zero-NIGHT zero-DUST onboarding, F3
+re-balance corruption (negative), F4 TTL expiry, F5 sponsor with
+insufficient DUST (negative), F6 sponsored contract deployment — are
+described in detail in `EXPERIMENT_GUIDELINE.md`. Two wallet seeds are
+required (one user, one sponsor); no new contracts are required for F1,
+and only a minimal counter contract for F2 and F6.

--- a/experiments/dust-sponsorship-feasibility/contracts/counter.compact
+++ b/experiments/dust-sponsorship-feasibility/contracts/counter.compact
@@ -1,0 +1,13 @@
+pragma language_version 0.23;
+
+import CompactStandardLibrary;
+
+// Minimal state-changing circuit for F2 and F6: produces a transaction whose
+// only economic component is the fee. No coins, no witnesses, no parameters.
+// The experiment is about who pays the Dust, not about contract design.
+
+export ledger round: Counter;
+
+export circuit bump_counter(): [] {
+  round.increment(1);
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f1-happy-path.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f1-happy-path.json
@@ -1,0 +1,57 @@
+{
+  "test": "F1",
+  "name": "happy-path",
+  "verdict": "PASS",
+  "txHash": "0030d3c27e518f5ca7e44e987928bf9633c4b1d4640139def1fc3ec6ef9d6117af",
+  "note": "Two-balanced tx accepted: user paid tokens, sponsor paid dust.",
+  "evidence": {
+    "fundingTx": "00e282764aa6b19372ae9f3801e40aeb503f3aefb251b81bde4d3457b5289ed8bc",
+    "userSeed": "8d17868d0f44339ffcd7c10ad92b5696362d9ac1d741ae3b15b4c02c5b5f1f62",
+    "fundAmount": "1000000",
+    "transferAmount": "100000",
+    "userBefore": {
+      "night": "1000000",
+      "dust": "0"
+    },
+    "userAfter": {
+      "night": "900000",
+      "dust": "0"
+    },
+    "sponsorBefore": {
+      "night": "249999999000000",
+      "dust": "1249999999999826393000000"
+    },
+    "sponsorAfter": {
+      "night": "249999999100000",
+      "dust": "1249984706050000000000000"
+    },
+    "wireHandoff": {
+      "serializable": true,
+      "bytes": 630,
+      "roundtrip": false,
+      "deserializeError": "arg.charCodeAt is not a function"
+    },
+    "ttl": "2026-06-11T13:32:33.662Z"
+  },
+  "ranAt": "2026-06-11T13:22:49.740Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f2-zero-start-onboarding.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f2-zero-start-onboarding.json
@@ -1,0 +1,56 @@
+{
+  "test": "F2",
+  "name": "zero-start-onboarding",
+  "verdict": "PASS",
+  "txHash": "000125b4e78542c5b1a6c5c3c6f6ff89a107bd127aa0df63d561bf5236418917ae",
+  "note": "User with zero NIGHT and zero DUST landed a sponsored circuit call.",
+  "evidence": {
+    "userSeed": "29af0af700724bc207dc4578f472a57d210a2329336010f486a90b9f0815a2e6",
+    "contractAddress": "f8ed3d78f7164a0d010ae2a15e616798f4bdd303139805d3eb52031dae77054c",
+    "userBefore": {
+      "night": "0",
+      "dust": "0"
+    },
+    "userAfter": {
+      "night": "0",
+      "dust": "0"
+    },
+    "sponsorBefore": {
+      "night": "249999999100000",
+      "dust": "1249999989926498413795088"
+    },
+    "sponsorAfter": {
+      "night": "249999999100000",
+      "dust": "1249999986027988072465053"
+    },
+    "wireHandoffs": [
+      {
+        "serializable": true,
+        "bytes": 3380,
+        "roundtrip": false,
+        "deserializeError": "arg.charCodeAt is not a function"
+      }
+    ]
+  },
+  "ranAt": "2026-06-11T13:24:08.251Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f3-rebalance-corruption.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f3-rebalance-corruption.json
@@ -1,0 +1,53 @@
+{
+  "test": "F3",
+  "name": "rebalance-corruption",
+  "verdict": "PARTIAL",
+  "txHash": "00836fe62e81f125a089b11da29a9bdc3ed0b7d9875b494e2e4fb952eae7b707af",
+  "note": "Sponsor 'all' re-balance degraded gracefully to dust-only; tx accepted, user change intact (post-hoc check).",
+  "evidence": {
+    "fundingTx": "004a0fd611d577cb9434f3967f1fed32883865f387ca8c14b5e8ceea624b947491",
+    "userSeed": "3d21a02f0b4c3fcbd97970b9bda3e7bb88bd9cc13b112201011b9476b3490934",
+    "userBefore": {
+      "night": "1000000",
+      "dust": "0"
+    },
+    "userAfter": {
+      "night": "0",
+      "dust": "0"
+    },
+    "sponsorAfter": {
+      "night": "249999998100000",
+      "dust": "1249970221235299122256237"
+    },
+    "tutorialWarningConfirmed": false,
+    "postHocCheck": {
+      "method": "CHECK_SEED=<userSeed> tsx src/check-balance.ts (re-sync the F3 user wallet after settlement)",
+      "settledUserBalances": {
+        "night": "900000",
+        "dust": "0"
+      },
+      "conclusion": "The sponsor's tokenKindsToBalance:'all' re-balance left the user's already-balanced unshielded section untouched; outcome identical to F1. Tutorial double-spend warning refuted on facade 4.0.1 / node 1.0.0."
+    }
+  },
+  "ranAt": "2026-06-11T13:25:48.793Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f4-ttl-expiry.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f4-ttl-expiry.json
@@ -1,0 +1,49 @@
+{
+  "test": "F4",
+  "name": "ttl-expiry",
+  "verdict": "PASS",
+  "errorCode": "ledger-182",
+  "note": "TTL-expired round-trip rejected at stage 'submit' with ledger-182.",
+  "evidence": {
+    "fundingTx": "00e6d48712d6e82f8648c8ba874b17aef2fc58c0d2fe2dce96ce33feedf38ba885",
+    "userSeed": "5f655a8a6780fe2d233427cfe5e5d7b8321a7feb420ee3836070cedd9628c98e",
+    "userTtlMs": 30000,
+    "sponsorDelayMs": 90000,
+    "failedAtStage": "submit",
+    "error": {
+      "name": "(FiberFailure) SubmissionError",
+      "message": "Transaction submission error",
+      "stack": "SubmissionError: Transaction submission error\n    at file:///Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/@midnight-ntwrk/wallet-sdk-capabilities/dist/submission/submissionService.js:31:279\n    at /Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/core.ts:1078:35\n    at <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/fiberRuntime.ts:1161:41)\n    at body (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/Utils.ts:786:14)\n    at FiberRuntime.Sync (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/fiberRuntime.ts:1161:19)\n    at <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/fiberRuntime.ts:1398:53)\n    at Object.f (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/tracer.ts:101:19)",
+      "cause": null
+    },
+    "nodeRejectionLines": [
+      "2026-06-11 14:40:22        RPC-CORE: submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1010: Invalid Transaction: Custom error: 182",
+      "2026-06-11 14:40:22        RPC-CORE: submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1010: Invalid Transaction: Custom error: 182"
+    ],
+    "userAfter": {
+      "night": "1000000",
+      "dust": "0"
+    }
+  },
+  "ranAt": "2026-06-11T13:40:22.660Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f5-insufficient-sponsor-dust.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f5-insufficient-sponsor-dust.json
@@ -1,0 +1,45 @@
+{
+  "test": "F5",
+  "name": "insufficient-sponsor-dust",
+  "verdict": "PASS",
+  "errorCode": "insufficient-dust",
+  "note": "Broke sponsor failed locally at balanceFinalizedTransaction: Insufficient Funds: could not balance dust",
+  "evidence": {
+    "fundingTx": "006c9665ae2d9bcebb5882856d0c2142141227827684b5f037dbb0443b772b3584",
+    "userSeed": "5c0204651f2880c4f3db3db89f158a1bfb77f3d4a580da582415658ee8a9214c",
+    "brokeSponsorSeed": "f0e578ac8514fe38b3faa22454c9e494177e68fa1864ad72cb1d4c2ec7945a13",
+    "brokeSponsorDust": "0",
+    "brokeBefore": {
+      "night": "0",
+      "dust": "0"
+    },
+    "failedAtStage": "sponsor-balance",
+    "error": {
+      "name": "(FiberFailure) Wallet.InsufficientFunds",
+      "message": "Insufficient Funds: could not balance dust",
+      "stack": "Wallet.InsufficientFunds: Insufficient Funds: could not balance dust\n    at catch (file:///Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet/dist/v1/Transacting.js:279:32)\n    at <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/core-effect.ts:108:32)\n    at body (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/Utils.ts:786:14)\n    at <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/core-effect.ts:108:13)\n    at <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/fiberRuntime.ts:1353:34)\n    at body (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/Utils.ts:786:14)\n    at FiberRuntime.Commit (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/dust-sponsorship-feasibility/node_modules/effect/src/internal/fiberRuntime.ts:1353:12)",
+      "cause": null
+    }
+  },
+  "ranAt": "2026-06-11T13:30:45.902Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/evidence/f6-sponsored-deployment.json
+++ b/experiments/dust-sponsorship-feasibility/evidence/f6-sponsored-deployment.json
@@ -1,0 +1,57 @@
+{
+  "test": "F6",
+  "name": "sponsored-deployment",
+  "verdict": "PASS",
+  "txHash": "0086c65c9b67a1c61fcf6887496fb15a64b5cbb54256204f7e81589cc2f3e5d455",
+  "note": "Zero-token user deployed a contract; sponsor paid the dust fee.",
+  "evidence": {
+    "userSeed": "9425c1451be7b83a93040788595a03753f2c37dbc65d56fd58f4f122dd3a0edc",
+    "contractAddress": "a25e334de4043d29dcc2e512a9a012b48f848f0a7907e28054e7a29f7206ac46",
+    "indexerSeesContract": true,
+    "userBefore": {
+      "night": "0",
+      "dust": "0"
+    },
+    "userAfter": {
+      "night": "0",
+      "dust": "0"
+    },
+    "sponsorBefore": {
+      "night": "249999996200000",
+      "dust": "1249849126960602120930643"
+    },
+    "sponsorAfter": {
+      "night": "249999996200000",
+      "dust": "1249840446359450615453459"
+    },
+    "wireHandoffs": [
+      {
+        "serializable": true,
+        "bytes": 1806,
+        "roundtrip": false,
+        "deserializeError": "arg.charCodeAt is not a function"
+      }
+    ]
+  },
+  "ranAt": "2026-06-11T13:32:08.471Z",
+  "sdkVersions": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0"
+  },
+  "nodeVersion": "midnightntwrk/midnight-node:1.0.0"
+}

--- a/experiments/dust-sponsorship-feasibility/infra/docker-compose.macos.yml
+++ b/experiments/dust-sponsorship-feasibility/infra/docker-compose.macos.yml
@@ -1,0 +1,45 @@
+# macOS override — bridge networking with port mappings.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+#
+# Host ports are offset by 10000 (19944/18088/16300) so this stack can run
+# beside the account-custody-prototype localnet (9944/8088/6300) — sharing
+# that stack means sharing its aged chain, and findDeployedContract grinds
+# through the whole history (observed: 240% CPU in wasm, unbounded memory
+# growth). The experiment wants a fresh, isolated chain anyway.
+
+services:
+  node:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "19944:9944"
+      - "30334:30333"
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9944/health']
+
+  indexer:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "18088:8088"
+    environment:
+      APP__INFRA__NODE__URL: 'ws://node:9944'
+      # indexer ≥4.3 runs a second (SPO) node connection with its own URL;
+      # without this it dials localhost inside the bridge network and the
+      # whole indexer exits once its reconnect budget runs out (~5 min).
+      APP__INFRA__SPO_NODE__URL: 'ws://node:9944'
+    depends_on:
+      node:
+        condition: service_healthy
+
+  proof-server:
+    network_mode: ""
+    networks: [midnight]
+    ports:
+      - "16300:6300"
+
+networks:
+  midnight:
+    driver: bridge

--- a/experiments/dust-sponsorship-feasibility/infra/docker-compose.yml
+++ b/experiments/dust-sponsorship-feasibility/infra/docker-compose.yml
@@ -1,0 +1,80 @@
+# Midnight local devnet — node + indexer + proof-server.
+# Run: docker compose up -d
+# macOS: docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+#
+# Image versions are pinned to those used by experiments/account-custody-
+# prototype/ — the repository's current stable Midnight stack. The brief
+# originally pinned node 0.22.5; bumped on the day the experiment was run,
+# per the brief's own instruction, and captured in FINDINGS.md (Header).
+#
+# `name:` is set explicitly — compose otherwise derives the project name from
+# the directory (`infra`), colliding with the other experiments' infra/ dirs.
+
+name: dust-sponsorship-feasibility
+
+services:
+  node:
+    image: 'midnightntwrk/midnight-node:1.0.0'
+    network_mode: host
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+    volumes:
+      - node-data:/data
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9944/health']
+      interval: 2s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    environment:
+      CFG_PRESET: 'dev'
+      SIDECHAIN_BLOCK_BENEFICIARY: '04bcf7ad3be7a5c790460be82a713af570f22e0f801f6659ab8e84a52be6969e'
+
+  indexer:
+    image: 'midnightntwrk/indexer-standalone:4.3.3'
+    network_mode: host
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - indexer-data:/data
+    env_file:
+      - .env
+    environment:
+      RUST_LOG: 'indexer=info,chain_indexer=info,indexer_api=info,info'
+      APP__INFRA__NODE__URL: 'ws://localhost:9944'
+      APP__APPLICATION__NETWORK_ID: 'undeployed'
+      # Required non-empty since indexer 4.3.x; SPO features are unused on
+      # the localnet, any placeholder is accepted (see the image's config.yaml).
+      APP__INFRA__SPO_NODE__BLOCKFROST_ID: 'dummy-not-using-spo'
+    healthcheck:
+      test: ['CMD-SHELL', 'cat /var/run/indexer-standalone/running']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+    depends_on:
+      node:
+        condition: service_healthy
+
+  proof-server:
+    image: 'midnightntwrk/proof-server:8.1.0'
+    network_mode: host
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      disable: true
+    environment:
+      RUST_BACKTRACE: 'full'
+      EXTRA_ARGS: -v
+
+volumes:
+  node-data:
+  indexer-data:

--- a/experiments/dust-sponsorship-feasibility/package-lock.json
+++ b/experiments/dust-sponsorship-feasibility/package-lock.json
@@ -1,0 +1,2910 @@
+{
+  "name": "dust-sponsorship-feasibility",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dust-sponsorship-feasibility",
+      "version": "0.1.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-runtime": "^0.16.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+        "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+        "@midnight-ntwrk/wallet-api": "^5.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+        "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+        "@midnight-ntwrk/zswap": "^4.0.0",
+        "@scure/bip39": "^2.0.1",
+        "bip39": "^3.1.0",
+        "rxjs": "^7.8.2",
+        "ws": "^8.19.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.3.tgz",
+      "integrity": "sha512-+auRYBXow2v7cT+wKzvjyMyyEojq+G7Sf80vIR57rtEPcxRFuMXuU9IKjwxZ3muclUgdGKwZXNeuki+g0GabgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "optimism": "^0.18.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0 || ^17.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.95.0.tgz",
+      "integrity": "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.4",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.20.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-js/-/compact-js-2.5.1.tgz",
+      "integrity": "sha512-UO0+tDiRadYFO2kaUu9PIhAOISvDKvmiyh9vSOyKEZLj3AUAY1qmmHm/oQrzPqrkiWHO0Rnln/j/zZ5dvc5vxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "^8.0.3",
+        "@midnight-ntwrk/platform-js": "^2.2.4",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/compact-runtime": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/compact-runtime/-/compact-runtime-0.16.0.tgz",
+      "integrity": "sha512-UR8+MI5zol+gkne17ZZru8xmZNf11xMgQJkiLT9KWsF+QD8Wuz1WONaqQLL0RAZ2aN2XlRsBFd0ViKDVh8prFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0",
+        "@types/object-inspect": "^1.8.1",
+        "object-inspect": "^1.12.3"
+      }
+    },
+    "node_modules/@midnight-ntwrk/ledger-v8": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger-v8/-/ledger-v8-8.1.0.tgz",
+      "integrity": "sha512-rwOVP5kBwACpYmmY6+oLeaiM3e5gHscRMjbZUOntOC5QdtqLdpeep6eQW1OngI+sxjjdVoGg2eE16sLf+DAHmQ=="
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-contracts": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-contracts/-/midnight-js-contracts-4.1.1.tgz",
+      "integrity": "sha512-vHeKyaj9RXTx+Cep3YpIRgg2EWkzibO4gxI7k/rYpXmGXc3waetrR5sb9FPR7v9SUX00/zf/sYbLp1NZhwZbjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-http-client-proof-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-http-client-proof-provider/-/midnight-js-http-client-proof-provider-4.1.1.tgz",
+      "integrity": "sha512-Q2VNRTvuWlf3MbjV7C3asuLHeFwtZMdh6t5Z+u8c8RDpejW9GhKaSjlJ2zgJII5ckE8/cocPEDwt3GKBebGHWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "cross-fetch": "^4.1.0",
+        "fetch-retry": "^6.0.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-indexer-public-data-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-indexer-public-data-provider/-/midnight-js-indexer-public-data-provider-4.1.1.tgz",
+      "integrity": "sha512-50CjiYqw/msRintyfkuNrJl1v4Zj+AaBFmV2uLjY/zpkPop4VBFH4QZSrtKsG1ljT9vzWsxU7Eo4Tn1tgKkPlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apollo/client": "^4.2.0",
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^4.1.0",
+        "graphql": "^16.14.0",
+        "graphql-ws": "^6.0.8",
+        "isomorphic-ws": "^5.0.0",
+        "rxjs": "^7.8.2",
+        "ws": "^8.20.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-level-private-state-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-level-private-state-provider/-/midnight-js-level-private-state-provider-4.1.1.tgz",
+      "integrity": "sha512-i+1lXJ4rcRGERnOPXHc3/Oh5ef7X/yb6p51bOAUjITazdPPcuU8qTeTeFgX+lPhWTGxROb9/pgrrVPH9G0FxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "abstract-level": "^3.1.1",
+        "buffer": "^6.0.3",
+        "level": "^10.0.0",
+        "superjson": "^2.2.6"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-network-id": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-network-id/-/midnight-js-network-id-4.1.1.tgz",
+      "integrity": "sha512-g49IBK0In1Jt2wKgi18rUvoy1ShGVrfb/VvgWALkc9Noc6+4MX5NTLVg5zqu+CyO2waIGb5lqDPnAhTD9wPAOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-node-zk-config-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-node-zk-config-provider/-/midnight-js-node-zk-config-provider-4.1.1.tgz",
+      "integrity": "sha512-fbBhLBhU/BjrQRnRJCcmKkhYRLlSqJyXEhq72vMS6vlKXprmDmAjlVV62+bn1aiAlNY9FXl1rrrMUFKQUmuZFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-types": "4.1.1",
+        "@midnight-ntwrk/midnight-js-utils": "4.1.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-protocol": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-protocol/-/midnight-js-protocol-4.1.1.tgz",
+      "integrity": "sha512-JH1010ir3YrawKsA4C08aIXWpFGHrCrAaBkZFbn+xh+iwOX5Ss0WU4//mDSEnHvQN0wD6GTc2JwUfKYFaS2CcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/compact-js": "2.5.1",
+        "@midnight-ntwrk/compact-runtime": "0.16.0",
+        "@midnight-ntwrk/ledger-v8": "8.1.0",
+        "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+        "@midnight-ntwrk/platform-js": "2.2.4"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-types/-/midnight-js-types-4.1.1.tgz",
+      "integrity": "sha512-MPT7YToXN2EsDtOOVSJonYZSZ4eqmdVgftBfH56w+tmZM0sZt9u+Mq18uuBQl9ebpTXnp8o7WqeISbgPMxTBcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "effect": "^3.20.0",
+        "pino": "^10.3.1",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/midnight-js-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/midnight-js-utils/-/midnight-js-utils-4.1.1.tgz",
+      "integrity": "sha512-b65QADd2FaZbWXe9D3fe9mSGmPlP1DTRMGSruJqhl9fOTNxBhQIzIKs0j/eL9Kv77dVeGDYgQdbV+JkDj3j5Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+        "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/onchain-runtime-v3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/onchain-runtime-v3/-/onchain-runtime-v3-3.0.0.tgz",
+      "integrity": "sha512-HbFbUOsvgpEFy1OT0Ni2LMFk4jnMQS1em+H+Mof/B3DpnNKl0Lkx5QiulKOc6pyU4KPEagOqx4fYNyVXFwgZ7g=="
+    },
+    "node_modules/@midnight-ntwrk/platform-js": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/platform-js/-/platform-js-2.2.4.tgz",
+      "integrity": "sha512-6mrYKSSE8kPgn/5rQ2xofDJk1yAZZRdLOO6Yelweuh5GOnOGz7Qw4venDG/c4TRqtV9ouFp+F5j7ta8aprMinw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.95.0",
+        "effect": "^3.20.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-api/-/wallet-api-5.0.0.tgz",
+      "integrity": "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/zswap": "^4.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "7.x"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-abstractions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-abstractions/-/wallet-sdk-abstractions-2.1.0.tgz",
+      "integrity": "sha512-mMcHFBrNxlZhurknS9J979HhrHQ0EsKdm6Kwaq7SAk/tStLOU2/sAoQzLUzzxr8Y60PcilTJdIKhaCgaydPATg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-address-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-3.1.2.tgz",
+      "integrity": "sha512-SRkgwmKFOZSUR25iurAB8U7kTKF7AljSl+tMkuuj8Pthc/l0yIg+/q1rFSozJ0Nz9FJRhshazDyrL0l84fOabg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@scure/base": "^2.0.0",
+        "@subsquid/scale-codec": "^4.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-capabilities": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-3.3.1.tgz",
+      "integrity": "sha512-V//D0wEKN0++XE+pKsXy6U5aH5/1+AoLdCl7Zp1RZilrdABffiywbJ0ZER/ePiTCG93ltDTz7L73WDyEJy6wPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-node-client": "^1.1.2",
+        "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-dust-wallet/-/wallet-sdk-dust-wallet-4.1.0.tgz",
+      "integrity": "sha512-RA+Zvb3a4LmyxMFOuHJUZ2I7WbtDHLyKVk1++4q/w3WH/G9dMMyv0H/dxsxjSnIlX9km1Ibf6dxYN4I3fmG9XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-facade": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-facade/-/wallet-sdk-facade-4.0.1.tgz",
+      "integrity": "sha512-m1AgeoS+jQrj2h5jQRIKv4UT61sWBF5S5PtzGi8/gweug3XYqPlkxJBZKZzS2078QDi9ToH/epWQeoUEqzKhvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.1",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.1.0",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-hd": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-hd/-/wallet-sdk-hd-3.0.2.tgz",
+      "integrity": "sha512-GdzZsfURF4WBh+bmSiimwOnj2vLjtd1pvMUJjRtY3OOnnr1mSesuX9//UPzb0fCjU1ZMCNb6UK7M2YcI4Gef4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-indexer-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-indexer-client/-/wallet-sdk-indexer-client-1.2.2.tgz",
+      "integrity": "sha512-GokfgV1lOhF1h341cuglp1VoTT/+yEDuYIbiPex29JJkFrjOXdJfCKPoROySBtyIyI65lnEBAXBT0+AOBjPzhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "graphql": "^16.13.0",
+        "graphql-http": "^1.22.4",
+        "graphql-ws": "^6.0.7"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-node-client": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-node-client/-/wallet-sdk-node-client-1.1.2.tgz",
+      "integrity": "sha512-nV6lg1M0QQOGss9JiofwO3+bcI+kQIoGV36F+KwyDMgUjAH2nT2/m3SbhLDGizwvJwgniWMuZQV6k/YZ7nCcWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@polkadot/api": "^16.5.4",
+        "@polkadot/types": "^16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@types/bn.js": "^5.2.0",
+        "bn.js": "^5.2.3",
+        "effect": "^3.19.19"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-prover-client/-/wallet-sdk-prover-client-1.2.2.tgz",
+      "integrity": "sha512-Xbniz3S/ab1uxiEJd3OaBxLkDfygPIAWgNZfApwAeac/U8yUVUjrqJ9aWyruztMY2MZHN7QxUjlcAWDK84hX3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@effect/platform": "^0.96.0",
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "web-worker": "^1.5.0"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-prover-client/node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-runtime": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-runtime/-/wallet-sdk-runtime-1.0.4.tgz",
+      "integrity": "sha512-Sc3mAkiCCNSI/BCrOtPoQDb+1rZlcr/Is9w90hRJJ8XT/7kdcmoekoctupXBLtc5UCeDX1FqUs2hz60CnwLoZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-shielded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-shielded/-/wallet-sdk-shielded-3.0.1.tgz",
+      "integrity": "sha512-/jNIXz1T4JvJNG67s1tODTPqb2lnBAZ2TuocZQmFj9N0hG2LYtA35Tm6sFUpy68HfPnxdyEWarK27Wj0VRbEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-unshielded-wallet": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-unshielded-wallet/-/wallet-sdk-unshielded-wallet-3.1.0.tgz",
+      "integrity": "sha512-GujzejaxF7Z1Pqmfp2uyz2mmtLb4ImIoL4njeh+3XLeSfJLedpizXi2WrHmcINO/z4x3pXTw3qU98dF04j97eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "^8.1.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.2",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.3.1",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.2",
+        "@midnight-ntwrk/wallet-sdk-runtime": "^1.0.4",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/wallet-sdk-utilities": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-utilities/-/wallet-sdk-utilities-1.2.0.tgz",
+      "integrity": "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@midnight-ntwrk/zkir-v2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zkir-v2/-/zkir-v2-2.1.0.tgz",
+      "integrity": "sha512-UDMujjzCt0SA89uqOFWUL4LZTkxVAS8JjvOaYMAgxlSrWfN7m5th1R1qGlpDJuSH39rbWt6WwtuK3k08Mta6LA=="
+    },
+    "node_modules/@midnight-ntwrk/zswap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zswap/-/zswap-4.0.0.tgz",
+      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@subsquid/scale-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.1.tgz",
+      "integrity": "sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2"
+      }
+    },
+    "node_modules/@subsquid/util-internal-hex": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==",
+      "license": "GPL-3.0-or-later"
+    },
+    "node_modules/@subsquid/util-internal-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.3.tgz",
+      "integrity": "sha512-H5qW5kG20IzVMpb7GhPbVRxGuACEf1DPIXE1+LNXYxt8t/GX4zQREQWHRvCB3lck+RORLJD3WJbQUtxN5UYB3Q==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/abstract-level": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-3.1.1.tgz",
+      "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^6.2.0",
+        "level-transcoder": "^1.0.1",
+        "maybe-combine-errors": "^1.0.0",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/browser-level": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-3.0.0.tgz",
+      "integrity": "sha512-kGXtLh29jMwqKaskz5xeDLtCtN1KBz/DbQSqmvH7QdJiyGRC7RAM8PPg6gvUiNMa+wVnaxS9eSmEtP/f5ajOVw==",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-3.0.0.tgz",
+      "integrity": "sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+      "integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
+      "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fastify/websocket": "^10 || ^11",
+        "crossws": "~0.3",
+        "graphql": "^15.10.1 || ^16",
+        "ws": "^8"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/websocket": {
+          "optional": true
+        },
+        "crossws": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/level": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-10.0.0.tgz",
+      "integrity": "sha512-aZJvdfRr/f0VBbSRF5C81FHON47ZsC2TkGxbBezXpGGXAUEL/s6+GP73nnhAYRSCIqUNsmJjfeOF4lzRDKbUig==",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^3.1.0",
+        "browser-level": "^3.0.0",
+        "classic-level": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-6.2.0.tgz",
+      "integrity": "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/maybe-combine-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
+      "integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "license": "MIT"
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.5.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/experiments/dust-sponsorship-feasibility/package.json
+++ b/experiments/dust-sponsorship-feasibility/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "dust-sponsorship-feasibility",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Empirical feasibility experiment — does wallet-level DUST fee sponsorship via tokenKindsToBalance splitting land on Midnight v1?",
+  "scripts": {
+    "compile": "compact compile contracts/counter.compact contracts/managed/counter",
+    "build": "tsc",
+    "deploy": "tsx src/deploy.ts",
+    "test:f1": "tsx src/tests/f1-happy-path.ts",
+    "test:f2": "tsx src/tests/f2-zero-start-onboarding.ts",
+    "test:f3": "tsx src/tests/f3-rebalance-corruption.ts",
+    "test:f4": "tsx src/tests/f4-ttl-expiry.ts",
+    "test:f5": "tsx src/tests/f5-insufficient-sponsor-dust.ts",
+    "test:f6": "tsx src/tests/f6-sponsored-deployment.ts",
+    "compose-findings": "tsx src/compose-findings.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/ledger-v8": "^8.0.3",
+    "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-network-id": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "^4.0.4",
+    "@midnight-ntwrk/midnight-js-types": "^4.0.4",
+    "@midnight-ntwrk/wallet-api": "^5.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "^4.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "^3.0.2",
+    "@midnight-ntwrk/wallet-sdk-shielded": "^3.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^3.0.0",
+    "@midnight-ntwrk/zswap": "^4.0.0",
+    "@scure/bip39": "^2.0.1",
+    "bip39": "^3.1.0",
+    "rxjs": "^7.8.2",
+    "ws": "^8.19.0"
+  }
+}

--- a/experiments/dust-sponsorship-feasibility/run-all.sh
+++ b/experiments/dust-sponsorship-feasibility/run-all.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# run-all.sh — bring up the devnet, compile, deploy, and run every test case.
+#
+# Acceptance criterion: this single script reproduces the entire experiment
+# end-to-end on a clean checkout. Anyone with the pinned SDK installed must
+# be able to reproduce the findings.
+#
+# Prerequisites:
+#   - Docker
+#   - Node.js >= 22
+#   - `compact` compiler on PATH
+#   - openssl (for one-time .env generation)
+#
+# Usage:
+#   ./run-all.sh              # run everything
+#   ./run-all.sh --fresh      # reset chain state first
+#   ./run-all.sh --tests f1   # run a subset (comma-separated test ids)
+#
+# Per-test evidence lands in evidence/<id>-<name>.json. After every test runs,
+# `tsx src/compose-findings.ts` regenerates the results table in FINDINGS.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$SCRIPT_DIR/infra"
+EVIDENCE_DIR="$SCRIPT_DIR/evidence"
+
+# ── Args ────────────────────────────────────────────────────────────────────
+
+FRESH=false
+TESTS=""
+for arg in "${@:-}"; do
+  case $arg in
+    --fresh) FRESH=true ;;
+    --tests=*) TESTS="${arg#--tests=}" ;;
+    --tests) shift; TESTS="${1:-}";;
+  esac
+done
+
+ALL_TESTS=(f1 f2 f3 f4 f5 f6)
+if [[ -n "$TESTS" ]]; then
+  IFS=',' read -r -a SELECTED <<< "$TESTS"
+else
+  SELECTED=("${ALL_TESTS[@]}")
+fi
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+check_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found"; exit 1; }; }
+check_cmd docker
+check_cmd node
+check_cmd openssl
+check_cmd compact
+
+NODE_MAJOR=$(node --version | sed 's/v\([0-9]*\).*/\1/')
+if [[ "$NODE_MAJOR" -lt 22 ]]; then
+  echo "ERROR: Node 22+ required (found $(node --version))"
+  exit 1
+fi
+
+# ── infra/.env ──────────────────────────────────────────────────────────────
+
+if [[ ! -f "$INFRA_DIR/.env" ]]; then
+  SECRET=$(openssl rand -hex 32)
+  sed "s/^APP__INFRA__SECRET=$/APP__INFRA__SECRET=$SECRET/" "$SCRIPT_DIR/.env.example" > "$INFRA_DIR/.env"
+  echo "infra/.env created (APP__INFRA__SECRET generated)"
+fi
+
+# Load .env into this shell so wallet seeds are available to tsx subprocesses.
+set -a
+source "$INFRA_DIR/.env"
+set +a
+export MIDNIGHT_NETWORK=local
+
+# ── Build ───────────────────────────────────────────────────────────────────
+
+cd "$SCRIPT_DIR"
+echo "Installing npm dependencies..."
+npm install --silent
+
+echo "Compiling Compact contract..."
+npm run compile
+
+# ── Compose ─────────────────────────────────────────────────────────────────
+
+COMPOSE_FILES="-f $INFRA_DIR/docker-compose.yml"
+NODE_PORT=9944
+INDEXER_PORT=8088
+PROOF_PORT=6300
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  COMPOSE_FILES="$COMPOSE_FILES -f $INFRA_DIR/docker-compose.macos.yml"
+  # Host ports offset by 10000 — see docker-compose.macos.yml for the why.
+  NODE_PORT=19944
+  INDEXER_PORT=18088
+  PROOF_PORT=16300
+  export NODE_URL="http://localhost:$NODE_PORT"
+  export INDEXER_URL="http://localhost:$INDEXER_PORT/api/v4/graphql"
+  export INDEXER_WS_URL="ws://localhost:$INDEXER_PORT/api/v4/graphql/ws"
+  export PROOF_SERVER_URL="http://127.0.0.1:$PROOF_PORT"
+fi
+COMPOSE="docker compose $COMPOSE_FILES"
+
+if $FRESH; then
+  echo ""
+  echo "=== Resetting chain state ==="
+  $COMPOSE down -v 2>/dev/null || true
+  rm -rf midnight-level-db deployment.json
+  sleep 2
+fi
+
+# ── Devnet ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Starting local Midnight devnet ==="
+$COMPOSE up -d node indexer proof-server
+
+echo "Waiting for node..."
+ELAPSED=0
+until curl -sf http://localhost:$NODE_PORT/health > /dev/null 2>&1; do
+  if (( ELAPSED >= 60 )); then
+    echo "ERROR: node did not start within 60s"
+    $COMPOSE logs node --tail 20
+    exit 1
+  fi
+  printf "."; sleep 2; (( ELAPSED += 2 ))
+done
+echo " OK"
+
+echo "Waiting for indexer..."
+ELAPSED=0
+until curl -sf http://localhost:$INDEXER_PORT/api/v4/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ __typename }"}' > /dev/null 2>&1; do
+  if (( ELAPSED >= 120 )); then
+    echo "WARN: indexer not ready after 120s"
+    break
+  fi
+  printf "."; sleep 3; (( ELAPSED += 3 ))
+done
+echo " OK"
+
+echo "Waiting for proof server..."
+ELAPSED=0
+until curl -sf http://localhost:$PROOF_PORT/version > /dev/null 2>&1; do
+  if (( ELAPSED >= 30 )); then
+    echo "WARN: proof server not responding"; break
+  fi
+  printf "."; sleep 2; (( ELAPSED += 2 ))
+done
+echo " OK"
+
+# ── Deploy (F2 setup: sponsor-paid counter instance) ────────────────────────
+
+mkdir -p "$EVIDENCE_DIR"
+
+if printf '%s\n' "${SELECTED[@]}" | grep -qx 'f2' && [[ ! -f "deployment.json" ]]; then
+  echo ""
+  echo "=== Deploying counter contract (sponsor-paid, setup for F2) ==="
+  npx tsx src/deploy.ts
+fi
+
+# ── Per-test execution ──────────────────────────────────────────────────────
+
+test_file_for() {
+  case "$1" in
+    f1) echo "src/tests/f1-happy-path.ts" ;;
+    f2) echo "src/tests/f2-zero-start-onboarding.ts" ;;
+    f3) echo "src/tests/f3-rebalance-corruption.ts" ;;
+    f4) echo "src/tests/f4-ttl-expiry.ts" ;;
+    f5) echo "src/tests/f5-insufficient-sponsor-dust.ts" ;;
+    f6) echo "src/tests/f6-sponsored-deployment.ts" ;;
+    *)  echo "" ;;
+  esac
+}
+
+upcase() { echo "$1" | tr '[:lower:]' '[:upper:]'; }
+
+for tid in "${SELECTED[@]}"; do
+  file=$(test_file_for "$tid")
+  if [[ -z "$file" ]]; then
+    echo "WARN: unknown test id '$tid', skipping"; continue
+  fi
+  TID_UPPER=$(upcase "$tid")
+  echo ""
+  echo "=== ${TID_UPPER}: ${file##*/} ==="
+  npx tsx "$file" || true   # never abort the suite — collect every test's outcome
+done
+
+# ── Compose FINDINGS.md ─────────────────────────────────────────────────────
+
+echo ""
+echo "=== Composing FINDINGS.md from evidence ==="
+npx tsx src/compose-findings.ts
+
+echo ""
+echo "=== Done ==="
+echo "Evidence: $EVIDENCE_DIR"
+echo "Report:   $SCRIPT_DIR/FINDINGS.md"

--- a/experiments/dust-sponsorship-feasibility/src/check-balance.ts
+++ b/experiments/dust-sponsorship-feasibility/src/check-balance.ts
@@ -1,0 +1,17 @@
+// Post-hoc balance check: sync a wallet from a seed recorded in evidence and
+// print its settled balances. Used to characterise F3 (whether the user's
+// change output survived the sponsor's 'all' re-balance).
+//
+// Usage: CHECK_SEED=<hex> tsx src/check-balance.ts
+
+import { createWallet } from './utils.js';
+import { syncWallet, currentState, balancesSnapshot } from './common.js';
+
+const seed = process.env.CHECK_SEED;
+if (!seed) throw new Error('CHECK_SEED env var required');
+
+const ctx = await createWallet(seed);
+await syncWallet(ctx, 'check');
+console.log(JSON.stringify(balancesSnapshot(await currentState(ctx)), null, 1));
+await ctx.wallet.stop();
+setTimeout(() => process.exit(0), 100).unref();

--- a/experiments/dust-sponsorship-feasibility/src/common.ts
+++ b/experiments/dust-sponsorship-feasibility/src/common.ts
@@ -1,0 +1,153 @@
+// Shared helpers — wallet sync, balance reading, evidence serialisation.
+//
+// Adapted from experiments/contract-custody-feasibility/src/common.ts. The
+// interactive mnemonic entry is dropped: every wallet in this experiment is
+// driven from an env seed or a freshly generated random seed, never a prompt.
+
+import * as rx from 'rxjs';
+import { Buffer } from 'node:buffer';
+import { randomBytes } from 'node:crypto';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import { ZswapChainState, nativeToken } from '@midnight-ntwrk/ledger-v8';
+
+import type { createWallet } from './utils.js';
+
+// Workaround for ledger-v8 bug: MerkleTree::collapse panics on non-empty
+// trees when producing shielded outputs. Inherited from contract-custody-
+// feasibility — drop on the day this issue is verified fixed and leave a
+// comment in FINDINGS.md if so.
+const _origTryApply = ZswapChainState.prototype.tryApply;
+ZswapChainState.prototype.tryApply = function (...args: unknown[]) {
+  try {
+    return _origTryApply.apply(this, args as any);
+  } catch {
+    return [this, new Map()];
+  }
+};
+
+export const NIGHT_RAW = nativeToken().raw;
+
+export function hexToBytes32(hex: string): Uint8Array {
+  const cleanHex = hex.replace(/^0x/, '');
+  const buffer = Buffer.from(cleanHex, 'hex');
+  const bytes = new Uint8Array(32);
+  bytes.set(buffer.subarray(0, Math.min(32, buffer.length)));
+  return bytes;
+}
+
+export function randomSeed(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export async function syncWallet(
+  walletCtx: Awaited<ReturnType<typeof createWallet>>,
+  label: string,
+): Promise<void> {
+  process.stdout.write(`Syncing ${label} to network`);
+  await rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(
+      rx.throttleTime(5_000),
+      rx.tap(() => process.stdout.write(' .')),
+      rx.filter((state) => state.isSynced === true),
+    ),
+  );
+  console.log('\nWallet Synced!');
+}
+
+export async function currentState(
+  walletCtx: Awaited<ReturnType<typeof createWallet>>,
+): Promise<any> {
+  return rx.firstValueFrom(walletCtx.wallet.state());
+}
+
+// Wait until the wallet state satisfies a predicate, or time out.
+export async function waitForState(
+  walletCtx: Awaited<ReturnType<typeof createWallet>>,
+  predicate: (state: any) => boolean,
+  timeoutMs = 120_000,
+  label = 'condition',
+): Promise<any> {
+  return rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(
+      rx.filter(predicate),
+      rx.timeout({ first: timeoutMs, with: () => rx.throwError(() => new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`)) }),
+    ),
+  );
+}
+
+export function nightBalanceOf(state: any): bigint {
+  const balances = state?.unshielded?.balances as Record<string, bigint> | undefined;
+  if (!balances) return 0n;
+  return BigInt(balances[NIGHT_RAW] ?? 0n);
+}
+
+// The Dust wallet exposes its balance behind a couple of API shapes,
+// depending on SDK minor. Probe them in order; null means unreadable, which
+// is itself worth recording in evidence.
+export function dustBalanceOf(state: any): bigint | null {
+  try {
+    const dustState = state?.dust;
+    const viaCapabilities =
+      dustState?.capabilities?.coinsAndBalances?.getWalletBalance?.(dustState.state, new Date());
+    if (viaCapabilities !== undefined) return BigInt(viaCapabilities);
+    const viaMethod = dustState?.walletBalance?.(new Date());
+    if (viaMethod !== undefined) return BigInt(viaMethod);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function balancesSnapshot(state: any): Record<string, string> {
+  return {
+    night: nightBalanceOf(state).toString(),
+    dust: dustBalanceOf(state)?.toString() ?? '(unreadable)',
+  };
+}
+
+// ─── Evidence file writer ────────────────────────────────────────────────────
+//
+// Every test case writes one JSON file under evidence/. The shape is fixed so
+// FINDINGS.md can be regenerated mechanically.
+
+export type Verdict = 'PASS' | 'FAIL' | 'PARTIAL' | 'PENDING';
+
+export interface Evidence {
+  test: string;            // brief test ID, e.g. 'F1'
+  name: string;            // descriptive name, e.g. 'happy-path'
+  verdict: Verdict;
+  txHash?: string;         // present when verdict === 'PASS'
+  errorCode?: string;      // present when verdict === 'FAIL' (e.g. 'ledger-168')
+  note: string;            // one-line summary
+  evidence: Record<string, unknown>;  // full request/response/log payload
+  ranAt: string;           // ISO timestamp
+  sdkVersions: Record<string, string>;
+  nodeVersion: string;
+}
+
+export function writeEvidence(testId: string, payload: Omit<Evidence, 'ranAt' | 'sdkVersions' | 'nodeVersion'>): string {
+  const evidenceDir = resolve(dirname(new URL(import.meta.url).pathname), '..', 'evidence');
+  mkdirSync(evidenceDir, { recursive: true });
+  const filePath = resolve(evidenceDir, `${testId.toLowerCase()}-${payload.name}.json`);
+  const sdkVersions = readSdkVersions();
+  const full: Evidence = {
+    ...payload,
+    ranAt: new Date().toISOString(),
+    sdkVersions,
+    nodeVersion: process.env.MIDNIGHT_NODE_IMAGE ?? 'midnightntwrk/midnight-node:1.0.0',
+  };
+  writeFileSync(filePath, JSON.stringify(full, (_k, v) => (typeof v === 'bigint' ? v.toString() : v), 2) + '\n');
+  return filePath;
+}
+
+function readSdkVersions(): Record<string, string> {
+  const pkgPath = resolve(dirname(new URL(import.meta.url).pathname), '..', 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  const out: Record<string, string> = {};
+  for (const [name, version] of Object.entries(pkg.dependencies as Record<string, string>)) {
+    if (name.startsWith('@midnight-ntwrk/')) out[name] = version;
+  }
+  return out;
+}

--- a/experiments/dust-sponsorship-feasibility/src/compose-findings.ts
+++ b/experiments/dust-sponsorship-feasibility/src/compose-findings.ts
@@ -1,0 +1,97 @@
+// Regenerate FINDINGS.md's results table mechanically from evidence/*.json.
+//
+// Reads every JSON file in evidence/, looks up the matching test id, and
+// rewrites the section between the markers
+//
+//   <!-- BEGIN-RESULTS-TABLE -->
+//   ...
+//   <!-- END-RESULTS-TABLE -->
+//
+// in FINDINGS.md.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '..');
+const EVIDENCE_DIR = path.join(ROOT, 'evidence');
+const FINDINGS = path.join(ROOT, 'FINDINGS.md');
+
+const TEST_ORDER = ['F1', 'F2', 'F3', 'F4', 'F5', 'F6'];
+const TEST_DESCRIPTIONS: Record<string, string> = {
+  F1: 'happy path: user balances tokens, sponsor balances dust',
+  F2: 'zero-NIGHT zero-DUST user circuit call',
+  F3: "re-balance corruption: sponsor balances 'all' (negative)",
+  F4: 'TTL expiry across the user→sponsor round-trip (negative)',
+  F5: 'sponsor with insufficient DUST (negative)',
+  F6: 'sponsored contract deployment (Passport onboarding shape)',
+};
+
+interface Evidence {
+  test: string;
+  name: string;
+  verdict: 'PASS' | 'FAIL' | 'PARTIAL' | 'PENDING';
+  txHash?: string;
+  errorCode?: string;
+  note: string;
+}
+
+function loadEvidence(): Map<string, Evidence> {
+  const out = new Map<string, Evidence>();
+  if (!fs.existsSync(EVIDENCE_DIR)) return out;
+  for (const f of fs.readdirSync(EVIDENCE_DIR)) {
+    if (!f.endsWith('.json')) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(EVIDENCE_DIR, f), 'utf-8')) as Evidence;
+      if (data.test) {
+        const existing = out.get(data.test);
+        if (!existing || (data as any).ranAt > (existing as any).ranAt) out.set(data.test, data);
+      }
+    } catch {
+      // Skip unparseable files.
+    }
+  }
+  return out;
+}
+
+function buildTable(evidence: Map<string, Evidence>): string {
+  const lines: string[] = [];
+  lines.push('| Test | Status  | Tx hash / error code | Note                                         |');
+  lines.push('| ---- | ------- | -------------------- | -------------------------------------------- |');
+  for (const id of TEST_ORDER) {
+    const e = evidence.get(id);
+    if (!e) {
+      lines.push(`| ${id}   | PENDING | —                    | ${TEST_DESCRIPTIONS[id]}`.padEnd(94) + '|');
+      continue;
+    }
+    const tx = e.txHash ? trimTx(e.txHash) : e.errorCode ?? '—';
+    lines.push(`| ${id}   | ${e.verdict.padEnd(7)} | ${tx.padEnd(20)} | ${(e.note || TEST_DESCRIPTIONS[id]).slice(0, 44).padEnd(44)} |`);
+  }
+  return lines.join('\n');
+}
+
+function trimTx(tx: string): string {
+  return tx.length > 20 ? tx.slice(0, 8) + '...' + tx.slice(-7) : tx;
+}
+
+function rewriteFindings(newTable: string): void {
+  const text = fs.readFileSync(FINDINGS, 'utf-8');
+  const begin = '<!-- BEGIN-RESULTS-TABLE -->';
+  const end = '<!-- END-RESULTS-TABLE -->';
+
+  if (text.includes(begin) && text.includes(end)) {
+    const re = new RegExp(`${begin}[\\s\\S]*?${end}`);
+    const out = text.replace(re, `${begin}\n\n${newTable}\n\n${end}`);
+    fs.writeFileSync(FINDINGS, out);
+    console.log(`Updated FINDINGS.md results table (${TEST_ORDER.length} rows).`);
+    return;
+  }
+
+  console.warn('Could not locate results-table markers in FINDINGS.md; appending instead.');
+  fs.appendFileSync(FINDINGS, `\n\n${newTable}\n`);
+}
+
+const ev = loadEvidence();
+console.log(`Loaded ${ev.size} evidence file(s).`);
+rewriteFindings(buildTable(ev));

--- a/experiments/dust-sponsorship-feasibility/src/deploy.ts
+++ b/experiments/dust-sponsorship-feasibility/src/deploy.ts
@@ -1,0 +1,26 @@
+// Deploy the counter contract with the sponsor paying its own fees — this is
+// setup for F2 (the zero-start user needs a pre-existing contract to call),
+// not the pattern under test. F6 deploys its own instance through the
+// sponsored flow.
+//
+// Usage:
+//   npm run deploy
+
+import { createProviders } from './utils.js';
+import { setupSponsor, setupCounter } from './test-helpers.js';
+
+async function main() {
+  console.log('═══ Deploy counter contract (sponsor-paid, setup for F2) ═══\n');
+
+  const sponsorCtx = await setupSponsor();
+  const providers = await createProviders(sponsorCtx);
+  const { address } = await setupCounter(providers, { reuseDeployment: false });
+  console.log(`\nDeployed @ ${address}`);
+  await sponsorCtx.wallet.stop();
+  setTimeout(() => process.exit(0), 100).unref();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/experiments/dust-sponsorship-feasibility/src/sponsorship.ts
+++ b/experiments/dust-sponsorship-feasibility/src/sponsorship.ts
@@ -1,0 +1,165 @@
+// The two-party wallet-level DUST sponsorship flow under test.
+//
+// User phase:    balance every token kind EXCEPT dust, sign, finalize.
+// Sponsor phase: balanceFinalizedTransaction(..., ['dust']), sign, finalize,
+//                submit.
+//
+// Per the brief (EXPERIMENT_GUIDELINE.md § Pattern summary), the result is a
+// single fully-balanced transaction with both parties' contributions baked
+// in. No contract-paymaster fee branch is involved.
+
+import * as Rx from 'rxjs';
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+
+import { CONFIG, zkConfigPath, PRIVATE_STATE_ID, type WalletCtx } from './utils.js';
+
+export const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+export type TokenKinds = 'all' | ('dust' | 'shielded' | 'unshielded')[];
+
+export function signerFor(ctx: WalletCtx) {
+  return (data: Uint8Array) => ctx.unshieldedKeystore.signData(data);
+}
+
+// Sign a balancing recipe with the given wallet's unshielded keystore and
+// finalize it (proving happens inside finalizeRecipe, via the facade's
+// proving service).
+export async function finalizeRecipeAs(ctx: WalletCtx, recipe: any) {
+  const signed = await ctx.wallet.signRecipe(recipe, signerFor(ctx));
+  return ctx.wallet.finalizeRecipe(signed);
+}
+
+// ── User phase ──────────────────────────────────────────────────────────────
+
+// For unbound transactions (contract calls and deployments coming out of
+// midnight-js): the user balances shielded + unshielded only, leaving the
+// dust branch open for the sponsor.
+export async function userBalanceUnbound(userCtx: WalletCtx, tx: any, ttl: Date) {
+  const recipe = await userCtx.wallet.balanceUnboundTransaction(
+    tx,
+    {
+      shieldedSecretKeys: userCtx.shieldedSecretKeys,
+      dustSecretKey: userCtx.dustSecretKey,
+    },
+    { ttl, tokenKindsToBalance: ['shielded', 'unshielded'] },
+  );
+  return finalizeRecipeAs(userCtx, recipe);
+}
+
+// For plain transfers: transferTransaction with payFees: false builds the
+// user's intent (their own coins in, recipient out) without a dust action.
+export async function userTransferWithoutFees(
+  userCtx: WalletCtx,
+  outputs: any[],
+  ttl: Date,
+) {
+  const recipe = await userCtx.wallet.transferTransaction(
+    outputs,
+    {
+      shieldedSecretKeys: userCtx.shieldedSecretKeys,
+      dustSecretKey: userCtx.dustSecretKey,
+    },
+    { ttl, payFees: false },
+  );
+  return finalizeRecipeAs(userCtx, recipe);
+}
+
+// ── Sponsor phase ───────────────────────────────────────────────────────────
+
+export async function sponsorBalanceDust(
+  sponsorCtx: WalletCtx,
+  finalizedTx: any,
+  ttl: Date,
+  tokenKindsToBalance: TokenKinds = ['dust'],
+) {
+  const recipe = await sponsorCtx.wallet.balanceFinalizedTransaction(
+    finalizedTx,
+    {
+      shieldedSecretKeys: sponsorCtx.shieldedSecretKeys,
+      dustSecretKey: sponsorCtx.dustSecretKey,
+    },
+    { ttl, tokenKindsToBalance },
+  );
+  return finalizeRecipeAs(sponsorCtx, recipe);
+}
+
+// ── Wire-handoff probe ──────────────────────────────────────────────────────
+//
+// In a real sponsor service the user→sponsor handoff crosses a network
+// boundary. Probe whether the finalized transaction serialises and
+// deserialises; record the outcome in evidence but never fail a test on it —
+// node acceptance is the question, wire format is a bonus observation.
+
+export function probeWireRoundtrip(finalizedTx: any): Record<string, unknown> {
+  try {
+    if (typeof finalizedTx?.serialize !== 'function') {
+      return { serializable: false, reason: 'no serialize() on FinalizedTransaction' };
+    }
+    const bytes = finalizedTx.serialize();
+    const ctor: any = finalizedTx.constructor;
+    if (typeof ctor?.deserialize === 'function') {
+      try {
+        // Common signatures: (raw) or (marker..., raw). Try plain first.
+        ctor.deserialize(bytes);
+        return { serializable: true, bytes: bytes.length, roundtrip: true };
+      } catch (e: any) {
+        return { serializable: true, bytes: bytes.length, roundtrip: false, deserializeError: e?.message };
+      }
+    }
+    return { serializable: true, bytes: bytes.length, roundtrip: 'no static deserialize' };
+  } catch (e: any) {
+    return { serializable: false, error: e?.message ?? String(e) };
+  }
+}
+
+// ── Sponsored providers for midnight-js ─────────────────────────────────────
+//
+// Drop-in providers where fee balancing is split across the two wallets:
+// every transaction midnight-js asks to balance goes through the user phase
+// (shielded + unshielded, user signs) and then the sponsor phase (dust,
+// sponsor signs); submission goes through the sponsor's wallet. This IS the
+// sponsor service in miniature — F2 and F6 exercise it for a circuit call
+// and a deployment respectively.
+
+export async function createSponsoredProviders(userCtx: WalletCtx, sponsorCtx: WalletCtx) {
+  const userState = await Rx.firstValueFrom(
+    userCtx.wallet.state().pipe(Rx.filter((s) => s.isSynced)),
+  );
+
+  const handoffLog: Record<string, unknown>[] = [];
+
+  const walletProvider = {
+    getCoinPublicKey: () => userState.shielded.coinPublicKey.toHexString(),
+    getEncryptionPublicKey: () => userState.shielded.encryptionPublicKey.toHexString(),
+    async balanceTx(tx: any, ttl?: Date) {
+      const effectiveTtl = ttl ?? new Date(Date.now() + DEFAULT_TTL_MS);
+      const userFinalized = await userBalanceUnbound(userCtx, tx, effectiveTtl);
+      handoffLog.push(probeWireRoundtrip(userFinalized));
+      return sponsorBalanceDust(sponsorCtx, userFinalized, effectiveTtl);
+    },
+    submitTx: (tx: any) => sponsorCtx.wallet.submitTransaction(tx) as any,
+  };
+
+  const zkConfigProvider = new NodeZkConfigProvider(zkConfigPath);
+
+  return {
+    providers: {
+      privateStateProvider: levelPrivateStateProvider({
+        midnightDbName: `midnight-level-db`,
+        privateStateStoreName: PRIVATE_STATE_ID,
+        privateStoragePasswordProvider: () => 'DustSponsorship!exp',
+        accountId: userState.shielded.encryptionPublicKey.toHexString().slice(0, 16),
+        walletProvider,
+      }),
+      publicDataProvider: indexerPublicDataProvider(CONFIG.indexer, CONFIG.indexerWS),
+      zkConfigProvider,
+      proofProvider: httpClientProofProvider(CONFIG.proofServer, zkConfigProvider),
+      walletProvider,
+      midnightProvider: walletProvider,
+    },
+    handoffLog,
+  };
+}

--- a/experiments/dust-sponsorship-feasibility/src/test-helpers.ts
+++ b/experiments/dust-sponsorship-feasibility/src/test-helpers.ts
@@ -1,0 +1,308 @@
+// Shared helpers for individual test runners under src/tests/.
+//
+// Each test under src/tests/ should:
+//   1. set up its wallets (sponsor from WALLET_SEED, user from a fresh seed)
+//   2. await the test action (the two-phase sponsorship flow)
+//   3. write evidence via writeEvidence() with verdict + tx hash or error code
+//
+// The intent is that adding a test is no more than one small file.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { CompiledContract } from '@midnight-ntwrk/compact-js';
+
+import { createWallet, CounterContract, zkConfigPath, PRIVATE_STATE_ID, unshieldedAddressOf, type WalletCtx } from './utils.js';
+import {
+  syncWallet,
+  currentState,
+  waitForState,
+  nightBalanceOf,
+  randomSeed,
+  writeEvidence,
+  NIGHT_RAW,
+  type Verdict,
+} from './common.js';
+import { finalizeRecipeAs, DEFAULT_TTL_MS } from './sponsorship.js';
+
+export const COMPILED_COUNTER = () =>
+  CompiledContract.make('counter', CounterContract.Contract).pipe(
+    CompiledContract.withVacantWitnesses,
+    CompiledContract.withCompiledFileAssets(zkConfigPath),
+  );
+
+export const DEPLOYMENT_FILE = 'deployment.json';
+
+// ── Wallet setup ────────────────────────────────────────────────────────────
+
+export async function setupSponsor(): Promise<WalletCtx> {
+  const seed = process.env.WALLET_SEED;
+  if (!seed) throw new Error('WALLET_SEED env var required (sponsor wallet)');
+  const ctx = await createWallet(seed);
+  await syncWallet(ctx, 'sponsor');
+  return ctx;
+}
+
+export async function setupFreshWallet(label: string, envOverride?: string): Promise<WalletCtx> {
+  const seed = (envOverride && process.env[envOverride]) || randomSeed();
+  const ctx = await createWallet(seed);
+  await syncWallet(ctx, label);
+  return ctx;
+}
+
+// Fund a user wallet with Night from the sponsor (sponsor pays its own fees —
+// this is setup, not the pattern under test). Waits until the user wallet
+// sees the funds.
+export async function fundUserWithNight(
+  sponsorCtx: WalletCtx,
+  userCtx: WalletCtx,
+  amount: bigint,
+): Promise<string> {
+  const sponsorNightBefore = nightBalanceOf(await currentState(sponsorCtx));
+  const ttl = new Date(Date.now() + DEFAULT_TTL_MS);
+  const recipe = await sponsorCtx.wallet.transferTransaction(
+    [
+      {
+        type: 'unshielded',
+        outputs: [
+          {
+            type: NIGHT_RAW,
+            receiverAddress: unshieldedAddressOf(userCtx),
+            amount,
+          },
+        ],
+      },
+    ] as any,
+    {
+      shieldedSecretKeys: sponsorCtx.shieldedSecretKeys,
+      dustSecretKey: sponsorCtx.dustSecretKey,
+    },
+    { ttl },
+  );
+  const finalized = await finalizeRecipeAs(sponsorCtx, recipe);
+  const txId = await sponsorCtx.wallet.submitTransaction(finalized);
+  console.log(`Funding tx submitted: ${txId}`);
+  await waitForState(
+    userCtx,
+    (s) => nightBalanceOf(s) >= amount,
+    180_000,
+    `user Night balance >= ${amount}`,
+  );
+  // The sponsor wallet must also see the funding tx applied before it
+  // balances anything else: its dust wallet spent a coin in this tx, and a
+  // sponsored balancing built against the stale state re-spends the same
+  // dust nullifier (observed on-node as DustDoubleSpend).
+  await waitForState(
+    sponsorCtx,
+    (s) => nightBalanceOf(s) <= sponsorNightBefore - amount,
+    180_000,
+    'sponsor state to reflect the funding spend',
+  );
+  await settle();
+  return String(txId);
+}
+
+// The dust wallet's view updates on the same indexer stream as the
+// unshielded one, but its state transition is not observable via balances
+// alone — give it a moment after the balance waits.
+export const settle = (ms = Number(process.env.SETTLE_MS ?? '8000')) =>
+  new Promise((r) => setTimeout(r, ms));
+
+// ── Counter contract ────────────────────────────────────────────────────────
+
+export function requireCompiled(): void {
+  if (!fs.existsSync(path.join(zkConfigPath, 'contract', 'index.js'))) {
+    throw new Error('Contract not compiled. Run: npm run compile');
+  }
+}
+
+// Deploy the counter (or reuse an existing deployment) with the given
+// providers. Used by deploy.ts with the sponsor's own providers, and by F6
+// with the sponsored providers (reuse=false, the deployment is the test).
+export async function setupCounter(
+  providers: any,
+  opts: { reuseDeployment?: boolean } = {},
+): Promise<{ address: string; found: any }> {
+  requireCompiled();
+  const reuse = opts.reuseDeployment ?? true;
+  const compiled = COMPILED_COUNTER();
+
+  if (reuse && fs.existsSync(DEPLOYMENT_FILE)) {
+    const address = JSON.parse(fs.readFileSync(DEPLOYMENT_FILE, 'utf-8')).contractAddress;
+    console.log(`Connecting to counter contract @ ${address}`);
+    const found = await (findDeployedContract as any)(providers, {
+      contractAddress: address,
+      compiledContract: compiled,
+      privateStateId: PRIVATE_STATE_ID,
+      initialPrivateState: {},
+    });
+    return { address, found };
+  }
+
+  console.log('Deploying counter contract...');
+  const deployed = await deployContract(providers, {
+    compiledContract: compiled,
+    privateStateId: PRIVATE_STATE_ID,
+    initialPrivateState: {},
+  });
+  const address = deployed.deployTxData.public.contractAddress;
+  fs.writeFileSync(
+    DEPLOYMENT_FILE,
+    JSON.stringify({ contractAddress: address, deployedAt: new Date().toISOString() }, null, 2),
+  );
+  console.log(`Deployed counter @ ${address}`);
+  return { address, found: deployed };
+}
+
+// ── Test runner ─────────────────────────────────────────────────────────────
+
+export async function runTest(opts: {
+  testId: string;       // 'F1', 'F6', etc.
+  name: string;         // descriptive: 'happy-path'
+  description: string;
+  action: () => Promise<{ verdict: Verdict; txHash?: string; errorCode?: string; note: string; details: Record<string, unknown> }>;
+}): Promise<void> {
+  const banner = `\n━━━ ${opts.testId}: ${opts.description} ━━━`;
+  console.log(banner);
+  let result: Awaited<ReturnType<typeof opts.action>>;
+  try {
+    result = await opts.action();
+  } catch (e: any) {
+    result = {
+      verdict: 'FAIL',
+      errorCode: classifyError(e),
+      note: `Threw: ${e?.message ?? String(e)}`,
+      details: { error: serialiseError(e) },
+    };
+  }
+  const file = writeEvidence(opts.testId, {
+    test: opts.testId,
+    name: opts.name,
+    verdict: result.verdict,
+    txHash: result.txHash,
+    errorCode: result.errorCode,
+    note: result.note,
+    evidence: result.details,
+  });
+  console.log(`◆ ${opts.testId} verdict: ${result.verdict}`);
+  if (result.txHash) console.log(`  tx:    ${result.txHash}`);
+  if (result.errorCode) console.log(`  error: ${result.errorCode}`);
+  console.log(`  note:  ${result.note}`);
+  console.log(`  evidence: ${path.relative(process.cwd(), file)}`);
+
+  // Force exit. Wallet/indexer subscriptions keep the event loop alive
+  // even after wallet.stop(); on the failure path stop() is never reached
+  // and the process hangs entirely. The bash orchestrator captures the exit
+  // code with `|| true`, so exiting non-zero on FAIL is harmless and
+  // surfaces failures clearly.
+  setTimeout(() => process.exit(result.verdict === 'FAIL' ? 1 : 0), 100).unref();
+}
+
+// Classify a thrown error into a stable code that FINDINGS.md can group on.
+export function classifyError(e: any): string {
+  // Search messages and own properties through the cause chain — but never
+  // stacks: stack frames carry file paths, and this experiment's directory
+  // name contains the word "dust".
+  const parts: string[] = [];
+  const walk = (x: any, depth = 0) => {
+    if (!x || depth > 4) return;
+    if (typeof x === 'string') {
+      parts.push(x);
+      return;
+    }
+    if (typeof x?.message === 'string') parts.push(x.message);
+    try {
+      for (const k of Object.keys(x)) {
+        if (k === 'stack') continue;
+        const v = (x as any)[k];
+        if (typeof v === 'string') parts.push(v);
+        else if (typeof v === 'object') walk(v, depth + 1);
+      }
+    } catch {
+      // best-effort
+    }
+    if ((x as any).cause) walk((x as any).cause, depth + 1);
+  };
+  walk(e);
+  const msg = parts.join(' ').toLowerCase();
+  const customMatch = msg.match(/custom error[\s:]+(\d{1,3})/);
+  if (customMatch) return `ledger-${customMatch[1]}`;
+  const ledgerMatch = msg.match(/ledger[\s-_:]?(?:error)?[\s-_:]?(\d{3})/);
+  if (ledgerMatch) return `ledger-${ledgerMatch[1]}`;
+  const errorCodeMatch = msg.match(/error\s+code[\s:]+(\w+)/i);
+  if (errorCodeMatch) return `node-${errorCodeMatch[1]}`;
+  if (msg.includes('ttl') || msg.includes('expired')) return 'ttl-error';
+  if (msg.includes('insufficient') && msg.includes('dust')) return 'insufficient-dust';
+  if (msg.includes('dust')) return 'dust-error';
+  if (msg.includes('double') && msg.includes('spend')) return 'double-spend';
+  if (msg.includes('compile') || msg.includes('compact')) return 'compile-error';
+  return 'js-error';
+}
+
+export function serialiseError(e: any): Record<string, unknown> {
+  if (!e) return { value: null };
+  // SubmissionError and friends carry their payload in own enumerable
+  // properties (effect-ts style), not in message/cause — capture them.
+  const extras: Record<string, unknown> = {};
+  try {
+    for (const k of Object.keys(e)) {
+      if (['name', 'message', 'stack', 'cause'].includes(k)) continue;
+      const v = (e as any)[k];
+      extras[k] =
+        typeof v === 'object' && v !== null
+          ? JSON.parse(JSON.stringify(v, (_kk, vv) => (typeof vv === 'bigint' ? vv.toString() : vv)))
+          : v;
+    }
+  } catch {
+    // best-effort
+  }
+  return {
+    name: e?.name ?? typeof e,
+    message: e?.message ?? String(e),
+    stack: e?.stack?.split('\n').slice(0, 8).join('\n') ?? null,
+    cause: e?.cause ? { message: (e.cause as any)?.message ?? String(e.cause) } : null,
+    ...extras,
+  };
+}
+
+// The wallet SDK's SubmissionError does not carry the node's rejection
+// detail (`1010: Invalid Transaction: Custom error: NNN`); only polkadot-js
+// console logging surfaces it. Hook the console so negative tests can attach
+// the actual node response to their evidence.
+export function captureNodeRejections(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const orig = { log: console.log, warn: console.warn, error: console.error };
+  const hook =
+    (fn: (...a: any[]) => void) =>
+    (...args: any[]) => {
+      const text = args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ');
+      if (/invalid transaction|custom error|rejected/i.test(text)) lines.push(text);
+      fn(...args);
+    };
+  console.log = hook(orig.log);
+  console.warn = hook(orig.warn);
+  console.error = hook(orig.error);
+  return {
+    lines,
+    restore: () => {
+      console.log = orig.log;
+      console.warn = orig.warn;
+      console.error = orig.error;
+    },
+  };
+}
+
+// Convenience: stop wallets, swallowing errors (tests stop both wallets in
+// success paths; failure paths rely on runTest's forced exit).
+export async function stopAll(...ctxs: (WalletCtx | undefined)[]): Promise<void> {
+  for (const ctx of ctxs) {
+    try {
+      await ctx?.wallet.stop();
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+export { currentState };

--- a/experiments/dust-sponsorship-feasibility/src/tests/f1-happy-path.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f1-happy-path.ts
@@ -1,0 +1,115 @@
+// F1 — Happy path.
+//
+// User wallet (holds NIGHT, zero DUST) initiates a trivial Night transfer
+// and balances only its own token kinds. Sponsor wallet balances the dust
+// branch, signs, and submits. Pass criterion: tx hash returned, indexer
+// confirms inclusion, user's Night balance reflects the transfer, sponsor's
+// DUST capacity reflects the fee deduction.
+
+import { setupSponsor, setupFreshWallet, fundUserWithNight, runTest, stopAll } from '../test-helpers.js';
+import {
+  currentState,
+  waitForState,
+  nightBalanceOf,
+  dustBalanceOf,
+  balancesSnapshot,
+  NIGHT_RAW,
+} from '../common.js';
+import {
+  userTransferWithoutFees,
+  sponsorBalanceDust,
+  probeWireRoundtrip,
+  DEFAULT_TTL_MS,
+} from '../sponsorship.js';
+import { unshieldedAddressOf } from '../utils.js';
+
+const FUND_AMOUNT = BigInt(process.env.F1_FUND_AMOUNT ?? '1000000');
+const TRANSFER_AMOUNT = BigInt(process.env.F1_TRANSFER_AMOUNT ?? '100000');
+
+await runTest({
+  testId: 'F1',
+  name: 'happy-path',
+  description: 'user balances tokens, sponsor balances dust, node accepts',
+  action: async () => {
+    const sponsor = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+
+    // Setup (not the pattern under test): give the user NIGHT to transfer.
+    const fundingTx = await fundUserWithNight(sponsor, user, FUND_AMOUNT);
+
+    const userStateBefore = await currentState(user);
+    const sponsorStateBefore = await currentState(sponsor);
+    const userBefore = balancesSnapshot(userStateBefore);
+    const sponsorBefore = balancesSnapshot(sponsorStateBefore);
+
+    const userDust = dustBalanceOf(userStateBefore);
+    if (userDust !== null && userDust > 0n) {
+      console.warn(`User wallet unexpectedly holds dust (${userDust}) — F1 precondition weakened, recording anyway.`);
+    }
+    const sponsorNightBeforeTransfer = nightBalanceOf(sponsorStateBefore);
+
+    // ── User phase: transfer NIGHT back to the sponsor, fees excluded ──────
+    const ttl = new Date(Date.now() + DEFAULT_TTL_MS);
+    const userFinalized = await userTransferWithoutFees(
+      user,
+      [
+        {
+          type: 'unshielded',
+          outputs: [
+            {
+              type: NIGHT_RAW,
+              receiverAddress: unshieldedAddressOf(sponsor),
+              amount: TRANSFER_AMOUNT,
+            },
+          ],
+        },
+      ],
+      ttl,
+    );
+    const wire = probeWireRoundtrip(userFinalized);
+
+    // ── Sponsor phase: balance dust, sign, submit ───────────────────────────
+    const fullyBalanced = await sponsorBalanceDust(sponsor, userFinalized, ttl);
+    const txId = await sponsor.wallet.submitTransaction(fullyBalanced);
+    console.log(`Sponsored tx submitted: ${txId}`);
+
+    // Inclusion: the wallets' views come from the indexer, so observing the
+    // balance changes confirms indexer inclusion. Wait for the *exact*
+    // post-transfer balance — a looser bound catches the transient state
+    // where inputs are spent but the change output is not yet credited.
+    await waitForState(
+      user,
+      (s) => nightBalanceOf(s) === FUND_AMOUNT - TRANSFER_AMOUNT,
+      180_000,
+      'user Night balance reflecting the sponsored transfer (incl. change)',
+    );
+    await waitForState(
+      sponsor,
+      (s) => nightBalanceOf(s) >= sponsorNightBeforeTransfer + TRANSFER_AMOUNT,
+      180_000,
+      'sponsor Night balance reflecting the received transfer',
+    );
+    const userAfter = balancesSnapshot(await currentState(user));
+    const sponsorAfter = balancesSnapshot(await currentState(sponsor));
+
+    await stopAll(user, sponsor);
+
+    return {
+      verdict: 'PASS' as const,
+      txHash: String(txId),
+      note: 'Two-balanced tx accepted: user paid tokens, sponsor paid dust.',
+      details: {
+        fundingTx,
+        userSeed: user.seed,
+        fundAmount: FUND_AMOUNT.toString(),
+        transferAmount: TRANSFER_AMOUNT.toString(),
+        userBefore,
+        userAfter,
+        sponsorBefore,
+        sponsorAfter,
+        wireHandoff: wire,
+        ttl: ttl.toISOString(),
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/tests/f2-zero-start-onboarding.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f2-zero-start-onboarding.ts
@@ -1,0 +1,59 @@
+// F2 — True zero-NIGHT, zero-DUST onboarding.
+//
+// Same two-phase flow as F1, but the user wallet holds nothing at all. The
+// user's only on-chain action is a trivial circuit call (bump_counter) whose
+// only economic component is the fee. If F1 passes but F2 fails, the user
+// must hold *some* NIGHT for sponsorship to work — material for the
+// bootstrap UX (see brief).
+
+import { setupSponsor, setupFreshWallet, setupCounter, runTest, stopAll } from '../test-helpers.js';
+import { currentState, balancesSnapshot, nightBalanceOf } from '../common.js';
+import { createSponsoredProviders } from '../sponsorship.js';
+
+await runTest({
+  testId: 'F2',
+  name: 'zero-start-onboarding',
+  description: 'zero-NIGHT zero-DUST user lands a circuit call via sponsor',
+  action: async () => {
+    const sponsor = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+
+    const userStateBefore = await currentState(user);
+    const userBefore = balancesSnapshot(userStateBefore);
+    if (nightBalanceOf(userStateBefore) !== 0n) {
+      throw new Error('Precondition violated: user wallet is not empty (reuse of a funded USER_SEED?)');
+    }
+    const sponsorBefore = balancesSnapshot(await currentState(sponsor));
+
+    // The counter must already exist (deployed by `npm run deploy`, sponsor-
+    // paid). F2 is about the user's circuit call, not the deployment — the
+    // deployment shape is F6's question.
+    const { providers, handoffLog } = await createSponsoredProviders(user, sponsor);
+    const { address, found } = await setupCounter(providers, { reuseDeployment: true });
+
+    const result = await found.callTx.bump_counter();
+    const txHash = result?.public?.txId ?? result?.public?.transactionHash;
+
+    const userAfter = balancesSnapshot(await currentState(user));
+    const sponsorAfter = balancesSnapshot(await currentState(sponsor));
+
+    await stopAll(user, sponsor);
+
+    return {
+      verdict: txHash ? ('PASS' as const) : ('PARTIAL' as const),
+      txHash: txHash ? String(txHash) : undefined,
+      note: txHash
+        ? 'User with zero NIGHT and zero DUST landed a sponsored circuit call.'
+        : 'callTx returned without surfacing a tx hash.',
+      details: {
+        userSeed: user.seed,
+        contractAddress: address,
+        userBefore,
+        userAfter,
+        sponsorBefore,
+        sponsorAfter,
+        wireHandoffs: handoffLog,
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/tests/f3-rebalance-corruption.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f3-rebalance-corruption.ts
@@ -1,0 +1,106 @@
+// F3 — Re-balance corruption (negative).
+//
+// Sponsor incorrectly calls balanceFinalizedTransaction with
+// tokenKindsToBalance: 'all' instead of ['dust'], attempting to re-balance
+// the user's already-balanced unshielded portion. The tutorial warns this
+// produces double-spending errors. The error shape — local exception or
+// post-submission rejection, error code, recovery path — is the deliverable.
+//
+// Verdict semantics: PASS = a failure was observed and characterised.
+// PARTIAL = the transaction was accepted anyway (the warning is refuted —
+// itself a finding). FAIL = the harness could not reach the sponsor phase.
+
+import {
+  setupSponsor,
+  setupFreshWallet,
+  fundUserWithNight,
+  runTest,
+  stopAll,
+  classifyError,
+  serialiseError,
+} from '../test-helpers.js';
+import { currentState, balancesSnapshot, NIGHT_RAW } from '../common.js';
+import { userTransferWithoutFees, sponsorBalanceDust, DEFAULT_TTL_MS } from '../sponsorship.js';
+import { unshieldedAddressOf } from '../utils.js';
+
+const FUND_AMOUNT = BigInt(process.env.F3_FUND_AMOUNT ?? '1000000');
+const TRANSFER_AMOUNT = BigInt(process.env.F3_TRANSFER_AMOUNT ?? '100000');
+
+await runTest({
+  testId: 'F3',
+  name: 'rebalance-corruption',
+  description: "sponsor re-balances with 'all' instead of ['dust'] (negative)",
+  action: async () => {
+    const sponsor = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+
+    const fundingTx = await fundUserWithNight(sponsor, user, FUND_AMOUNT);
+    const userBefore = balancesSnapshot(await currentState(user));
+
+    const ttl = new Date(Date.now() + DEFAULT_TTL_MS);
+    const userFinalized = await userTransferWithoutFees(
+      user,
+      [
+        {
+          type: 'unshielded',
+          outputs: [
+            {
+              type: NIGHT_RAW,
+              receiverAddress: unshieldedAddressOf(sponsor),
+              amount: TRANSFER_AMOUNT,
+            },
+          ],
+        },
+      ],
+      ttl,
+    );
+
+    let stage = 'sponsor-balance';
+    let txId: unknown;
+    let observedError: any;
+    try {
+      const fullyBalanced = await sponsorBalanceDust(sponsor, userFinalized, ttl, 'all');
+      stage = 'submit';
+      txId = await sponsor.wallet.submitTransaction(fullyBalanced);
+      stage = 'accepted';
+    } catch (e: any) {
+      observedError = e;
+    }
+
+    const userAfter = balancesSnapshot(await currentState(user));
+    const sponsorAfter = balancesSnapshot(await currentState(sponsor));
+    await stopAll(user, sponsor);
+
+    if (observedError) {
+      return {
+        verdict: 'PASS' as const,
+        errorCode: classifyError(observedError),
+        note: `Failure observed at stage '${stage}': ${String(observedError?.message ?? observedError).slice(0, 120)}`,
+        details: {
+          fundingTx,
+          userSeed: user.seed,
+          failedAtStage: stage,
+          error: serialiseError(observedError),
+          userBefore,
+          userAfter,
+          sponsorAfter,
+          tutorialWarningConfirmed: true,
+        },
+      };
+    }
+
+    return {
+      verdict: 'PARTIAL' as const,
+      txHash: txId ? String(txId) : undefined,
+      note: "Sponsor 'all' re-balance was accepted by the node — the tutorial's double-spend warning did not reproduce.",
+      details: {
+        fundingTx,
+        userSeed: user.seed,
+        userBefore,
+        userAfter,
+        sponsorAfter,
+        tutorialWarningConfirmed: false,
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/tests/f4-ttl-expiry.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f4-ttl-expiry.ts
@@ -1,0 +1,121 @@
+// F4 — TTL expiry across the round-trip (negative).
+//
+// User signs and finalises with a short TTL; the sponsor deliberately delays
+// past it, then attempts to balance and submit. Establishes the latency
+// budget a sponsor service has between receiving a user's finalised
+// transaction and submitting the dual-balanced result. Pass criterion: a
+// specific TTL-related error, and the stage at which it surfaces.
+
+import {
+  setupSponsor,
+  setupFreshWallet,
+  fundUserWithNight,
+  runTest,
+  stopAll,
+  classifyError,
+  serialiseError,
+  captureNodeRejections,
+} from '../test-helpers.js';
+import { currentState, balancesSnapshot, NIGHT_RAW } from '../common.js';
+import { userTransferWithoutFees, sponsorBalanceDust } from '../sponsorship.js';
+import { unshieldedAddressOf } from '../utils.js';
+
+const FUND_AMOUNT = BigInt(process.env.F4_FUND_AMOUNT ?? '1000000');
+const TRANSFER_AMOUNT = BigInt(process.env.F4_TRANSFER_AMOUNT ?? '100000');
+const USER_TTL_MS = Number(process.env.F4_USER_TTL_MS ?? '30000');
+const SPONSOR_DELAY_MS = Number(process.env.F4_SPONSOR_DELAY_MS ?? '90000');
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+await runTest({
+  testId: 'F4',
+  name: 'ttl-expiry',
+  description: `user TTL ${USER_TTL_MS / 1000}s, sponsor delays ${SPONSOR_DELAY_MS / 1000}s (negative)`,
+  action: async () => {
+    const sponsor = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+
+    const fundingTx = await fundUserWithNight(sponsor, user, FUND_AMOUNT);
+
+    // ── User phase with a deliberately short TTL ────────────────────────────
+    const userTtl = new Date(Date.now() + USER_TTL_MS);
+    let userFinalized: any;
+    let stage = 'user-balance';
+    let observedError: any;
+    let txId: unknown;
+    const nodeCapture = captureNodeRejections();
+    try {
+      userFinalized = await userTransferWithoutFees(
+        user,
+        [
+          {
+            type: 'unshielded',
+            outputs: [
+              {
+                type: NIGHT_RAW,
+                receiverAddress: unshieldedAddressOf(sponsor),
+                amount: TRANSFER_AMOUNT,
+              },
+            ],
+          },
+        ],
+        userTtl,
+      );
+
+      console.log(`User tx finalised with TTL ${userTtl.toISOString()}; sponsor sleeping ${SPONSOR_DELAY_MS}ms...`);
+      await sleep(SPONSOR_DELAY_MS);
+
+      stage = 'sponsor-balance';
+      // The sponsor uses a fresh TTL for its own balancing transaction — the
+      // expired clock lives in the *user's* transaction.
+      const sponsorTtl = new Date(Date.now() + 10 * 60 * 1000);
+      const fullyBalanced = await sponsorBalanceDust(sponsor, userFinalized, sponsorTtl);
+
+      stage = 'submit';
+      txId = await sponsor.wallet.submitTransaction(fullyBalanced);
+      stage = 'accepted';
+    } catch (e: any) {
+      observedError = e;
+    }
+
+    nodeCapture.restore();
+    const userAfter = balancesSnapshot(await currentState(user));
+    await stopAll(user, sponsor);
+
+    if (observedError) {
+      // The SDK's SubmissionError hides the node detail; prefer the captured
+      // node-side rejection line for the error code.
+      const nodeLine = nodeCapture.lines.join(' ');
+      const custom = nodeLine.match(/custom error:\s*(\d{1,3})/i);
+      const code = custom ? `ledger-${custom[1]}` : classifyError(observedError);
+      return {
+        verdict: 'PASS' as const,
+        errorCode: code,
+        note: `TTL-expired round-trip rejected at stage '${stage}' with ${code}.`,
+        details: {
+          fundingTx,
+          userSeed: user.seed,
+          userTtlMs: USER_TTL_MS,
+          sponsorDelayMs: SPONSOR_DELAY_MS,
+          failedAtStage: stage,
+          error: serialiseError(observedError),
+          nodeRejectionLines: nodeCapture.lines.slice(0, 5),
+          userAfter,
+        },
+      };
+    }
+
+    return {
+      verdict: 'PARTIAL' as const,
+      txHash: txId ? String(txId) : undefined,
+      note: `Transaction was accepted despite the user TTL expiring ${(SPONSOR_DELAY_MS - USER_TTL_MS) / 1000}s earlier — TTL not enforced as expected.`,
+      details: {
+        fundingTx,
+        userSeed: user.seed,
+        userTtlMs: USER_TTL_MS,
+        sponsorDelayMs: SPONSOR_DELAY_MS,
+        userAfter,
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/tests/f5-insufficient-sponsor-dust.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f5-insufficient-sponsor-dust.ts
@@ -1,0 +1,120 @@
+// F5 — Sponsor with insufficient DUST (negative).
+//
+// The sponsoring wallet has no DUST capacity at all (a fresh wallet — the
+// degenerate case of "below the fee required"). Pass criterion: the broke
+// sponsor's balanceFinalizedTransaction call fails locally, before
+// submission, with a clear error. Confirms the failure mode is detectable
+// client-side, not silent or post-submission.
+//
+// The genesis wallet still plays a role here — it funds the user (setup),
+// but the *sponsor under test* is the broke wallet.
+
+import {
+  setupSponsor,
+  setupFreshWallet,
+  fundUserWithNight,
+  runTest,
+  stopAll,
+  classifyError,
+  serialiseError,
+} from '../test-helpers.js';
+import { currentState, balancesSnapshot, dustBalanceOf, NIGHT_RAW } from '../common.js';
+import { userTransferWithoutFees, sponsorBalanceDust, DEFAULT_TTL_MS } from '../sponsorship.js';
+import { unshieldedAddressOf } from '../utils.js';
+
+const FUND_AMOUNT = BigInt(process.env.F5_FUND_AMOUNT ?? '1000000');
+const TRANSFER_AMOUNT = BigInt(process.env.F5_TRANSFER_AMOUNT ?? '100000');
+
+await runTest({
+  testId: 'F5',
+  name: 'insufficient-sponsor-dust',
+  description: 'sponsor with zero DUST capacity fails client-side (negative)',
+  action: async () => {
+    const funder = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+    const brokeSponsor = await setupFreshWallet('broke-sponsor', 'BROKE_SPONSOR_SEED');
+
+    const brokeState = await currentState(brokeSponsor);
+    const brokeDust = dustBalanceOf(brokeState);
+    const brokeBefore = balancesSnapshot(brokeState);
+
+    const fundingTx = await fundUserWithNight(funder, user, FUND_AMOUNT);
+
+    const ttl = new Date(Date.now() + DEFAULT_TTL_MS);
+    const userFinalized = await userTransferWithoutFees(
+      user,
+      [
+        {
+          type: 'unshielded',
+          outputs: [
+            {
+              type: NIGHT_RAW,
+              receiverAddress: unshieldedAddressOf(funder),
+              amount: TRANSFER_AMOUNT,
+            },
+          ],
+        },
+      ],
+      ttl,
+    );
+
+    let stage = 'sponsor-balance';
+    let observedError: any;
+    let txId: unknown;
+    try {
+      const fullyBalanced = await sponsorBalanceDust(brokeSponsor, userFinalized, ttl);
+      stage = 'submit';
+      txId = await brokeSponsor.wallet.submitTransaction(fullyBalanced);
+      stage = 'accepted';
+    } catch (e: any) {
+      observedError = e;
+    }
+
+    await stopAll(user, funder, brokeSponsor);
+
+    if (observedError && stage === 'sponsor-balance') {
+      return {
+        verdict: 'PASS' as const,
+        errorCode: classifyError(observedError),
+        note: `Broke sponsor failed locally at balanceFinalizedTransaction: ${String(observedError?.message ?? observedError).slice(0, 110)}`,
+        details: {
+          fundingTx,
+          userSeed: user.seed,
+          brokeSponsorSeed: brokeSponsor.seed,
+          brokeSponsorDust: brokeDust?.toString() ?? '(unreadable)',
+          brokeBefore,
+          failedAtStage: stage,
+          error: serialiseError(observedError),
+        },
+      };
+    }
+
+    if (observedError) {
+      return {
+        verdict: 'PARTIAL' as const,
+        errorCode: classifyError(observedError),
+        note: `Failure surfaced at stage '${stage}', not client-side at balancing — detectability weaker than hoped.`,
+        details: {
+          fundingTx,
+          userSeed: user.seed,
+          brokeSponsorSeed: brokeSponsor.seed,
+          failedAtStage: stage,
+          error: serialiseError(observedError),
+        },
+      };
+    }
+
+    return {
+      verdict: 'FAIL' as const,
+      txHash: txId ? String(txId) : undefined,
+      errorCode: 'no-error-observed',
+      note: 'A sponsor with zero DUST capacity produced an accepted transaction — investigate (who paid the fee?).',
+      details: {
+        fundingTx,
+        userSeed: user.seed,
+        brokeSponsorSeed: brokeSponsor.seed,
+        brokeSponsorDust: brokeDust?.toString() ?? '(unreadable)',
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/tests/f6-sponsored-deployment.ts
+++ b/experiments/dust-sponsorship-feasibility/src/tests/f6-sponsored-deployment.ts
@@ -1,0 +1,88 @@
+// F6 — Sponsored contract deployment.
+//
+// The Passport onboarding shape: a user with zero NIGHT and zero DUST
+// deploys a contract, with the deploy transaction balanced in two phases
+// (user: shielded+unshielded, a no-op for an empty wallet; sponsor: dust).
+// If sponsorship does not extend to deployment transactions, a fresh user
+// cannot create their account contract without pre-funding — alternative A
+// would fail for the single most important transaction in the Passport
+// lifecycle.
+//
+// Unlike F2 this deploys its own contract instance and does NOT touch
+// deployment.json (which belongs to the sponsor-paid F2 setup).
+
+import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+
+import {
+  setupSponsor,
+  setupFreshWallet,
+  runTest,
+  stopAll,
+  COMPILED_COUNTER,
+  requireCompiled,
+} from '../test-helpers.js';
+import { currentState, balancesSnapshot, nightBalanceOf } from '../common.js';
+import { createSponsoredProviders } from '../sponsorship.js';
+import { PRIVATE_STATE_ID } from '../utils.js';
+
+await runTest({
+  testId: 'F6',
+  name: 'sponsored-deployment',
+  description: 'zero-NIGHT zero-DUST user deploys a contract via sponsor',
+  action: async () => {
+    requireCompiled();
+    const sponsor = await setupSponsor();
+    const user = await setupFreshWallet('user', 'USER_SEED');
+
+    const userStateBefore = await currentState(user);
+    const userBefore = balancesSnapshot(userStateBefore);
+    if (nightBalanceOf(userStateBefore) !== 0n) {
+      throw new Error('Precondition violated: user wallet is not empty (reuse of a funded USER_SEED?)');
+    }
+    const sponsorBefore = balancesSnapshot(await currentState(sponsor));
+
+    const { providers, handoffLog } = await createSponsoredProviders(user, sponsor);
+
+    const deployed = await deployContract(providers, {
+      compiledContract: COMPILED_COUNTER(),
+      privateStateId: PRIVATE_STATE_ID,
+      initialPrivateState: {},
+    });
+    const address = deployed.deployTxData.public.contractAddress;
+    const txHash =
+      deployed.deployTxData.public.txId ?? deployed.deployTxData.public.transactionHash;
+
+    // Indexer check: the contract state must be queryable at the new address.
+    let indexerSeesContract: boolean | string = 'not-checked';
+    try {
+      const pdp: any = providers.publicDataProvider;
+      if (typeof pdp.queryContractState === 'function') {
+        const st = await pdp.queryContractState(address);
+        indexerSeesContract = st != null;
+      }
+    } catch (e: any) {
+      indexerSeesContract = `query failed: ${e?.message ?? String(e)}`;
+    }
+
+    const userAfter = balancesSnapshot(await currentState(user));
+    const sponsorAfter = balancesSnapshot(await currentState(sponsor));
+
+    await stopAll(user, sponsor);
+
+    return {
+      verdict: 'PASS' as const,
+      txHash: txHash ? String(txHash) : undefined,
+      note: 'Zero-token user deployed a contract; sponsor paid the dust fee.',
+      details: {
+        userSeed: user.seed,
+        contractAddress: address,
+        indexerSeesContract,
+        userBefore,
+        userAfter,
+        sponsorBefore,
+        sponsorAfter,
+        wireHandoffs: handoffLog,
+      },
+    };
+  },
+});

--- a/experiments/dust-sponsorship-feasibility/src/utils.ts
+++ b/experiments/dust-sponsorship-feasibility/src/utils.ts
@@ -1,0 +1,195 @@
+// Provider/wallet plumbing — adapted from
+// experiments/contract-custody-feasibility/src/utils.ts. The custody
+// contract is replaced by the minimal counter contract; everything else is
+// kept as close to the reference harness as possible so that differences in
+// findings cannot be blamed on harness drift.
+
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { WebSocket } from 'ws';
+import * as Rx from 'rxjs';
+import { Buffer } from 'buffer';
+
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { setNetworkId, getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
+import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
+import {
+  UnshieldedAddress,
+  MidnightBech32m,
+} from '@midnight-ntwrk/wallet-sdk-address-format';
+import {
+  createKeystore,
+  PublicKey,
+  UnshieldedWallet,
+} from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+
+// The wallet-sdk storage interface wants `upsert`, `get`, `delete`, `list`.
+// We don't need history for this experiment, so supply a no-op stub.
+const NoopTxHistoryStorage = {
+  upsert: async (..._args: unknown[]) => undefined,
+  get:    async (..._args: unknown[]) => null,
+  delete: async (..._args: unknown[]) => undefined,
+  list:   async (..._args: unknown[]) => [] as unknown[],
+  clear:  async (..._args: unknown[]) => undefined,
+};
+
+// Enable WebSocket for GraphQL subscriptions.
+// @ts-expect-error required for wallet sync
+globalThis.WebSocket = WebSocket;
+
+const NETWORK = process.env.MIDNIGHT_NETWORK ?? 'local';
+
+const CONFIGS: Record<
+  string,
+  { networkId: string; indexer: string; indexerWS: string; node: string; proofServer: string }
+> = {
+  local: {
+    networkId: 'undeployed',
+    // Defaults match the linux host-network compose; on macOS run-all.sh
+    // exports the 1xxxx-offset URLs matching docker-compose.macos.yml.
+    indexer: process.env.INDEXER_URL ?? 'http://localhost:8088/api/v4/graphql',
+    indexerWS: process.env.INDEXER_WS_URL ?? 'ws://localhost:8088/api/v4/graphql/ws',
+    node: process.env.NODE_URL ?? 'http://localhost:9944',
+    proofServer: process.env.PROOF_SERVER_URL ?? 'http://127.0.0.1:6300',
+  },
+  preprod: {
+    networkId: 'preprod',
+    indexer: 'https://indexer.preprod.midnight.network/api/v3/graphql',
+    indexerWS: 'wss://indexer.preprod.midnight.network/api/v3/graphql/ws',
+    node: 'https://rpc.preprod.midnight.network',
+    proofServer: 'http://127.0.0.1:6300',
+  },
+};
+
+export const CONFIG = CONFIGS[NETWORK] ?? CONFIGS.local;
+setNetworkId(CONFIG.networkId as any);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const zkConfigPath = path.resolve(__dirname, '..', 'contracts', 'managed', 'counter');
+
+const contractPath = path.join(zkConfigPath, 'contract', 'index.js');
+export const CounterContract = await import(pathToFileURL(contractPath).href);
+
+export const PRIVATE_STATE_ID = 'dust-sponsorship-state';
+
+// ─── Wallet ─────────────────────────────────────────────────────────────────
+
+export function deriveKeys(seed: string) {
+  const hdWallet = HDWallet.fromSeed(Buffer.from(seed, 'hex'));
+  if (hdWallet.type !== 'seedOk') throw new Error('Invalid seed');
+
+  const result = hdWallet.hdWallet
+    .selectAccount(0)
+    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
+    .deriveKeysAt(0);
+
+  if (result.type !== 'keysDerived') throw new Error('Key derivation failed');
+
+  hdWallet.hdWallet.clear();
+  return result.keys;
+}
+
+export async function createWallet(seed: string) {
+  const keys = deriveKeys(seed);
+  const networkId = getNetworkId();
+
+  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(keys[Roles.Zswap]);
+  const dustSecretKey = ledger.DustSecretKey.fromSeed(keys[Roles.Dust]);
+  const unshieldedKeystore = createKeystore(keys[Roles.NightExternal], networkId);
+
+  // feeBlocksMargin: fee headroom beyond the SDK's estimate. The counter
+  // circuit is tiny, but the reference harness needed 100 for its k=15
+  // circuit and the margin costs nothing on a devnet. Override with
+  // FEE_BLOCKS_MARGIN if a test needs a tight value.
+  const feeBlocksMargin = Number(process.env.FEE_BLOCKS_MARGIN ?? '100');
+
+  const configuration = {
+    networkId,
+    indexerClientConnection: {
+      indexerHttpUrl: CONFIG.indexer,
+      indexerWsUrl: CONFIG.indexerWS,
+    },
+    provingServerUrl: new URL(CONFIG.proofServer),
+    relayURL: new URL(CONFIG.node.replace(/^http/, 'ws')),
+    costParameters: {
+      feeBlocksMargin,
+    },
+    txHistoryStorage: NoopTxHistoryStorage,
+  };
+
+  const wallet: WalletFacade = await (WalletFacade as any).init({
+    configuration,
+    shielded: (config: any) => ShieldedWallet(config).startWithSecretKeys(shieldedSecretKeys),
+    unshielded: (config: any) =>
+      UnshieldedWallet(config).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: (config: any) =>
+      DustWallet(config).startWithSecretKey(
+        dustSecretKey,
+        ledger.LedgerParameters.initialParameters().dust,
+      ),
+  });
+
+  await wallet.start(shieldedSecretKeys, dustSecretKey);
+
+  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore, seed };
+}
+
+export type WalletCtx = Awaited<ReturnType<typeof createWallet>>;
+
+export function unshieldedAddressOf(ctx: WalletCtx): UnshieldedAddress {
+  // getBech32Address() returns a MidnightBech32m instance, not a string.
+  const bech32 = ctx.unshieldedKeystore.getBech32Address();
+  return UnshieldedAddress.codec.decode(getNetworkId() as any, bech32 as MidnightBech32m);
+}
+
+// Standard single-wallet providers: the wallet balances and pays for its own
+// transactions. Used by deploy.ts (the sponsor deploying the counter
+// contract for F2) — the sponsorship-split providers live in sponsorship.ts.
+export async function createProviders(walletCtx: WalletCtx) {
+  const state = await Rx.firstValueFrom(walletCtx.wallet.state().pipe(Rx.filter((s) => s.isSynced)));
+
+  const signFn = (payload: Uint8Array) => walletCtx.unshieldedKeystore.signData(payload);
+
+  const walletProvider = {
+    getCoinPublicKey: () => state.shielded.coinPublicKey.toHexString(),
+    getEncryptionPublicKey: () => state.shielded.encryptionPublicKey.toHexString(),
+    async balanceTx(tx: any, ttl?: Date) {
+      const recipe = await walletCtx.wallet.balanceUnboundTransaction(
+        tx,
+        {
+          shieldedSecretKeys: walletCtx.shieldedSecretKeys,
+          dustSecretKey: walletCtx.dustSecretKey,
+        },
+        { ttl: ttl ?? new Date(Date.now() + 30 * 60 * 1000) },
+      );
+
+      const signed = await walletCtx.wallet.signRecipe(recipe, signFn);
+      return walletCtx.wallet.finalizeRecipe(signed);
+    },
+    submitTx: (tx: any) => walletCtx.wallet.submitTransaction(tx) as any,
+  };
+
+  const zkConfigProvider = new NodeZkConfigProvider(zkConfigPath);
+
+  return {
+    privateStateProvider: levelPrivateStateProvider({
+      midnightDbName: `midnight-level-db`,
+      privateStateStoreName: PRIVATE_STATE_ID,
+      privateStoragePasswordProvider: () => 'DustSponsorship!exp',
+      accountId: state.shielded.encryptionPublicKey.toHexString().slice(0, 16),
+      walletProvider,
+    }),
+    publicDataProvider: indexerPublicDataProvider(CONFIG.indexer, CONFIG.indexerWS),
+    zkConfigProvider,
+    proofProvider: httpClientProofProvider(CONFIG.proofServer, zkConfigProvider),
+    walletProvider,
+    midnightProvider: walletProvider,
+  };
+}

--- a/experiments/dust-sponsorship-feasibility/tsconfig.json
+++ b/experiments/dust-sponsorship-feasibility/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}


### PR DESCRIPTION
Empirical answer to the C24 fee-model question: wallet-level DUST sponsorship is feasible on v1; alternative A is the path forward. A sponsor wallet pays the DUST fee on a user's transaction via tokenKindsToBalance splitting: the user balances ['shielded', 'unshielded'] (or builds a transfer with payFees: false), signs, and finalises; the sponsor balances ['dust'] on the finalised transaction, signs, and submits. The node accepts the two-balanced result.