### PR TITLE
MIP draft: contract custody of Midnight-native assets

### DIFF
--- a/docs/mps-mip/README.md
+++ b/docs/mps-mip/README.md
@@ -22,9 +22,10 @@ the others hang from". We author that keystone as small building blocks,
 each independently reviewable, each usable without the others:
 
 1. **Asset custody** (`mips/mip-xxxx-native-asset-custody.md`): how a
-   contract holds and releases Night and shielded values; authorisation
-   abstracted to a single seam; validated by the stateless-custody and
-   account-custody experiments.
+   contract holds and releases unshielded values (Night and any other
+   unshielded color) and shielded values; authorisation abstracted to a
+   single seam; validated by the stateless-custody and account-custody
+   experiments.
 2. **Account and authorisation** (not yet drafted): credential schemes,
    device lifecycle, revocation epochs, and scoped grants; instantiates
    the seam.

--- a/docs/mps-mip/README.md
+++ b/docs/mps-mip/README.md
@@ -1,0 +1,43 @@
+# MPS and MIP working drafts
+
+This folder holds Midnight Problem Statements (MPS) and Midnight
+Improvement Proposals (MIP) authored by this workspace, in the state they
+are in before or after submission to the canonical repository,
+[midnightntwrk/midnight-improvement-proposals](https://github.com/midnightntwrk/midnight-improvement-proposals).
+Editor numbers are assigned upstream at merge; files here use `xxxx`
+until then. Once a document is merged upstream, the upstream copy is
+canonical and the copy here is retired to a pointer.
+
+## Submitted (upstream copy is canonical)
+
+- `mps/mps-asset-custody-model.md` → upstream **MPS-0018**,
+  Multi-key Account Custody for Midnight-Native Assets.
+- `mps/mps-domain-separation.md` → upstream **MPS-0027**,
+  Domain Separation for Midnight Hash Constructions.
+
+## In draft
+
+MPS-0018 recommends a multi-key account contract MIP as "the keystone
+the others hang from". We author that keystone as small building blocks,
+each independently reviewable, each usable without the others:
+
+1. **Asset custody** (`mips/mip-xxxx-native-asset-custody.md`): how a
+   contract holds and releases Night and shielded values; authorisation
+   abstracted to a single seam; validated by the stateless-custody and
+   account-custody experiments.
+2. **Account and authorisation** (not yet drafted): credential schemes,
+   device lifecycle, revocation epochs, and scoped grants; instantiates
+   the seam.
+3. **Recovery paths** (not yet drafted): total-loss recovery behind the
+   seam; the prototype realises this with BUSS, and the standard stays
+   scheme-agnostic at the contract surface.
+
+## Process
+
+Submissions follow the upstream MIP-0001 lifecycle: Draft status on
+entry, editor-assigned numbers, and a separate submission issue. A MIP
+addressing an MPS is listed in that MPS header's Proposed Solutions
+field rather than in the MIP's `Requires` line, which is reserved for
+MIP-on-MIP dependencies. Upstream draft PRs use the literal filename
+`mip-xxxx.md`; the descriptive filenames in this folder are local
+conveniences and are renamed on submission.

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -56,6 +56,13 @@ stateless custody pattern has been validated end to end against a
 production node, including a byte-level audit of every observer-visible
 surface.
 
+The same encryption that hides holdings also separates reading from
+releasing: reconstructing the contract's shielded position needs only the
+account encryption secret, whereas releasing assets needs the authorisation
+seam, so that secret can be delegated as a read-only viewing capability —
+to an accountant, auditor, or compliance function — without ceding custody
+(Rationale R9).
+
 The specification also makes normative a change-handling rule (persist
 the change coin that leaves the transaction live, never a coin the
 transaction consumed) whose violation has been observed to silently
@@ -134,6 +141,10 @@ interpreted as described in RFC 2119.
   descriptions of the contract's shielded holdings.
 - **Inbox**: an append-only map of encrypted coin descriptions in the
   custody contract's public state; the discovery and recovery channel.
+- **Viewing capability**: the account encryption secret used as a
+  read-only credential — it decrypts the inbox and drives the discovery
+  walk (section 6.5), reconstructing the contract's shielded holdings from
+  chain data, and confers no authority to release assets (Rationale R9).
 - **Color**: the 32-byte token-type identifier of an unshielded or
   shielded token, spelled throughout as the ecosystem term of art.
 - **Night**: the native unshielded token, whose color is the
@@ -610,6 +621,39 @@ prohibition. Token registry and NFT standardisation effects are
 upstream of custody only at the metadata layer. The name service
 (MIP-0007) locates accounts; nothing here depends on it.
 
+**R9. Viewing delegation (read/write separation).** Reconstructing the
+contract's shielded holdings and history from chain data requires only the
+account encryption secret: it drives the inbox walk (section 6.5), which
+yields every coin description, amount, color, and reconstructable
+counterparty. Releasing those assets requires the authorisation seam
+(INV-1). The two capabilities live in different secrets, so read and write
+separate cleanly — the encryption secret is a pure viewing capability that
+confers no power to move a single coin, a corollary of INV-1 rather than a
+new mechanism. This makes read-only delegation a first-class affordance of
+the design: a holder can hand a purpose-specific encryption secret to an
+accountant, an auditor, a tax authority, or an institutional compliance
+function — the oversight need the institutional problem statements
+(MPS-0006, MPS-0016, MPS-0024) carry — and obtain third-party bookkeeping
+over otherwise private holdings without ceding custody. The unshielded
+balances are already public through the section 5 mirror, so a delegate
+holding the viewing capability sees the whole position: public unshielded,
+private shielded. The delegation is out of band — it shares a secret,
+invokes no circuit, and needs no ledger support — which is why this MIP adds
+no viewing mechanism; custody of the encryption secret itself remains the
+instantiating and recovery standards' subject (section 2, section 6.7).
+
+The capability is coarse, deliberately. A single encryption secret governs
+the whole inbox, so disclosing it reveals the contract's entire shielded
+past and future until `enc_key` is rotated (section 6.7); there is no native
+scoping to a date range, a coin subset, or a color, and revoking a
+delegate's view means rotating the key and re-encrypting the live entries,
+after which the delegate retains whatever it has already read (Security
+Considerations S2). Finer-grained viewing — hierarchical or epoch-scoped
+viewing keys, or an incoming/outgoing split in the manner of shielded-pool
+viewing keys — advertises additional keys without disturbing any invariant
+here, and is left to a successor standard, the read-side analogue of the
+scoped-spending policies section 2 defers.
+
 ## Path to Active
 
 ### Acceptance Criteria
@@ -672,7 +716,10 @@ instance. Wallets unaware of this standard are unaffected.
   watching, but does not enable theft: releasing assets still requires
   the authorisation seam (INV-1). Key rotation is the procedure of
   section 6.7; old entries remain readable to the attacker, so rotation
-  bounds future, not past, exposure.
+  bounds future, not past, exposure. The same property is a feature under
+  deliberate disclosure (delegated viewing, R9): the encryption secret is a
+  read capability and never a release capability, so the trust boundary is
+  identical whether it leaks or is shared on purpose.
 - **S3. Inbox poisoning.** The contract cannot verify that a deposit's
   inbox entry matches the deposited coin. A malicious depositor can
   deposit a coin whose entry is garbage, producing value the owner

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -3,6 +3,7 @@ MIP: X
 Title: Contract Custody of Midnight-Native Assets
 Authors:
   - Nicolas Di Prima (NicolasDP)
+  - Hector Bulgarini (hbulgarini)
 Status: Draft
 Category: Standards
 Created: 2026-07-07

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -56,9 +56,10 @@ production node, including a byte-level audit of every observer-visible
 surface.
 
 The specification also makes normative a change-handling rule (persist
-the re-owned coin returned by `sendImmediateShielded`, never the consumed
-change coin) whose violation has been observed to silently strand funds
-in ecosystem library code.
+the change coin that leaves the transaction live, never a coin the
+transaction consumed) whose violation has been observed to silently
+strand funds in ecosystem library code; the defect is fixed upstream,
+and the rule keeps the failure class out of conforming implementations.
 
 ## Motivation
 
@@ -97,15 +98,19 @@ custody that does not pay the privacy price MPS-0018 had to assume, and
 the corresponding MPS-0018 open question resolves to a narrower one
 about residual metadata (Security Considerations S4).
 
-**The prevailing recipe also strands change.** `sendImmediateShielded`
-re-owns a change coin by consuming it and creating a replacement,
-returned as the `sent` field of its result. Library code that persists
-the consumed coin instead of the replacement produces holdings whose
-next spend the node rejects as a double spend. MIP-0011 requires the
-change coin to be returned and recommends persisting it, but its burn
-flows never surface the re-owning step, where two coin objects exist and
-only one survives; that step is precisely where library code fails. A
-standard is the right place to state the rule normatively.
+**The prevailing recipe stranded change.** `sendShielded` already
+routes change back to the sending contract as a live, self-owned
+output. Widely used library code nevertheless followed it with a
+redundant re-owning call, `sendImmediateShielded(change, self)`, which
+consumes the change coin (revealing its nullifier in that same
+transaction) and creates a replacement returned as the `sent` field of
+its result; the code then persisted the consumed coin, so every later
+spend of change was rejected by the node as a double spend. The defect
+was reported upstream with a node-level reproducer and has been fixed
+by removing the redundant step. A standard is still the right place to
+state the surviving-coin rule normatively, because implementations
+that deliberately route change onward re-enter the two-coin situation
+the defect lived in (section 6.3).
 
 ## Specification
 
@@ -300,7 +305,7 @@ discovery and total-loss recovery must work from chain data alone
 A separate circuit, `append_inbox(entry)`, appends an entry without a
 coin claim. Clients use it to backfill entries for change coins, whose
 descriptions only exist once the spend has executed (section 6.3): the
-spend returns the re-owned change description privately to the caller,
+spend returns the surviving change description privately to the caller,
 and the client encrypts it and appends the entry in a later
 transaction. All InboxEntry cryptography is performed client-side, by
 depositors and by the owner's client; the contract never encrypts,
@@ -331,16 +336,23 @@ Semantics (authorised):
    (`sendShielded` over a `QualifiedShieldedCoinInfo` with a valid
    `mt_index`), per the spend-path discipline MIP-0011 codifies.
 2. `sendShielded(coin, recipient, amount)` executes the spend.
-3. **Change rule (normative).** If change exists, the circuit MUST
-   re-own it in the same transaction via `sendImmediateShielded(change,
-   self, change.value)` and MUST treat the **`sent` field of that call's
-   result** as the coin the contract now holds. The consumed change coin
-   (`result.change`) MUST NOT be persisted, returned as the held coin,
-   or recorded in any coin store: its nullifier is revealed in this very
-   transaction, and any later spend of it is rejected as a double spend.
-   Rationale R4 documents the failure this rule prevents.
-4. The circuit returns the re-owned change coin description (or none) to
-   the caller. Circuit return values travel in the transaction's
+3. **Change rule (normative).** The coin recorded as held after a
+   partial spend MUST be live at the end of the transaction: its
+   commitment created by the transaction and its nullifier not
+   revealed in it. `sendShielded` already routes change back to the
+   contract as a self-owned output, so the baseline realisation is to
+   persist the change coin of its result directly; no re-owning step
+   is needed. A circuit MAY instead spend the change onward in the
+   same transaction via `sendImmediateShielded`, which is meaningful
+   only towards a recipient other than the contract itself; a circuit
+   that does so MUST treat the **`sent` field of that call's result**
+   as the surviving coin, and MUST NOT persist, return, or record the
+   coin that call consumed, whose nullifier is revealed in that very
+   transaction and whose later spend the node rejects as a double
+   spend. Rationale R4 documents the failure this rule prevents and
+   its upstream history.
+4. The circuit returns the surviving change coin description (or none)
+   to the caller. Circuit return values travel in the transaction's
    communication commitment and are not public.
 5. `round` is incremented.
 
@@ -385,10 +397,10 @@ behaviour:
   `mt_index` from the depositing transaction's commitment-tree
   positions; for a single-output transaction this is the transaction's
   start index.
-- After a spend with change, the client records the returned re-owned
-  coin and captures its `mt_index` from the spend transaction's position
-  window, then backfills the inbox via `append_inbox` no later than its
-  next inbox write (invariant INV-4).
+- After a spend with change, the client records the returned change
+  coin and captures its `mt_index` from the spend transaction's
+  position window, then backfills the inbox via `append_inbox` no later
+  than its next inbox write (invariant INV-4).
 - Where a transaction carries several commitments, clients MAY resolve
   the index by candidate retry: an incorrect qualified description
   yields an unsatisfiable witness at proving time and no transaction is
@@ -452,8 +464,9 @@ A conforming implementation MUST satisfy all of the following.
   or into the public transcript, beyond protocol commitments,
   nullifiers, and the send path's single-bit comparison outcomes.
 - **INV-3 (change continuity).** After a partial spend, the coin
-  recorded as held is spendable in a later transaction. Equivalently:
-  the re-owned coin, never the consumed change coin, is what survives.
+  recorded as held is spendable in a later transaction. Equivalently: a
+  coin whose nullifier the spend transaction revealed is never what
+  survives.
 - **INV-4 (reconstruction completeness).** For every coin the contract
   holds, the inbox contains an entry from which the coin description is
   recoverable by the holder of the account encryption secret, subject
@@ -531,20 +544,26 @@ write. What the stateless design costs is wallet-side
 state management, which section 6.5 specifies, with the inbox as its
 durable backstop.
 
-**R4. The change rule.** `sendImmediateShielded` consumes the change
-coin it is given (its nullifier is revealed in that same transaction)
-and creates a replacement with an evolved nonce, returned as `.sent`.
-Persisting the consumed coin makes every later change spend fail as an
-attempted double spend, while the replacement sits unrecorded; the
+**R4. The change rule.** `sendImmediateShielded` consumes the coin it
+is given (its nullifier is revealed in that same transaction) and
+creates a replacement with an evolved nonce, returned as `.sent`. The
+prevailing treasury recipe applied it redundantly to change that
+`sendShielded` had already routed back to the contract, and then
+persisted the consumed coin; every later change spend failed as an
+attempted double spend while the replacement sat unrecorded. The
 failure was reproduced on a production node through both custody
 patterns, in the treasury modules of a widely used contract library
-(the same pattern MPS-0018 cites as the working recipe), and disappears
-under the rule of section 6.3. MIP-0011 requires the change coin to be
-returned by the circuit and recommends persisting it, which is correct
-for its own burn flows, but those flows never surface the re-owning
-step, where two coin objects exist and only one survives; this MIP
-states the rule at the level where the defect lives, and recommends a
-clarifying note upstream for consumers who add the re-owning step.
+(the same pattern MPS-0018 cites as the working recipe), reported
+upstream with the reproducer, and resolved by removing the redundant
+step so implementations persist the live change coin of the send
+result. This MIP states the rule at the level of the surviving coin so
+both realisations conform: the baseline (persist the send result's
+change directly, which is also MIP-0011's guidance for its burn flows)
+and deliberate onward routing (persist that call's `sent` coin). The
+node-level evidence behind this rationale validated the re-owning
+variant; the baseline realisation is upstream-tested in a simulator,
+and its cross-transaction change spend is exercised on a node by
+conformance test 3.
 
 **R5. Inbox rather than out-of-band delivery or ledger ciphertexts.**
 Ledger ciphertexts on contract-owned outputs are rejected by the node,
@@ -598,10 +617,10 @@ upstream of custody only at the metadata layer. The name service
 - [ ] Cryptographer review of section 6 (secretless-coin analysis, the
       InboxEntry construction, and the disclosure bounds) with findings
       addressed.
-- [ ] The change rule (6.3, R4) accepted upstream in at least one widely
-      used contract library, or that library documents divergence; the
-      clarifying note recommended against MIP-0011 (R4) resolved either
-      way.
+- [ ] The change rule (6.3, R4) upheld upstream: the defect report and
+      library fix are merged; node-level validation of the baseline
+      realisation's cross-transaction change spend (conformance test 3)
+      completed against a fixed release.
 - [ ] A public reference implementation passing the conformance suite
       (Testing section), including the observer leak audit with a
       passing positive control.
@@ -616,8 +635,10 @@ upstream of custody only at the metadata layer. The name service
 ### Implementation Plan
 
 1. Publish the reference implementation and conformance suite.
-2. File and track the upstream library defect report and change-rule
-   fix, and the MIP-0011 clarifying note.
+2. Track the upstream change-rule fix (report filed, fix merged)
+   through node-level validation of the fixed pattern; no MIP-0011
+   change is needed, since its guidance matches the baseline
+   realisation.
 3. File and track the indexer discovery surface.
 4. Engage a wallet provider for the independent implementation.
 5. Submit for editor numbering; iterate through community commentary.
@@ -706,10 +727,11 @@ instance. Wallets unaware of this standard are unaffected.
   this specification and diverges from it in known ways (its deposits
   do not increment `round`, and its shielded path is the public-map
   control pattern).
-- Upstream dependencies: a defect report and change-rule fix for the
-  affected contract library, and the MIP-0011 clarifying note, both
-  tracked by the Implementation Plan; an indexer surface for
-  contract-transaction enumeration (Path to Active).
+- Upstream status: the change-rule defect report and the library fix
+  are filed and merged (References); node-level validation of the fixed
+  pattern is tracked by the Implementation Plan. Remaining dependency:
+  an indexer surface for contract-transaction enumeration (Path to
+  Active).
 - This MIP contains no implementation code; the artefacts above are its
   evidence base, and the reference implementation is an acceptance
   criterion, not an existing artefact.
@@ -727,10 +749,11 @@ observe the failures this standard rules out):
    INV-4, INV-5).
 2. **Witness spend**: full-amount spend from the coin store is accepted
    by the node (INV-1, INV-2).
-3. **Change chain**: partial spend, re-capture of the re-owned change,
-   spend of the change in a later transaction (INV-3). This test is the
-   regression gate for the change rule and fails on the consumed-coin
-   defect.
+3. **Change chain**: partial spend, re-capture of the surviving
+   change, spend of the change in a later transaction (INV-3),
+   exercised under the realisation the implementation uses (6.3). This
+   test is the regression gate for the change rule and fails on the
+   consumed-coin defect.
 4. **Third-party deposit and discovery**: a second, independent wallet
    deposits against the advertised key; the owner discovers and spends
    using the inbox walk and chain data only (INV-4).
@@ -769,8 +792,10 @@ without a satisfying witness and observing the abort.
   derivations, the contract-call communication commitment, and the
   rejection of ciphertexts on contract-owned outputs.
 - OpenZeppelin Compact contracts: the public-map treasury pattern and
-  the stateless precedents; the change-rule defect report is to be
-  filed and linked per the Implementation Plan.
+  the stateless precedents; the change-rule
+  [defect report](https://github.com/OpenZeppelin/compact-contracts/issues/656)
+  and its
+  [resolution](https://github.com/OpenZeppelin/compact-contracts/pull/661).
 - Midnight Passport workspace: the stateless custody experiment
   (evidence and conformance probes, `experiments/stateless-shielded-custody/`)
   and the account-custody prototype

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -30,7 +30,8 @@ Replaces: none
 ## Abstract
 
 This MIP specifies how a Compact contract custodies Midnight-native
-values: Night (unshielded tokens) and shielded Zswap coins. It is the
+values: unshielded tokens (Night and any other unshielded color) and
+shielded Zswap coins. It is the
 first building block of the multi-key account contract recommended by
 MPS-0018, deliberately limited to the asset surface. Who may authorise a
 release, how credentials are managed, and how control is recovered are
@@ -39,10 +40,10 @@ the seam they attach to.
 
 Deposits are permissionless. Releases are gated by a single internal
 authorisation seam whose observable semantics this MIP fixes and whose
-credential scheme it deliberately does not. Night custody pairs the
-protocol receive and send operations with an explicit per-colour balance
+credential scheme it deliberately does not. Unshielded custody pairs the
+protocol receive and send operations with an explicit per-color balance
 mirror. Shielded custody is **stateless**: a held coin's description
-(nonce, colour, value) never enters public ledger state. Deposits pair
+(nonce, color, value) never enters public ledger state. Deposits pair
 the protocol-level coin claim with an encrypted inbox entry, addressed to
 an account encryption key advertised on-ledger, and spends supply the
 coin description as a private witness from a wallet-local coin store. An
@@ -127,14 +128,17 @@ interpreted as described in RFC 2119.
   descriptions of the contract's shielded holdings.
 - **Inbox**: an append-only map of encrypted coin descriptions in the
   custody contract's public state; the discovery and recovery channel.
-- **Colour**: the 32-byte token-type identifier of an unshielded or
-  shielded token. Prose in this document uses the spelling "colour";
-  code positions use the standard library spelling `color`.
+- **Color**: the 32-byte token-type identifier of an unshielded or
+  shielded token, spelled throughout as the ecosystem term of art.
+- **Night**: the native unshielded token, whose color is the
+  all-zero value. This MIP treats it as one unshielded color among
+  many.
 
 ### 2. Scope and composition
 
-This MIP specifies the custody of Night and shielded Zswap coins by a
-per-account contract instance. The following are explicitly out of
+This MIP specifies the custody of unshielded tokens and shielded Zswap
+coins, across all colors of each class, by a per-account contract
+instance. The following are explicitly out of
 scope, and conforming extensions MUST NOT weaken any invariant in
 section 7 when adding them:
 
@@ -154,9 +158,10 @@ section 7 when adding them:
 - **Dust**: the custody contract holds no Dust; where Dust balances
   live and how fees are paid without fragmenting custody is the open
   question MPS-0018 records, and is out of scope here.
-- **Token issuance**: minting and burning of a contract's own colours
-  is specified by MIP-0011. A custody contract holds arbitrary colours
-  it did not issue.
+- **Token issuance**: minting and burning of a contract's own colors
+  is specified by MIP-0011 for the shielded class, and by the ledger's
+  contract-mint effects for the unshielded class. A custody contract
+  holds arbitrary colors it did not issue.
 - **Name discovery**: locating a custody contract by human-readable
   name is the name service's subject (MIP-0007).
 
@@ -180,8 +185,9 @@ export ledger inbox_count: Uint<64>;
 // Append-only encrypted coin descriptions (InboxEntry, section 6.4),
 // keyed by ordinal.
 
-export ledger night_balances: Map<Bytes<32>, Uint<128>>;
-// Explicit mirror of the contract's Night holdings per colour.
+export ledger unshielded_balances: Map<Bytes<32>, Uint<128>>;
+// Explicit mirror of the contract's unshielded holdings per color.
+// Night is the all-zero color.
 ```
 
 Implementations MAY extend this state (for example with the account
@@ -232,31 +238,36 @@ Deposits (sections 5 and 6.2) and inbox appends (section 6.2) are
 permissionless: anyone may fund the account or contribute a discovery
 entry. They still increment `round`.
 
-### 5. Night custody
+### 5. Unshielded custody
 
-- `deposit_night(color, amount)` (permissionless): receives the
-  unshielded tokens for the contract and credits `night_balances` for
-  that colour.
-- `withdraw_night(color, amount, recipient)` (authorised): checks and
-  debits the mirror, then sends the tokens to a user address.
+The unshielded class is color-generic: Night is the native color, and
+any contract may mint further unshielded colors through the ledger's
+contract-mint effects. This MIP custodies every unshielded color
+identically; nothing in this section is specific to Night.
 
-The mirror exists because contract Night balances are not otherwise
-readable from contract state. Night transferred to the contract outside
-`deposit_night` is held but not mirrored; clients MUST treat the mirror
-as a lower bound on holdings. Implementations MAY provide an authorised
-reconciliation circuit that lifts the mirror to observed deposits; such
-a circuit MUST NOT credit beyond deposits observed on-chain, and the
-ledger's protocol-level balance check remains the backstop against
-over-withdrawal even if the mirror drifts high. Withdrawal recipients
-are user addresses; contract-to-contract Night transfer is not part of
-this standard.
+- `deposit_unshielded(color, amount)` (permissionless): receives the
+  unshielded tokens for the contract and credits `unshielded_balances`
+  for that color.
+- `withdraw_unshielded(color, amount, recipient)` (authorised): checks
+  and debits the mirror, then sends the tokens to a user address.
+
+The mirror exists because contract unshielded balances are not
+otherwise readable from contract state. Tokens transferred to the
+contract outside `deposit_unshielded` are held but not mirrored;
+clients MUST treat the mirror as a lower bound on holdings.
+Implementations MAY provide an authorised reconciliation circuit that
+lifts the mirror to observed deposits; such a circuit MUST NOT credit
+beyond deposits observed on-chain, and the ledger's protocol-level
+balance check remains the backstop against over-withdrawal even if the
+mirror drifts high. Withdrawal recipients are user addresses;
+contract-to-contract unshielded transfer is not part of this standard.
 
 ### 6. Shielded custody (stateless)
 
 #### 6.1 Design rule
 
 The custody contract MUST NOT write a held coin's description (nonce,
-colour, or value), in whole or in part, into public ledger state or into
+color, or value), in whole or in part, into public ledger state or into
 any publicly disclosed circuit output. The only coin-derived values that
 may appear publicly are the protocol-level hiding commitments and
 nullifiers, and the single-bit comparison outcomes inherent to the
@@ -432,7 +443,7 @@ A conforming implementation MUST satisfy all of the following.
   `require_authorised()`; no circuit releases assets on any other
   authority.
 - **INV-2 (no public coin material).** No execution of any circuit
-  writes a held coin's nonce, colour, or value into public ledger state
+  writes a held coin's nonce, color, or value into public ledger state
   or into the public transcript, beyond protocol commitments,
   nullifiers, and the send path's single-bit comparison outcomes.
 - **INV-3 (change continuity).** After a partial spend, the coin
@@ -451,9 +462,9 @@ A conforming implementation MUST satisfy all of the following.
   contract addresses.
 - **INV-7 (round monotonicity).** Every state-changing call strictly
   increases `round`.
-- **INV-8 (mirror soundness).** `night_balances` never exceeds the
-  contract's actual Night holdings per colour; a conforming withdrawal
-  never debits below zero.
+- **INV-8 (mirror soundness).** `unshielded_balances` never exceeds
+  the contract's actual unshielded holdings per color; a conforming
+  withdrawal never debits below zero.
 
 ### 8. Versioning
 
@@ -565,8 +576,8 @@ and the depositor of a coin can watch that coin's first onward move
 balances, and conforming counterparties are hidden.
 
 **R8. Relationship to neighbouring standards.** MIP-0011 governs a
-contract's own issued colours (mint and burn); this MIP governs holding
-arbitrary colours on an account's behalf; the two compose, and this MIP
+contract's own issued colors (mint and burn); this MIP governs holding
+arbitrary colors on an account's behalf; the two compose, and this MIP
 adopts MIP-0011's spend-path discipline and caller-authentication
 prohibition. Token registry and NFT standardisation effects are
 upstream of custody only at the metadata layer. The name service
@@ -664,7 +675,8 @@ instance. Wallets unaware of this standard are unaffected.
   write), the only holder of the change description is the client.
   Clients SHOULD minimise this window; the reference behaviour appends
   immediately.
-- **S8. Mirror drift.** The Night mirror is a lower bound (section 5).
+- **S8. Mirror drift.** The unshielded mirror is a lower bound
+  (section 5).
   Treating it as exact can under-report holdings but cannot enable
   over-withdrawal (INV-8): the ledger enforces actual balances at the
   protocol level.
@@ -684,10 +696,11 @@ instance. Wallets unaware of this standard are unaffected.
   unversioned inbox container with a key-derivation stand-in; the
   versioned container of section 6.4 is specified here and awaits the
   reference implementation required by Path to Active. The
-  account-custody prototype validates the Night surface and a working
-  seam instantiation; it predates this specification and diverges from
-  it in known ways (its deposits do not increment `round`, and its
-  shielded path is the public-map control pattern).
+  account-custody prototype validates the unshielded surface (under
+  Night-specific naming) and a working seam instantiation; it predates
+  this specification and diverges from it in known ways (its deposits
+  do not increment `round`, and its shielded path is the public-map
+  control pattern).
 - Upstream dependencies: a defect report and change-rule fix for the
   affected contract library, and the MIP-0011 clarifying note, both
   tracked by the Implementation Plan; an indexer surface for
@@ -720,9 +733,10 @@ observe the failures this standard rules out):
    and through the public-map pattern; a byte-scan of raw transactions
    and contract state finds coin material in the control (validating
    the scanner) and none in the conforming path (INV-2).
-6. **Night mirror**: deposit, withdraw, and attempted over-withdrawal
-   against the mirror (INV-8), plus an unmirrored transfer confirming
-   lower-bound semantics.
+6. **Unshielded mirror**: deposit, withdraw, and attempted
+   over-withdrawal against the mirror (INV-8), plus an unmirrored
+   transfer confirming lower-bound semantics; run for Night and for at
+   least one non-native unshielded color.
 7. **One-hop payment**: a payment between two custody contracts routed
    per section 6.6; no transaction in the flow contains both contract
    addresses (INV-6).

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -299,7 +299,12 @@ discovery and total-loss recovery must work from chain data alone
 
 A separate circuit, `append_inbox(entry)`, appends an entry without a
 coin claim. Clients use it to backfill entries for change coins, whose
-descriptions only exist once the spend has executed (section 6.3).
+descriptions only exist once the spend has executed (section 6.3): the
+spend returns the re-owned change description privately to the caller,
+and the client encrypts it and appends the entry in a later
+transaction. All InboxEntry cryptography is performed client-side, by
+depositors and by the owner's client; the contract never encrypts,
+decrypts, or inspects entries, and stores them as opaque bytes.
 Implementations MAY gate `append_inbox` behind the authorisation seam:
 change-coin backfill is always performed by the owner's own client, so
 gating it loses nothing, while the entry paired with `deposit_shielded`

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -1,0 +1,775 @@
+---
+MIP: X
+Title: Contract Custody of Midnight-Native Assets
+Authors:
+  - Nicolas Di Prima (NicolasDP)
+Status: Draft
+Category: Standards
+Created: 2026-07-07
+License: Apache-2.0
+Requires: none
+Replaces: none
+---
+
+<!--
+ Copyright 2026 Midnight Foundation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+## Abstract
+
+This MIP specifies how a Compact contract custodies Midnight-native
+values: Night (unshielded tokens) and shielded Zswap coins. It is the
+first building block of the multi-key account contract recommended by
+MPS-0018, deliberately limited to the asset surface. Who may authorise a
+release, how credentials are managed, and how control is recovered are
+the subjects of companion building blocks; this document specifies only
+the seam they attach to.
+
+Deposits are permissionless. Releases are gated by a single internal
+authorisation seam whose observable semantics this MIP fixes and whose
+credential scheme it deliberately does not. Night custody pairs the
+protocol receive and send operations with an explicit per-colour balance
+mirror. Shielded custody is **stateless**: a held coin's description
+(nonce, colour, value) never enters public ledger state. Deposits pair
+the protocol-level coin claim with an encrypted inbox entry, addressed to
+an account encryption key advertised on-ledger, and spends supply the
+coin description as a private witness from a wallet-local coin store. An
+observer learns that the custody contract acted, but never the amounts,
+the token types, the balances, or the counterparties of conforming
+payments. This removes the holdings-publicity trade-off carried by the
+prevailing `Map<color, QualifiedShieldedCoinInfo>` pattern, and the
+stateless custody pattern has been validated end to end against a
+production node, including a byte-level audit of every observer-visible
+surface.
+
+The specification also makes normative a change-handling rule (persist
+the re-owned coin returned by `sendImmediateShielded`, never the consumed
+change coin) whose violation has been observed to silently strand funds
+in ecosystem library code.
+
+## Motivation
+
+MPS-0018 frames the problem: Midnight has no ratified model for an
+on-chain account that custodies and authorises a user's native assets
+under multi-key, multi-device control while satisfying lost-device
+recovery, total-loss recovery, and key non-exfiltration at once. Its
+first recommended MIP is the multi-key account contract, "the keystone
+the others hang from". This document delivers the custody half of that
+keystone as a free-standing building block.
+
+**Why a building block rather than the whole keystone.** The custody
+surface and the authorisation surface stabilise on different clocks. How
+a contract holds and releases value is settled by ledger mechanics and
+has been validated experimentally. How callers should be authenticated
+is an active, unsettled conversation upstream: in-circuit verification
+of native address ownership has been requested in the
+[token-standards discussion](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/142),
+a [stdlib caller-identity primitive](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/213)
+has been proposed, and threshold and MPC custody impose their own
+constraints. Binding the
+custody rules to any one credential scheme would hold the settled part
+hostage to the unsettled part. Splitting them also keeps each document
+small enough to review well, and lets institutional custody profiles
+(MPS-0006, MPS-0016, MPS-0024) reuse the asset surface under their own
+authorisation regimes.
+
+**A refinement to the problem statement.** MPS-0018 records that
+contract custody of shielded notes "leaks holdings into public ledger
+state". Experimental evidence summarised in the Rationale shows the
+ledger itself forces no such leak: the publicity is a property of the
+prevailing storage pattern, which writes each held coin's full
+description into public contract state so later spends can look it up.
+A stateless pattern removes the leak. This MIP therefore specifies
+custody that does not pay the privacy price MPS-0018 had to assume, and
+the corresponding MPS-0018 open question resolves to a narrower one
+about residual metadata (Security Considerations S4).
+
+**The prevailing recipe also strands change.** `sendImmediateShielded`
+re-owns a change coin by consuming it and creating a replacement,
+returned as the `sent` field of its result. Library code that persists
+the consumed coin instead of the replacement produces holdings whose
+next spend the node rejects as a double spend. MIP-0011 requires the
+change coin to be returned and recommends persisting it, but its burn
+flows never surface the re-owning step, where two coin objects exist and
+only one survives; that step is precisely where library code fails. A
+standard is the right place to state the rule normatively.
+
+## Specification
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described in RFC 2119.
+
+### 1. Terminology
+
+- **Custody contract**: the Compact contract instance specified here,
+  holding assets on behalf of exactly one account.
+- **Instantiating standard**: a companion document that instantiates
+  the authorisation seam (section 4) with a concrete credential scheme
+  and lifecycle: the account standard for personal custody, or an
+  institutional custody profile. This MIP does not depend on any
+  particular one.
+- **Coin description**: the `(nonce, color, value)` triple of a
+  shielded coin; **qualified** when extended with its commitment-tree
+  index (`mt_index`).
+- **Coin store**: wallet-local private state holding the qualified coin
+  descriptions of the contract's shielded holdings.
+- **Inbox**: an append-only map of encrypted coin descriptions in the
+  custody contract's public state; the discovery and recovery channel.
+- **Colour**: the 32-byte token-type identifier of an unshielded or
+  shielded token. Prose in this document uses the spelling "colour";
+  code positions use the standard library spelling `color`.
+
+### 2. Scope and composition
+
+This MIP specifies the custody of Night and shielded Zswap coins by a
+per-account contract instance. The following are explicitly out of
+scope, and conforming extensions MUST NOT weaken any invariant in
+section 7 when adding them:
+
+- **Authorisation schemes and key management**: credential formats,
+  device sets, revocation, and ceremonies belong to the instantiating
+  standard. This MIP fixes only the seam semantics (section 4).
+- **Recovery mechanisms**: a companion standard may change who can
+  satisfy the seam; the custody rules are unaffected by construction,
+  because assets sit in the contract and never move during recovery.
+  The availability and recovery of the account encryption secret is
+  likewise the recovery standard's subject; this MIP requires only that
+  a client holding that secret can execute the inbox walk (section
+  6.5), and specifies the on-ledger key lifecycle (section 6.7).
+- **Delegated or scoped spending policies** (grants, allowances,
+  session permissions): these are authorisation-policy objects behind
+  the same seam.
+- **Dust**: the custody contract holds no Dust; where Dust balances
+  live and how fees are paid without fragmenting custody is the open
+  question MPS-0018 records, and is out of scope here.
+- **Token issuance**: minting and burning of a contract's own colours
+  is specified by MIP-0011. A custody contract holds arbitrary colours
+  it did not issue.
+- **Name discovery**: locating a custody contract by human-readable
+  name is the name service's subject (MIP-0007).
+
+Each account is one contract instance. A registry topology was
+considered and rejected (Rationale R2).
+
+### 3. Public ledger state
+
+```compact
+export ledger round: Uint<64>;
+// Strictly increased by every state-changing circuit. Gives the seam a
+// replay anchor and observers a cheap consistency post-condition.
+
+export ledger enc_key: Bytes<32>;
+// The account encryption public key. Depositors encrypt coin
+// descriptions to this key (section 6). Set at deploy; rotated only
+// through the authorised circuit of section 6.7.
+
+export ledger inbox: Map<Uint<64>, Bytes<192>>;
+export ledger inbox_count: Uint<64>;
+// Append-only encrypted coin descriptions (InboxEntry, section 6.4),
+// keyed by ordinal.
+
+export ledger night_balances: Map<Bytes<32>, Uint<128>>;
+// Explicit mirror of the contract's Night holdings per colour.
+```
+
+Implementations MAY extend this state (for example with the account
+standard's credential structures) provided every invariant in section 7
+still holds. Implementations MUST NOT add state that records any part of
+a held shielded coin's description (section 6.1).
+
+### 4. The authorisation seam
+
+Every circuit that releases assets, and every state-changing circuit
+other than deposits and inbox appends, MUST be gated by a single
+internal authorisation check, hereafter `require_authorised()`, with the
+following observable semantics:
+
+1. The caller proves authority by a mechanism an instantiating
+   standard specifies. The proof MUST bind to the specific call: at
+   minimum to the circuit identity, its arguments, and a freshness
+   element that the contract state advances (the `round` counter of
+   section 3). A witness-supplied secret entering the call's own proof
+   satisfies the binding, freshness included, by construction, because
+   the transaction transcript pins the pre-state it executes against; a
+   transferable artefact such as a signature MUST cover the freshness
+   element explicitly, since INV-7 on its own does not make stale
+   authorisations fail.
+2. On success, the circuit proceeds and `round` is incremented.
+3. On failure, the circuit aborts; no state changes.
+
+Conforming contracts MUST document which instantiating standard their
+seam implements.
+
+The check MUST be one internal seam such that replacing the credential
+scheme does not alter any other circuit's specification. Implementations
+MUST NOT derive caller identity from wallet-supplied transaction
+metadata that the circuit does not constrain; in particular,
+`ownPublicKey()` MUST NOT be used for authorisation, a rule MIP-0011
+states for token contracts and which applies here identically.
+
+Candidate seam instantiations, none of which this MIP requires, include
+proof of knowledge of a committed secret, in-circuit signature
+verification, a future stdlib caller-identity primitive (proposed
+upstream; note that a caller derived from unshielded input ownership
+cannot authenticate shielded callers, and binds authority to a single
+ledger-scheme key rather than to an account policy or to a threshold
+scheme on another curve), and threshold schemes presenting any of the
+former. The instantiating standard selects and profiles these.
+
+Deposits (sections 5 and 6.2) and inbox appends (section 6.2) are
+permissionless: anyone may fund the account or contribute a discovery
+entry. They still increment `round`.
+
+### 5. Night custody
+
+- `deposit_night(color, amount)` (permissionless): receives the
+  unshielded tokens for the contract and credits `night_balances` for
+  that colour.
+- `withdraw_night(color, amount, recipient)` (authorised): checks and
+  debits the mirror, then sends the tokens to a user address.
+
+The mirror exists because contract Night balances are not otherwise
+readable from contract state. Night transferred to the contract outside
+`deposit_night` is held but not mirrored; clients MUST treat the mirror
+as a lower bound on holdings. Implementations MAY provide an authorised
+reconciliation circuit that lifts the mirror to observed deposits; such
+a circuit MUST NOT credit beyond deposits observed on-chain, and the
+ledger's protocol-level balance check remains the backstop against
+over-withdrawal even if the mirror drifts high. Withdrawal recipients
+are user addresses; contract-to-contract Night transfer is not part of
+this standard.
+
+### 6. Shielded custody (stateless)
+
+#### 6.1 Design rule
+
+The custody contract MUST NOT write a held coin's description (nonce,
+colour, or value), in whole or in part, into public ledger state or into
+any publicly disclosed circuit output. The only coin-derived values that
+may appear publicly are the protocol-level hiding commitments and
+nullifiers, and the single-bit comparison outcomes inherent to the
+standard library send path.
+
+#### 6.2 Deposit
+
+```compact
+export circuit deposit_shielded(coin: ShieldedCoinInfo, entry: Bytes<192>): []
+```
+
+Semantics: claims the coin for the contract (`receiveShielded`), appends
+`entry` to the inbox, increments `inbox_count`, increments `round`.
+Deposits are permissionless.
+
+`entry` MUST be an `InboxEntry` (section 6.4) encrypting the coin
+description to `enc_key`. The depositor knows the coin description by
+construction: they built the Zswap output. The contract cannot verify
+the correspondence between `coin` and `entry`; the consequences and the
+trust model are addressed in Security Considerations S3.
+
+The ledger rejects encrypted-payload fields on contract-owned Zswap
+outputs, so the standard coin-ciphertext channel that user-held coins
+enjoy is unavailable for deposits to contracts; the inbox is its
+replacement. MIP-0011 documents the same constraint for contract-minted
+coins and resorts to out-of-band delivery; custody cannot, because
+discovery and total-loss recovery must work from chain data alone
+(Rationale R5).
+
+A separate circuit, `append_inbox(entry)`, appends an entry without a
+coin claim. Clients use it to backfill entries for change coins, whose
+descriptions only exist once the spend has executed (section 6.3).
+Implementations MAY gate `append_inbox` behind the authorisation seam:
+change-coin backfill is always performed by the owner's own client, so
+gating it loses nothing, while the entry paired with `deposit_shielded`
+MUST remain permissionless. Spam against an ungated append surface is
+addressed in Security Considerations S9.
+
+#### 6.3 Spend and the change rule
+
+```compact
+witness held_coin(color: Bytes<32>): QualifiedShieldedCoinInfo;
+
+export circuit withdraw_shielded(
+  recipient: ZswapCoinPublicKey,
+  color:     Bytes<32>,
+  amount:    Uint<128>,
+): Maybe<ShieldedCoinInfo>
+```
+
+Semantics (authorised):
+
+1. The qualified coin description enters the circuit through the
+   `held_coin` witness, from the wallet-local coin store. It is never
+   read from ledger state. Contract-held coins are Merkle-path spends
+   (`sendShielded` over a `QualifiedShieldedCoinInfo` with a valid
+   `mt_index`), per the spend-path discipline MIP-0011 codifies.
+2. `sendShielded(coin, recipient, amount)` executes the spend.
+3. **Change rule (normative).** If change exists, the circuit MUST
+   re-own it in the same transaction via `sendImmediateShielded(change,
+   self, change.value)` and MUST treat the **`sent` field of that call's
+   result** as the coin the contract now holds. The consumed change coin
+   (`result.change`) MUST NOT be persisted, returned as the held coin,
+   or recorded in any coin store: its nullifier is revealed in this very
+   transaction, and any later spend of it is rejected as a double spend.
+   Rationale R4 documents the failure this rule prevents.
+4. The circuit returns the re-owned change coin description (or none) to
+   the caller. Circuit return values travel in the transaction's
+   communication commitment and are not public.
+5. `round` is incremented.
+
+The recipient type is deliberately `ZswapCoinPublicKey` and not
+`Either<ZswapCoinPublicKey, ContractAddress>`: see section 6.6.
+
+#### 6.4 InboxEntry format
+
+`InboxEntry` version 1 is a fixed 192-byte container:
+
+| Offset | Length | Field |
+|---|---|---|
+| 0 | 1 | `version` = `0x01` |
+| 1 | 1 | `suite` = `0x01` (X25519 + HKDF-SHA256 + AES-256-GCM) |
+| 2 | 32 | ephemeral X25519 public key |
+| 34 | 12 | AEAD nonce |
+| 46 | 16 | AEAD tag |
+| 62 | 80 | ciphertext |
+| 142 | 50 | zero padding |
+
+Plaintext (80 bytes): `nonce (32) || color (32) || value as unsigned
+128-bit big-endian (16)`. The AEAD key is
+`HKDF-SHA256(ikm = X25519(eph_sk, enc_key), info = "midnight:custody:inbox:v1")`
+with an empty salt (the RFC 5869 default) and an output length of 32
+bytes; the AEAD associated data is the first two container bytes
+(`version || suite`). Writers MUST set the padding to zero; readers
+MUST ignore it. The `info` tag is to be registered under the
+domain-separation registry recommended by MPS-0027. The `mt_index` is
+deliberately not stored: it is recomputed from chain data (section
+6.5), which keeps entries valid independently of tree state.
+
+Readers MUST skip entries with an unknown `version` or `suite` rather
+than treat them as errors; new suites require a revision of this
+section.
+
+#### 6.5 Coin store, index capture, and discovery
+
+Clients MUST maintain a wallet-local coin store, with the following
+behaviour:
+
+- After a deposit, the client records the coin description and captures
+  `mt_index` from the depositing transaction's commitment-tree
+  positions; for a single-output transaction this is the transaction's
+  start index.
+- After a spend with change, the client records the returned re-owned
+  coin and captures its `mt_index` from the spend transaction's position
+  window, then backfills the inbox via `append_inbox` no later than its
+  next inbox write (invariant INV-4).
+- Where a transaction carries several commitments, clients MAY resolve
+  the index by candidate retry: an incorrect qualified description
+  yields an unsatisfiable witness at proving time and no transaction is
+  submitted, so retry cannot mis-spend (INV-5 relies on this).
+
+Discovery MUST be possible from public chain data alone. The normative
+procedure is the **inbox walk**: enumerate `inbox[0 .. inbox_count)`,
+decrypt each entry with the account encryption secret, skip entries that
+fail authentication or version checks, verify each candidate coin by
+recomputing its commitment against chain data, and capture indices as
+above. This procedure serves both third-party-deposit discovery and
+total-loss reconstruction of the coin store. Locating the depositing
+transactions benefits from an indexer surface that enumerates a
+contract's transactions by address; absent one, clients fall back to a
+block-range scan or candidate retry. The indexer surface is recorded as
+an ecosystem dependency in Path to Active.
+
+#### 6.6 Counterparty rules
+
+- A conforming custody contract MUST NOT create a shielded output whose
+  recipient is a contract address, except the self-recipient change
+  output of section 6.3. A shielded output addressed to a contract
+  carries that contract address in cleartext and must be claimed by the
+  receiving contract in the same transaction, so a direct
+  contract-to-contract payment publishes the pair of accounts. (Outputs
+  addressed to a different contract are additionally rejected by the
+  current ledger.)
+- Payments between two custody contracts MUST be routed as one hop: the
+  paying contract sends to a shielded coin public key controlled by the
+  recipient; the recipient deposits into their own contract in a
+  separate transaction. The observer then sees two events that share no
+  address, amount, or token type.
+- Because a coin deposited directly into a custody contract has no
+  owner secret, its depositor can compute its nullifier and observe its
+  first onward move, including deterministically derived same-value
+  descendants. Clients SHOULD break this trail for received funds (for
+  example by splitting value across spends, or routing through a
+  user-held coin) before privacy-sensitive use.
+
+#### 6.7 Encryption-key lifecycle
+
+`enc_key` is set at deploy. Implementations MUST expose exactly one way
+to change it: an authorised circuit, `rotate_enc_key(new_key)`, gated by
+the seam and incrementing `round`. After a rotation the client SHOULD
+re-encrypt the descriptions of all held coins into fresh inbox entries
+under the new key, so that the inbox walk (6.5) succeeds with the new
+secret alone; entries under the old key remain on-ledger and readable to
+whoever holds the old secret (Security Considerations S2). Custody of
+the encryption secret itself, including its recovery after total loss,
+is the instantiating and recovery standards' subject.
+
+### 7. Invariants
+
+A conforming implementation MUST satisfy all of the following.
+
+- **INV-1 (single seam).** Every asset-releasing operation is gated by
+  `require_authorised()`; no circuit releases assets on any other
+  authority.
+- **INV-2 (no public coin material).** No execution of any circuit
+  writes a held coin's nonce, colour, or value into public ledger state
+  or into the public transcript, beyond protocol commitments,
+  nullifiers, and the send path's single-bit comparison outcomes.
+- **INV-3 (change continuity).** After a partial spend, the coin
+  recorded as held is spendable in a later transaction. Equivalently:
+  the re-owned coin, never the consumed change coin, is what survives.
+- **INV-4 (reconstruction completeness).** For every coin the contract
+  holds, the inbox contains an entry from which the coin description is
+  recoverable by the holder of the account encryption secret, subject
+  to the depositor trust assumption (S3). For change coins the client
+  MUST append the entry no later than its next inbox write.
+- **INV-5 (capture safety).** No coin-store capture strategy can cause
+  an unintended spend: an incorrect qualified description fails at
+  proving, before any transaction exists.
+- **INV-6 (counterparty unlinkability).** A conforming payment between
+  two custody contracts produces no transaction containing both
+  contract addresses.
+- **INV-7 (round monotonicity).** Every state-changing call strictly
+  increases `round`.
+- **INV-8 (mirror soundness).** `night_balances` never exceeds the
+  contract's actual Night holdings per colour; a conforming withdrawal
+  never debits below zero.
+
+### 8. Versioning
+
+- This specification is versioned by its MIP number and revision
+  history; substantive changes after acceptance require a new MIP that
+  lists this one in `Replaces`.
+- The `InboxEntry` container is self-versioned (leading version byte);
+  readers MUST tolerate unknown versions (6.4).
+- Contracts SHOULD expose a constant `spec_version` cell so clients can
+  gate features; instances are otherwise immutable per the ledger's
+  deploy semantics, and fleet migration expectations belong to the
+  implementation, not to this specification.
+
+## Rationale
+
+**R1. Contract custody rather than address custody.** Address custody
+(assets at seed-derived addresses) reintroduces a seed-shaped root and
+decouples assets from the account object, so revocation and recovery
+stop covering them, violating the MPS-0018 goals. Contract custody keeps
+"recovered account implies recovered assets" true by construction:
+assets sit in the contract, and a change of who satisfies the seam moves
+nothing. The historical objection to contract custody of shielded assets
+was the publicity leak, which section 6 removes.
+
+**R2. Per-account contracts rather than a registry.** A registry
+concentrates every account's activity behind one address, which improves
+the metadata anonymity set, but it makes the ledger schema
+ecosystem-wide, concentrates upgrade risk, and turns the registry into a
+single censorship and correlation point at the application layer.
+Per-account instances keep schema evolution per-user and isolate
+failure. A future shared-custody profile with witness-private account
+binding can widen the anonymity set without changing this
+specification's invariants; it is left as a successor proposal.
+
+**R3. Stateless shielded custody rather than the public-map pattern.**
+The alternatives were measured against a production node, with a
+byte-level audit of every observer-visible surface (raw transactions and
+per-call contract state), running identical deposit, partial-spend, and
+change lifecycles through both patterns:
+
+| Property | Public map (`insertCoin`) | Stateless (this MIP) |
+|---|---|---|
+| Coin nonce visible to observers | yes, verbatim | no |
+| Token type visible | yes, verbatim | no |
+| Amounts and balances visible | yes | no |
+| Spend watchable in advance (nullifier precomputable by anyone) | yes | only by parties who know the coin description |
+| Deposit-to-spend linkable by observers | yes | no |
+| Node accepts spends | yes | yes, including change chains |
+| Client complexity | none beyond calls | coin store, index capture, inbox handling |
+
+The compiler's disclosure analysis independently bounds the stateless
+pattern's public surface: the forced disclosures are hash links
+(commitments and nullifiers) and single-bit comparison outcomes, never
+raw coin fields. MIP-0011's own analysis of coin operations reaches the
+same conclusion from the issuance side: coin operations emit only
+commitments and nullifiers, and, mint effects aside (which do not arise
+in custody), the only way a value becomes public is an explicit ledger
+write. What the stateless design costs is wallet-side
+state management, which section 6.5 specifies, with the inbox as its
+durable backstop.
+
+**R4. The change rule.** `sendImmediateShielded` consumes the change
+coin it is given (its nullifier is revealed in that same transaction)
+and creates a replacement with an evolved nonce, returned as `.sent`.
+Persisting the consumed coin makes every later change spend fail as an
+attempted double spend, while the replacement sits unrecorded; the
+failure was reproduced on a production node through both custody
+patterns, in the treasury modules of a widely used contract library
+(the same pattern MPS-0018 cites as the working recipe), and disappears
+under the rule of section 6.3. MIP-0011 requires the change coin to be
+returned by the circuit and recommends persisting it, which is correct
+for its own burn flows, but those flows never surface the re-owning
+step, where two coin objects exist and only one survives; this MIP
+states the rule at the level where the defect lives, and recommends a
+clarifying note upstream for consumers who add the re-owning step.
+
+**R5. Inbox rather than out-of-band delivery or ledger ciphertexts.**
+Ledger ciphertexts on contract-owned outputs are rejected by the node,
+so the encrypted channel that user coins enjoy is unavailable.
+Out-of-band delivery, which MIP-0011 accepts for mint recipients, breaks
+the "chain data is sufficient" property (INV-4) and adds a liveness
+dependency between depositor and owner; for custody, discovery and
+total-loss reconstruction are requirements, not conveniences. An
+on-ledger encrypted inbox costs contract state but makes both possible
+from chain data alone.
+
+**R6. An abstract seam rather than authorisation profiles.** An earlier
+draft of the keystone specified credential profiles (hash preimage,
+in-circuit signature) alongside custody. Profiles belong to the
+instantiating standards: the upstream conversation on caller identity
+is active, and
+custody must not re-open every time it moves. What custody genuinely
+depends on is only the seam semantics of section 4, which every
+candidate scheme can satisfy. This also lets institutional custody
+(MPS-0006, MPS-0016, MPS-0024) adopt the asset surface unchanged:
+MPS-0024's core problem, that asset movement is proof-authorised rather
+than signature-authorised, is eased under contract custody, because
+spend authority becomes the contract's seam rather than possession of a
+coin-secret witness, and the seam can be instantiated with whatever
+threshold-controlled mechanism the custodian's control framework
+requires.
+
+**R7. What stays visible.** Two leaks are structural to any contract
+custody on today's ledger and are documented rather than hidden:
+deposits to and spends from a custody contract are labelled with its
+contract address (activity metadata: counts and timing, not contents);
+and the depositor of a coin can watch that coin's first onward move
+(section 6.6 mitigations). Within those bounds, amounts, token types,
+balances, and conforming counterparties are hidden.
+
+**R8. Relationship to neighbouring standards.** MIP-0011 governs a
+contract's own issued colours (mint and burn); this MIP governs holding
+arbitrary colours on an account's behalf; the two compose, and this MIP
+adopts MIP-0011's spend-path discipline and caller-authentication
+prohibition. Token registry and NFT standardisation effects are
+upstream of custody only at the metadata layer. The name service
+(MIP-0007) locates accounts; nothing here depends on it.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] MIP number assigned by an editor; listed in MPS-0018's header as
+      a proposed solution, with the MPS-0018 problem statement refined
+      per the Motivation.
+- [ ] Cryptographer review of section 6 (secretless-coin analysis, the
+      InboxEntry construction, and the disclosure bounds) with findings
+      addressed.
+- [ ] The change rule (6.3, R4) accepted upstream in at least one widely
+      used contract library, or that library documents divergence; the
+      clarifying note recommended against MIP-0011 (R4) resolved either
+      way.
+- [ ] A public reference implementation passing the conformance suite
+      (Testing section), including the observer leak audit with a
+      passing positive control.
+- [ ] A second, independent implementation by a wallet provider or
+      ecosystem team interoperating with the reference (deposit by one,
+      discovery and spend by the other).
+- [ ] Indexer surface (or documented block-scan procedure) for
+      enumerating a contract's transactions by address, sufficient for
+      third-party-deposit discovery without depositor cooperation.
+- [ ] Deployment exercised on a public test network.
+
+### Implementation Plan
+
+1. Publish the reference implementation and conformance suite.
+2. File and track the upstream library defect report and change-rule
+   fix, and the MIP-0011 clarifying note.
+3. File and track the indexer discovery surface.
+4. Engage a wallet provider for the independent implementation.
+5. Submit for editor numbering; iterate through community commentary.
+6. Author the companion account standard against the seam, followed by
+   the recovery-paths MIP recommended by MPS-0018.
+
+## Backwards Compatibility Assessment
+
+This MIP introduces a new contract standard. It requires no ledger,
+consensus, or node change and no hard fork: every mechanism used
+(contract-owned Zswap coins, witness-supplied spends, in-transaction
+re-owning of change, contract state) exists in the current stable
+network protocol. Existing deployments of the public-map pattern remain
+valid; they do not conform to INV-2 and carry the documented publicity
+leak, and migrating requires spending held coins into a conforming
+instance. Wallets unaware of this standard are unaffected.
+
+## Security Considerations
+
+- **S1. Secretless coins.** A contract-owned coin's commitment and
+  nullifier are deterministic functions of its description and the
+  contract address. Anyone who learns a coin description can watch that
+  coin. The standard therefore treats coin descriptions as secrets
+  (witness supply, encrypted inbox) and documents the depositor
+  exception (R7, 6.6).
+- **S2. Encryption-key compromise.** Disclosure of the account
+  encryption secret reveals the contract's holdings and enables
+  watching, but does not enable theft: releasing assets still requires
+  the authorisation seam (INV-1). Key rotation is the procedure of
+  section 6.7; old entries remain readable to the attacker, so rotation
+  bounds future, not past, exposure.
+- **S3. Inbox poisoning.** The contract cannot verify that a deposit's
+  inbox entry matches the deposited coin. A malicious depositor can
+  deposit a coin whose entry is garbage, producing value the owner
+  cannot reconstruct from chain data; the depositor, who knows the
+  description, could later reveal or exploit it. The owner loses nothing
+  they previously held, and honest clients detect mismatches at
+  discovery by recomputing the commitment against chain data. Binding
+  the entry to the coin in-circuit (proving correct encryption of the
+  claimed coin) is possible in principle at significant circuit cost; it
+  is left as a hardening extension.
+- **S4. Metadata.** Activity metadata per custody contract is public
+  (R7): event counts, timing, and the contract address on every deposit
+  and spend. Applications with strong unlinkability requirements SHOULD
+  consider the shared-custody successor profile (R2) and traffic-shaping
+  practices. This is the residual form of the MPS-0018 privacy question.
+- **S5. Seam misuse.** The seam MUST NOT be satisfiable by
+  wallet-supplied, circuit-unconstrained data; `ownPublicKey()` is the
+  canonical counter-example (section 4). A seam satisfiable without any
+  witness-supplied secret or verified credential is not conforming: a
+  custody contract whose seam is vacuous publishes no coin material but
+  protects nothing.
+- **S6. Hash discipline.** All domain-separation tags used by this
+  standard (currently the InboxEntry HKDF `info` string) MUST be
+  registered under the registry recommended by MPS-0027 once it is
+  established, and commitments stored in ledger state MUST use hash
+  constructions whose outputs are stable across toolchain versions.
+- **S7. Availability of the coin store.** Between a change-producing
+  spend and the corresponding inbox append (INV-4 allows the next
+  write), the only holder of the change description is the client.
+  Clients SHOULD minimise this window; the reference behaviour appends
+  immediately.
+- **S8. Mirror drift.** The Night mirror is a lower bound (section 5).
+  Treating it as exact can under-report holdings but cannot enable
+  over-withdrawal (INV-8): the ledger enforces actual balances at the
+  protocol level.
+- **S9. Inbox spam.** An ungated `append_inbox` lets anyone grow the
+  contract's public state and inflate the cost of the inbox walk.
+  Entries that fail AEAD authentication are skipped at negligible cost,
+  and transaction fees bound the attack economically; implementations
+  for which this is insufficient MAY gate `append_inbox` behind the
+  seam (section 6.2) without losing any specified behaviour.
+
+## Implementation
+
+- Evidence base: the stateless custody experiment in the Midnight
+  Passport workspace validates the custody mechanics against a
+  production node (deposits, witness spends, change chains, third-party
+  deposit and discovery, and the observer leak audit), using a 160-byte
+  unversioned inbox container with a key-derivation stand-in; the
+  versioned container of section 6.4 is specified here and awaits the
+  reference implementation required by Path to Active. The
+  account-custody prototype validates the Night surface and a working
+  seam instantiation; it predates this specification and diverges from
+  it in known ways (its deposits do not increment `round`, and its
+  shielded path is the public-map control pattern).
+- Upstream dependencies: a defect report and change-rule fix for the
+  affected contract library, and the MIP-0011 clarifying note, both
+  tracked by the Implementation Plan; an indexer surface for
+  contract-transaction enumeration (Path to Active).
+- This MIP contains no implementation code; the artefacts above are its
+  evidence base, and the reference implementation is an acceptance
+  criterion, not an existing artefact.
+
+## Testing
+
+Conformance is demonstrated by a suite exercising, against a real node
+(the simulator does not enforce the ledger's nullifier set and cannot
+observe the failures this standard rules out):
+
+1. **Deposit conformance**: deposit lands; public state holds no coin
+   material; the inbox entry decrypts to the deposited coin; index
+   capture succeeds, including a wrong-index candidate-retry probe
+   that fails at proving without producing a transaction (INV-2,
+   INV-4, INV-5).
+2. **Witness spend**: full-amount spend from the coin store is accepted
+   by the node (INV-1, INV-2).
+3. **Change chain**: partial spend, re-capture of the re-owned change,
+   spend of the change in a later transaction (INV-3). This test is the
+   regression gate for the change rule and fails on the consumed-coin
+   defect.
+4. **Third-party deposit and discovery**: a second, independent wallet
+   deposits against the advertised key; the owner discovers and spends
+   using the inbox walk and chain data only (INV-4).
+5. **Observer leak audit**: identical lifecycles through this standard
+   and through the public-map pattern; a byte-scan of raw transactions
+   and contract state finds coin material in the control (validating
+   the scanner) and none in the conforming path (INV-2).
+6. **Night mirror**: deposit, withdraw, and attempted over-withdrawal
+   against the mirror (INV-8), plus an unmirrored transfer confirming
+   lower-bound semantics.
+7. **One-hop payment**: a payment between two custody contracts routed
+   per section 6.6; no transaction in the flow contains both contract
+   addresses (INV-6).
+
+`round` monotonicity (INV-7) is asserted as a post-condition of every
+test above; INV-1 is exercised by running each authorised circuit once
+without a satisfying witness and observing the abort.
+
+## References (Optional)
+
+- [MPS-0018](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0018-asset-custody-model.md):
+  Multi-key Account Custody for Midnight-Native Assets (the parent
+  problem statement).
+- [MIP-0011](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0011-native-shielded-token.md):
+  Native Shielded Token Standard (spend-path discipline, disclosure
+  semantics, caller-authentication prohibition).
+- [MPS-0027](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0027-domain-separation.md):
+  Domain Separation for Midnight Hash Constructions (tag registry).
+- MPS-0006, MPS-0016, MPS-0024, MPS-0025: the institutional custody
+  problem statements this surface is designed to be reusable under.
+- MIP-0003: ECDSA support; MIP-0007: name service registry and resolver
+  (context, not dependencies).
+- Midnight ledger sources for the on-chain structures relied on here:
+  Zswap input and output structures, coin commitment and nullifier
+  derivations, the contract-call communication commitment, and the
+  rejection of ciphertexts on contract-owned outputs.
+- OpenZeppelin Compact contracts: the public-map treasury pattern and
+  the stateless precedents; the change-rule defect report is to be
+  filed and linked per the Implementation Plan.
+- Midnight Passport workspace: the stateless custody experiment
+  (evidence and conformance probes, `experiments/stateless-shielded-custody/`)
+  and the account-custody prototype
+  (`experiments/account-custody-prototype/`); to be linked at their
+  public locations on submission.
+
+## Acknowledgements
+
+The IOG Advanced Research and Creativity department, the Midnight
+Foundation, and the OpenZeppelin Compact contracts team, whose treasury
+patterns this standard builds on.
+
+## Copyright Waiver
+
+This document is licensed under the Apache License, Version 2.0, and its
+contribution is made under the Midnight Foundation Contributor License
+Agreement.
+
+Portions of this document were drafted with the assistance of a large
+language model. The named authors reviewed all content and are solely
+accountable for it.

--- a/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
+++ b/docs/mps-mip/mips/mip-xxxx-native-asset-custody.md
@@ -560,10 +560,12 @@ result. This MIP states the rule at the level of the surviving coin so
 both realisations conform: the baseline (persist the send result's
 change directly, which is also MIP-0011's guidance for its burn flows)
 and deliberate onward routing (persist that call's `sent` coin). The
-node-level evidence behind this rationale validated the re-owning
-variant; the baseline realisation is upstream-tested in a simulator,
-and its cross-transaction change spend is exercised on a node by
-conformance test 3.
+node-level evidence behind this rationale covers both realisations:
+the re-owning variant was validated when the defect was reproduced,
+and the baseline realisation has since passed the same change chains
+on a node through both custody patterns, including the
+cross-transaction change spend that simulator tests cannot exercise.
+Conformance test 3 keeps that check as the standing regression gate.
 
 **R5. Inbox rather than out-of-band delivery or ledger ciphertexts.**
 Ledger ciphertexts on contract-owned outputs are rejected by the node,
@@ -649,9 +651,9 @@ upstream of custody only at the metadata layer. The name service
 
 This MIP introduces a new contract standard. It requires no ledger,
 consensus, or node change and no hard fork: every mechanism used
-(contract-owned Zswap coins, witness-supplied spends, in-transaction
-re-owning of change, contract state) exists in the current stable
-network protocol. Existing deployments of the public-map pattern remain
+(contract-owned Zswap coins, witness-supplied spends, send-level
+change routing back to the contract, contract state) exists in the
+current stable network protocol. Existing deployments of the public-map pattern remain
 valid; they do not conform to INV-2 and carry the documented publicity
 leak, and migrating requires spending held coins into a conforming
 instance. Wallets unaware of this standard are unaffected.
@@ -728,10 +730,11 @@ instance. Wallets unaware of this standard are unaffected.
   do not increment `round`, and its shielded path is the public-map
   control pattern).
 - Upstream status: the change-rule defect report and the library fix
-  are filed and merged (References); node-level validation of the fixed
-  pattern is tracked by the Implementation Plan. Remaining dependency:
-  an indexer surface for contract-transaction enumeration (Path to
-  Active).
+  are filed and merged (References); the fixed pattern is validated on
+  a node by the stateless custody experiment, whose change chains run
+  the baseline realisation through both custody patterns. Remaining
+  dependency: an indexer surface for contract-transaction enumeration
+  (Path to Active).
 - This MIP contains no implementation code; the artefacts above are its
   evidence base, and the reference implementation is an acceptance
   criterion, not an existing artefact.

--- a/docs/mps-mip/mps/mps-asset-custody-model.md
+++ b/docs/mps-mip/mps/mps-asset-custody-model.md
@@ -1,3 +1,14 @@
+> **Canonical copy upstream.** This document was submitted to
+> [midnightntwrk/midnight-improvement-proposals](https://github.com/midnightntwrk/midnight-improvement-proposals)
+> and merged as
+> [MPS-0018](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0018-asset-custody-model.md),
+> which is now the canonical version. The copy below is retained for
+> local reference only; where the two differ, MPS-0018 governs. Note
+> that experimental evidence gathered after submission shows the
+> shielded-custody publicity described in the Abstract is a property of
+> the prevailing storage pattern, not of the ledger; see the
+> asset-custody MIP draft in `../mips/`.
+
 <!--
  Copyright 2026 Midnight Foundation
 

--- a/docs/mps-mip/mps/mps-domain-separation.md
+++ b/docs/mps-mip/mps/mps-domain-separation.md
@@ -1,3 +1,11 @@
+> **Canonical copy upstream.** This document was submitted to
+> [midnightntwrk/midnight-improvement-proposals](https://github.com/midnightntwrk/midnight-improvement-proposals)
+> and merged as
+> [MPS-0027](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0027-domain-separation.md),
+> which is now the canonical version. The copy below is a pre-numbering
+> snapshot retained for local reference only; where the two differ,
+> MPS-0027 governs.
+
 <!--
  Copyright 2026 Midnight Foundation
 

--- a/experiments/stateless-shielded-custody/FINDINGS.md
+++ b/experiments/stateless-shielded-custody/FINDINGS.md
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| Experiment run | 2026/07/03 (localnet) |
+| Experiment run | 2026/07/03; re-run 2026/07/08 with upstream-simplified change handling (localnet) |
 | Compact toolchain | 0.31.1 (language 0.23) |
 | Node image | `midnightntwrk/midnight-node:1.0.0` |
 | Indexer image | `midnightntwrk/indexer-standalone:4.3.3` |
@@ -42,11 +42,11 @@ and the C4 stakes.
 
 | Probe | Verdict | Tx hash / error | Ran | Note |
 |-------|---------|-----------------|-----|------|
-| **W1** compile-disclosure | **PASS** | — | 2026/07/03 | Compiler-forced disclosures decompose into 33 hiding-hash clause(s) (commitment/nullifier links) and 8 single-bit clause(s) (has-change / sufficient-balance com |
-| **W2** stateless-deposit | **PASS** | `00d77fbc79dce3d7…` | 2026/07/03 | Deposit landed with no QSCI in public ledger state; the encrypted inbox blob round-trips to the exact coin; mt_index recovered from the indexer (startIndex infe |
-| **W3** witness-spend | **PASS** | `0097444fac9a43eb…` | 2026/07/03 | Node ACCEPTED a contract shielded spend whose QSCI came from the witness — the S5 "structurally impossible" reading is refuted on this stack; stateless custody  |
-| **W5** third-party-deposit | **PARTIAL** | `00f51d4244acd837…` | 2026/07/03 | Deposit, decrypt, and spend all worked, but the contract-address → tx indexer lookup is missing — the discovery loop needs an indexer surface or block scan (C17 |
-| **W6** leak-audit | **PASS** | — | 2026/07/03 | The insertCoin control leaks its coin (nonce/colour) into the raw transaction and the indexer per-call state (positive control confirms the scanner); the statel |
+| **W1** compile-disclosure | **PASS** | — | 2026/07/08 | Compiler-forced disclosures decompose into 15 hiding-hash clause(s) (commitment/nullifier links), 2 single-bit clause(s) (has-change / sufficient-balance compar |
+| **W2** stateless-deposit | **PASS** | `0051a26e9223a421…` | 2026/07/08 | Deposit landed with no QSCI in public ledger state; the encrypted inbox blob round-trips to the exact coin; mt_index recovered from the indexer (startIndex infe |
+| **W3** witness-spend | **PASS** | `00e18429467f7e2b…` | 2026/07/08 | Node ACCEPTED a contract shielded spend whose QSCI came from the witness — the S5 "structurally impossible" reading is refuted on this stack; stateless custody  |
+| **W5** third-party-deposit | **PARTIAL** | `00cbf033a557c041…` | 2026/07/08 | Deposit, decrypt, and spend all worked, but the contract-address → tx indexer lookup is missing — the discovery loop needs an indexer surface or block scan (C17 |
+| **W6** leak-audit | **PASS** | — | 2026/07/08 | The insertCoin control leaks its coin (nonce/colour) into the raw transaction and the indexer per-call state (positive control confirms the scanner); the statel |
 
 <!-- END RESULTS -->
 
@@ -54,15 +54,26 @@ and the C4 stakes.
 
 ### W1 — compile-time disclosure
 
-**PASS** (2026/07/03, toolchain 0.31.1). All three undisclosed probe
-variants are rejected, and the 41 disclosure clauses across them decompose
-cleanly: **33 hiding-hash clauses** (commitment/nullifier "link"
+**PASS** (re-run 2026/07/08, toolchain 0.31.1). All three undisclosed probe
+variants are rejected, and the 23 disclosure clauses across them decompose
+cleanly: **15 hiding-hash clauses** (commitment/nullifier "link"
 diagnostics — "…the coin with the commitment given by a hash of the witness
-value") and **8 single-bit clauses** (booleans of comparisons involving
+value"), **2 single-bit clauses** (booleans of comparisons involving
 subtractions on the witness value — the has-change / sufficient-balance
-checks inside `sendShielded`/`sendImmediateShielded` — plus the change
-conditional). **Zero clauses name a raw coin field as the published
-object.** The main contract compiles with the disclosures declared.
+checks inside `sendShielded`, plus the change conditional), and **6
+caller-return clauses** (p3 only: returning the kept change coin from the
+circuit — return values travel in the communication commitment, which is
+caller-visible rather than an observer surface, and handing the change to
+the caller IS the design; W6 confirms nothing coin-shaped reaches observer
+surfaces). **Zero clauses name a raw coin field as published to the
+transcript.** The main contract compiles with the disclosures declared.
+
+The p3 probe matches the current change handling: upstream removed the
+redundant re-owning step (OpenZeppelin/compact-contracts#661), so keeping
+change now means returning `result.change` to the caller, and the probe
+omits disclose() on that path rather than on a `sendImmediateShielded`
+re-send. The clause counts dropped from the first run (41 → 23) because
+the re-send's own stdlib machinery no longer appears.
 
 Catalogued finding: each stateless spend structurally leaks a handful of
 comparison **bits** (change existed or not, balance sufficed) on top of the
@@ -86,11 +97,12 @@ spend whose QualifiedShieldedCoinInfo is witness-supplied from wallet-local
 storage. The S5 "witness/off-ledger spend is structurally impossible"
 reading is refuted empirically on `midnight-node:1.0.0`; contract-held
 shielded coins can be spent with no QSCI in public state (phase 1). The
-change chain also completes (phase 2): the change is re-owned
-in-transaction, returned through the private call result, re-captured with
+change chain also completes (phase 2): `sendShielded` itself routes the
+change back to the contract as a fresh self-owned output, the circuit
+returns it through the private call result, the client re-captures it with
 candidate-mt_index retry (a wrong candidate fails at the prover as an
-unsatisfiable witness — prove HTTP 400 — and cannot mis-spend), spent in a
-later transaction, and its backup blob appended to the inbox.
+unsatisfiable witness — prove HTTP 400 — and cannot mis-spend), spends it
+in a later transaction, and appends its backup blob to the inbox.
 
 **Along the way W3 exposed an upstream bug** (phases 2–3, confirmed by the
 insertCoin control comparator failing identically before the fix):
@@ -109,6 +121,23 @@ both the stateless and the insertCoin change chains work. This means the
 canonical OZ treasury change path has plausibly never been spent on a real
 node (their tests are simulator-only), and the prototype's second
 `withdraw_shielded` from the same colour would fail.
+
+**Resolved upstream since the first run.** The re-owning step was itself
+redundant: `sendShielded` already emits change as a fresh self-owned output
+dwelling at the contract address, so `result.change` is live the moment the
+call returns — the defect only arises when the same transaction ALSO burns
+that coin's nullifier. Upstream dropped the re-send at all three sites and
+retains `result.change` directly (OpenZeppelin/compact-contracts#661).
+Both paths of this experiment now carry the same simplified realisation,
+and the full change chain re-ran green on localnet 2026/07/08: the
+stateless path spent the retained change cross-transaction (two candidate
+mt_indices in the spend window, first accepted), and the insertCoin control
+spent its recorded change from the authoritative mt_index. The upstream
+regression tests assert only that the change nullifier is absent within the
+same transaction (dry simulator); this run is the cross-transaction
+confirmation on a real node. The general rule survives at the
+surviving-coin level: hold `result.change` when change is kept, hold
+`.sent` when change is deliberately routed onward in-transaction.
 
 ### W4 — manual offer (fallback)
 
@@ -179,10 +208,17 @@ confirmed, H4 with one indexer-surface gap (W5).
 
 Two upstream items fall out:
 
-1. **OZ `ShieldedTreasury` change bug** — `_send` persists
-   `result.change` instead of `sendImmediateShielded(...).sent`, leaving
-   the treasury's change unspendable on a real node (see W3). Applies to
-   every consumer of the pattern, including our account-custody prototype.
+1. **OZ `ShieldedTreasury` change bug — reported, and resolved upstream.**
+   `_send` persisted `result.change` while also re-spending it, leaving the
+   treasury's change unspendable on a real node (see W3). Upstream resolved
+   it by deleting the redundant re-send
+   (OpenZeppelin/compact-contracts#661); this experiment adopted the same
+   realisation on both paths and re-verified the full change chain on
+   localnet — the cross-transaction evidence the upstream simulator tests
+   cannot provide. Still outstanding on our side: the account-custody
+   prototype's `withdraw_shielded` / `grant_withdraw_shielded` carry the
+   pre-fix pattern (re-spend plus persist `result.change`) and need the
+   same deletion.
 2. **Indexer discovery surface** — no query enumerates a contract's
    transactions or Zswap outputs by address, which third-party-deposit
    discovery (and any C17 sync of contract-held coins) needs.

--- a/experiments/stateless-shielded-custody/README.md
+++ b/experiments/stateless-shielded-custody/README.md
@@ -15,8 +15,10 @@ See [`EXPERIMENT_GUIDELINE.md`](EXPERIMENT_GUIDELINE.md) for the brief and
   inbox (coin info encrypted to the account's advertised key). No
   `insertCoin`.
 - **Spend**: the QSCI enters the circuit as a **witness** from wallet-local
-  storage; change is re-owned in-transaction and returned through the
-  private call result.
+  storage; `sendShielded` itself routes any change back to the contract as a
+  self-owned output, which the circuit returns through the private call
+  result (no re-owning step; upstream removed the redundant re-send in
+  OpenZeppelin/compact-contracts#661).
 - **Control**: the same contract carries the S6/OZ `insertCoin` pattern for
   the leak-audit baseline.
 

--- a/experiments/stateless-shielded-custody/contracts/probes/p3-change-undisclosed.compact
+++ b/experiments/stateless-shielded-custody/contracts/probes/p3-change-undisclosed.compact
@@ -4,12 +4,18 @@ import CompactStandardLibrary;
 
 // W1 probe 3 — change handling with the SendResult undisclosed.
 //
-// Question: does re-owning the change to the contract
-// (sendImmediateShielded on result.change) compile without disclosing the
-// change coin? The change coin's info is exactly what the stateless design
-// keeps private, so a forced disclosure here would matter — subject to the
-// usual caveat that disclose() permits publication but only transcript
-// writes cause it (W6 settles what is actually published).
+// Question: does KEEPING the change coin compile without disclosing it? In
+// the current design (after upstream removed the redundant re-owning step,
+// OpenZeppelin/compact-contracts#661) keeping the change means returning
+// result.change to the caller — sendShielded has already routed the coin
+// back to the contract as a self-owned output, and the caller must learn
+// its info to retain custody client-side. This probe omits disclose() on
+// the whole change path (the branch on result.change.is_some and the
+// returned coin) to map what the compiler forces — subject to the usual
+// caveat that disclose() permits publication but only transcript writes
+// cause it, and that circuit return values travel in the communication
+// commitment (caller-visible, not an observer surface); W6 settles what is
+// actually published.
 
 witness held_coin(color: Bytes<32>): QualifiedShieldedCoinInfo;
 
@@ -23,19 +29,16 @@ export circuit spend_change_undisclosed(
   recipient: ZswapCoinPublicKey,
   color:     Bytes<32>,
   amount:    Uint<128>,
-): [] {
+): Maybe<ShieldedCoinInfo> {
   const coin = held_coin(color);
   const result = sendShielded(
     coin,
     left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
     disclose(amount),
   );
-  if (result.change.is_some) {
-    sendImmediateShielded(
-      result.change.value,
-      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
-      result.change.value.value,
-    );
-  }
   round = ((round + (1 as Uint<64>)) as Uint<64>);
+  if (result.change.is_some) {
+    return some<ShieldedCoinInfo>(result.change.value);
+  }
+  return none<ShieldedCoinInfo>();
 }

--- a/experiments/stateless-shielded-custody/contracts/stateless.compact
+++ b/experiments/stateless-shielded-custody/contracts/stateless.compact
@@ -21,8 +21,9 @@ import CompactStandardLibrary;
 //   - spends take the QSCI from a witness (wallet-local coin store, C16
 //     stand-in) — the mt_index is captured client-side from the indexer at
 //     deposit time (the S5 technique);
-//   - change is re-owned to the contract in-transaction and re-captured
-//     client-side; no insertCoin anywhere on the stateless path.
+//   - change comes back to the contract from sendShielded itself (a fresh
+//     self-owned output) and is re-captured client-side; no insertCoin
+//     anywhere on the stateless path.
 //
 // The contract ALSO carries the S6 insertCoin pattern verbatim
 // (deposit_public / spend_public) as the control group: the W6 leak audit
@@ -88,22 +89,27 @@ export circuit deposit_stateless(coin: ShieldedCoinInfo, blob: Bytes<160>): [] {
   bump();
 }
 
-// Spend: the QSCI arrives via witness, never from ledger state. Change is
-// re-owned to the contract in this same transaction (sendImmediateShielded)
-// and returned to the caller — return values travel in the communication
-// commitment (private to the caller), not in the transcript. The client
-// re-captures the change's mt_index from the indexer and, in a follow-up
-// call, appends an encrypted backup blob via append_backup so the inbox
-// stays complete (the change nonce is derived in-circuit, so it cannot be
-// pre-encrypted as an argument to this same call).
+// Spend: the QSCI arrives via witness, never from ledger state. When the
+// spend produces change, sendShielded itself routes it back to the contract
+// as a fresh self-owned output and hands it to the circuit as result.change
+// — no separate re-owning step is needed (upstream removed the redundant
+// re-send after our defect report; OpenZeppelin/compact-contracts#661).
+// The change coin is returned to the caller — return values travel in the
+// communication commitment (private to the caller), not in the transcript.
+// The client re-captures the change's mt_index from the indexer and, in a
+// follow-up call, appends an encrypted backup blob via append_backup so the
+// inbox stays complete (the change nonce is derived in-circuit, so it
+// cannot be pre-encrypted as an argument to this same call).
 //
-// CRITICAL (found by W3 phase 2/3): sendImmediateShielded re-owns the
-// change by TRANSIENTLY SPENDING it — result.change's nullifier is burnt
-// in this very transaction — and creates a fresh coin with an evolved
-// nonce, returned as `.sent`. The holdable coin is `.sent`, NOT
-// result.change. Storing result.change (as OZ ShieldedTreasury._send and
-// our S6 port both do) leaves an unspendable zombie: any later spend hits
-// NullifierAlreadyPresent ("attempted double spend").
+// CRITICAL (found by W3 phase 2/3): the rule is about the SURVIVING coin.
+// result.change is live and contract-owned the moment sendShielded returns;
+// hold it and it stays spendable. Re-spending it in the same transaction
+// (the old sendImmediateShielded re-owning step) burns its nullifier and
+// evolves the nonce — the surviving coin becomes that call's `.sent`, and
+// holding anything else is the zombie-change defect: the later spend proves
+// (the commitment is in the tree) but the node rejects with
+// NullifierAlreadyPresent ("attempted double spend"). Re-spending change is
+// only meaningful to route it somewhere other than self.
 export circuit spend_stateless(
   recipient: ZswapCoinPublicKey,
   color:     Bytes<32>,
@@ -115,16 +121,10 @@ export circuit spend_stateless(
     left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
     disclose(amount),
   );
-  if (disclose(result.change.is_some)) {
-    const redeposit = sendImmediateShielded(
-      disclose(result.change.value),
-      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
-      disclose(result.change.value.value),
-    );
-    bump();
-    return some<ShieldedCoinInfo>(disclose(redeposit.sent));
-  }
   bump();
+  if (disclose(result.change.is_some)) {
+    return some<ShieldedCoinInfo>(disclose(result.change.value));
+  }
   return none<ShieldedCoinInfo>();
 }
 
@@ -170,17 +170,16 @@ export circuit spend_public(
     disclose(amount),
   );
   if (disclose(result.change.is_some)) {
-    // Insert the RE-OWNED coin (.sent, evolved nonce), not result.change —
-    // see the note on spend_stateless. Inserting result.change is the OZ /
-    // S6 bug that makes the change unspendable (NullifierAlreadyPresent).
-    const redeposit = sendImmediateShielded(
-      disclose(result.change.value),
-      right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
-      disclose(result.change.value.value),
-    );
+    // Insert the change exactly as sendShielded emitted it — it is already
+    // a live, self-owned output (the upstream ShieldedTreasury fix,
+    // OpenZeppelin/compact-contracts#661). The earlier re-owning step
+    // (sendImmediateShielded to self, insert `.sent`) also worked but spent
+    // an extra nullifier per change; inserting result.change while ALSO
+    // re-spending it was the original zombie-change bug — see the note on
+    // spend_stateless.
     public_coins.insertCoin(
       disclose(color),
-      disclose(redeposit.sent),
+      disclose(result.change.value),
       right<ZswapCoinPublicKey, ContractAddress>(kernel.self()),
     );
   } else {

--- a/experiments/stateless-shielded-custody/evidence/w1-compile-disclosure.json
+++ b/experiments/stateless-shielded-custody/evidence/w1-compile-disclosure.json
@@ -3,7 +3,7 @@
   "name": "compile-disclosure",
   "description": "Compiler-forced disclosure surface for stdlib receiveShielded/sendShielded with witness coins",
   "verdict": "PASS",
-  "note": "Compiler-forced disclosures decompose into 33 hiding-hash clause(s) (commitment/nullifier links) and 8 single-bit clause(s) (has-change / sufficient-balance comparisons and the change branch). No clause forces raw nonce/colour/value publication, and the main contract compiles with the disclosures declared. The bit-level clauses are a catalogued finding: each stateless spend leaks a handful of comparison bits. On-chain confirmation of what is actually published is W6.",
+  "note": "Compiler-forced disclosures decompose into 15 hiding-hash clause(s) (commitment/nullifier links), 2 single-bit clause(s) (has-change / sufficient-balance comparisons and the change branch), and 6 caller-return clause(s) (the kept change coin handed back through the communication commitment — deliberate, custody is client-side; not an observer surface). No clause forces raw nonce/colour/value publication to the transcript, and the main contract compiles with the disclosures declared. The bit-level clauses are a catalogued finding: each stateless spend leaks a handful of comparison bits. On-chain confirmation of what is actually published is W6.",
   "details": {
     "probes": [
       {
@@ -44,50 +44,37 @@
           "the call to standard-library circuit sendShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
           "the call to standard-library circuit sendShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the witness value",
           "the call to standard-library circuit sendShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a claim of nullifier and the coin with the nullifier given by a hash of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a claim of nullifier and the coin with the nullifier given by a hash of the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a claim of nullifier and the coin with the nullifier given by a hash of a converted form of a hash of a modulus of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a claim of nullifier and the coin with the nullifier given by a hash of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin receive and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "the call to standard-library circuit sendImmediateShielded might disclose a link between a coin spend and the coin with the commitment given by a hash of a converted form of a hash of a modulus of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-          "performing this ledger operation might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value"
+          "returning this value from exported circuit spend_change_undisclosed might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
+          "the value returned from exported circuit spend_change_undisclosed might disclose the witness value",
+          "the value returned from exported circuit spend_change_undisclosed might disclose the result of a subtraction involving the witness value",
+          "the value returned from exported circuit spend_change_undisclosed might disclose a converted form of a hash of a modulus of the witness value",
+          "the value returned from exported circuit spend_change_undisclosed might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
+          "returning this value from exported circuit spend_change_undisclosed might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value"
         ],
         "rawOutputFile": "evidence/w1-p3-change-undisclosed.compiler.txt"
       }
     ],
     "mainContractCompiled": true,
     "disclosuresByClass": {
-      "hash": 33,
-      "bit": 8,
+      "return": 6,
+      "hash": 15,
+      "bit": 2,
       "other": 0
     },
+    "returnChannelClauses": [
+      "returning this value from exported circuit spend_change_undisclosed might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
+      "the value returned from exported circuit spend_change_undisclosed might disclose the witness value",
+      "the value returned from exported circuit spend_change_undisclosed might disclose the result of a subtraction involving the witness value",
+      "the value returned from exported circuit spend_change_undisclosed might disclose a converted form of a hash of a modulus of the witness value",
+      "the value returned from exported circuit spend_change_undisclosed might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value"
+    ],
     "bitLevelClauses": [
-      "the call to standard-library circuit sendShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-      "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-      "the call to standard-library circuit sendImmediateShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value",
-      "performing this ledger operation might disclose the boolean value of the boolean value of the result of a comparison involving the result of a subtraction involving the witness value"
+      "the call to standard-library circuit sendShielded might disclose the boolean value of the result of a comparison involving the result of a subtraction involving the witness value"
     ],
     "otherClauses": [],
     "compactVersion": "0.31.1"
   },
-  "ranAt": "2026-07-03T10:20:00.984Z",
+  "ranAt": "2026-07-08T14:55:25.709Z",
   "stack": {
     "node": "midnightntwrk/midnight-node:1.0.0",
     "indexer": "midnightntwrk/indexer-standalone:4.3.3",

--- a/experiments/stateless-shielded-custody/evidence/w1-p3-change-undisclosed.compiler.txt
+++ b/experiments/stateless-shielded-custody/evidence/w1-p3-change-undisclosed.compiler.txt
@@ -1,287 +1,121 @@
 
-Exception: p3-change-undisclosed.compact line 28 char 18:
+Exception: p3-change-undisclosed.compact line 34 char 18:
   potential witness-value disclosure must be declared but is not:
     witness value potentially disclosed:
-      the return value of witness held_coin at line 14 char 1
+      the return value of witness held_coin at line 20 char 1
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a claim
       of nullifier and the coin with the nullifier given by a hash of the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       receive and the coin with the commitment given by a hash of the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       spend and the coin with the commitment given by a hash of the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       receive and the coin with the commitment given by a hash of the result of a subtraction
       involving the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       spend and the coin with the commitment given by a hash of the result of a subtraction
       involving the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose the boolean value of
       the result of a comparison involving the result of a subtraction involving the witness
       value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       receive and the coin with the commitment given by a hash of a converted form of a hash
       of a modulus of the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
     nature of the disclosure:
       the call to standard-library circuit sendShielded might disclose a link between a coin
       spend and the coin with the commitment given by a hash of a converted form of a hash of
       a modulus of the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-Exception: p3-change-undisclosed.compact line 34 char 5:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+Exception: p3-change-undisclosed.compact line 41 char 5:
   potential witness-value disclosure must be declared but is not:
     witness value potentially disclosed:
-      the return value of witness held_coin at line 14 char 1
+      the return value of witness held_coin at line 20 char 1
     nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a claim of nullifier and the coin with the nullifier given by a hash of the witness
-      value
+      returning this value from exported circuit spend_change_undisclosed might disclose the
+      boolean value of the boolean value of the result of a comparison involving the result of
+      a subtraction involving the witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose the boolean
-      value of the boolean value of the result of a comparison involving the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the conditional branch at line 33 char 3
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a claim of nullifier and the coin with the nullifier given by a hash of the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose the boolean
-      value of the result of a comparison involving the result of a subtraction involving the
-      witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose the boolean
-      value of the result of a comparison involving the result of a subtraction involving the
-      witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose the boolean
-      value of the boolean value of the result of a comparison involving the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose the boolean
-      value of the boolean value of the result of a comparison involving the result of a
-      subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a claim of nullifier and the coin with the nullifier given by a hash of a converted form
-      of a hash of a modulus of the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a claim of nullifier and the coin with the nullifier given by a hash of the boolean
-      value of the result of a comparison involving the result of a subtraction involving the
-      witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of a converted form of a
-      hash of a modulus of the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of the boolean value of
-      the result of a comparison involving the result of a subtraction involving the witness
-      value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of the boolean value of
-      the result of a comparison involving the result of a subtraction involving the witness
-      value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of a converted form of a
-      hash of a modulus of the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of the boolean value of
-      the result of a comparison involving the result of a subtraction involving the witness
-      value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of the boolean value of
-      the result of a comparison involving the result of a subtraction involving the witness
-      value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the third argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin receive and the coin with the commitment given by a hash of a converted form of a
-      hash of a modulus of the boolean value of the result of a comparison involving the
-      result of a subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-    nature of the disclosure:
-      the call to standard-library circuit sendImmediateShielded might disclose a link between
-      a coin spend and the coin with the commitment given by a hash of a converted form of a
-      hash of a modulus of the boolean value of the result of a comparison involving the
-      result of a subtraction involving the witness value
-    via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the first argument to sendImmediateShielded at line 34 char 5
-Exception: p3-change-undisclosed.compact line 36 char 56:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the conditional branch at line 40 char 3
+Exception: p3-change-undisclosed.compact line 41 char 5:
   potential witness-value disclosure must be declared but is not:
     witness value potentially disclosed:
-      the return value of witness held_coin at line 14 char 1
+      the return value of witness held_coin at line 20 char 1
     nature of the disclosure:
-      performing this ledger operation might disclose the boolean value of the boolean value
-      of the result of a comparison involving the result of a subtraction involving the
+      the value returned from exported circuit spend_change_undisclosed might disclose the
       witness value
     via this path through the program:
-      the binding of coin at line 27 char 9
-      the first argument to sendShielded at line 28 char 18
-      the binding of result at line 28 char 9
-      the conditional branch at line 33 char 3
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the argument to some at line 41 char 12
+    nature of the disclosure:
+      the value returned from exported circuit spend_change_undisclosed might disclose the
+      result of a subtraction involving the witness value
+    via this path through the program:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the argument to some at line 41 char 12
+    nature of the disclosure:
+      the value returned from exported circuit spend_change_undisclosed might disclose a
+      converted form of a hash of a modulus of the witness value
+    via this path through the program:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the argument to some at line 41 char 12
+    nature of the disclosure:
+      the value returned from exported circuit spend_change_undisclosed might disclose the
+      boolean value of the result of a comparison involving the result of a subtraction
+      involving the witness value
+    via this path through the program:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the argument to some at line 41 char 12
+Exception: p3-change-undisclosed.compact line 43 char 3:
+  potential witness-value disclosure must be declared but is not:
+    witness value potentially disclosed:
+      the return value of witness held_coin at line 20 char 1
+    nature of the disclosure:
+      returning this value from exported circuit spend_change_undisclosed might disclose the
+      boolean value of the boolean value of the result of a comparison involving the result of
+      a subtraction involving the witness value
+    via this path through the program:
+      the binding of coin at line 33 char 9
+      the first argument to sendShielded at line 34 char 18
+      the binding of result at line 34 char 9
+      the conditional branch at line 40 char 3

--- a/experiments/stateless-shielded-custody/evidence/w2-stateless-deposit.json
+++ b/experiments/stateless-shielded-custody/evidence/w2-stateless-deposit.json
@@ -3,36 +3,36 @@
   "name": "stateless-deposit",
   "description": "deposit_stateless + encrypted inbox + client-side QSCI capture",
   "verdict": "PASS",
-  "txHash": "00d77fbc79dce3d7f8e012ec0d1e357815ae39c1966868fdc478b3bfdd46e2dfe6",
+  "txHash": "0051a26e9223a42173cd753753cc86a6b0668c7a22cb23bbfe52ff8e9baab4a8b6",
   "note": "Deposit landed with no QSCI in public ledger state; the encrypted inbox blob round-trips to the exact coin; mt_index recovered from the indexer (startIndex inference).",
   "details": {
-    "mintTx": "00af18d5087e8c65db1825572041f94924edaf7ebfe92dc9331be6dacab7567c50",
-    "depositTx": "00d77fbc79dce3d7f8e012ec0d1e357815ae39c1966868fdc478b3bfdd46e2dfe6",
+    "mintTx": "00bf23648acf78dffec5a7442a2df309d0fac7a15b08d715a78e3134c78b3993e0",
+    "depositTx": "0051a26e9223a42173cd753753cc86a6b0668c7a22cb23bbfe52ff8e9baab4a8b6",
     "mtIndex": "29",
     "indexerPosition": {
       "startIndex": 29,
       "endIndex": 30,
-      "blockHeight": 112,
+      "blockHeight": 20,
       "status": "SUCCESS",
       "raw": {
-        "id": 39,
-        "hash": "52a5aeb62afd758d2de46338d27e989c2f2d1ac17db6000f511f1a180d47b831",
+        "id": 30,
+        "hash": "c1317bd6951cba7bc24ba40c11325450d1da0f60fb186d144d09b975cda2e96a",
         "startIndex": 29,
         "endIndex": 30,
         "transactionResult": {
           "status": "SUCCESS"
         },
         "block": {
-          "height": 112,
-          "hash": "882cf49899f10f5ff59e40ddb49154803b35b56f24912af15f1246107aaf07ea"
+          "height": 20,
+          "hash": "792946c7fce1d635095ba900c38b59da21cc47867027862b1b9dc629d878a556"
         }
       }
     },
-    "custodyAddress": "28f1199a78c8743372a3a1a23ed37396f33c720e1e0f6a0b6ca7b3fc1af89467",
-    "colorHex": "b7d0234687f5b44885ffb0123c3622a71920aa0df1d0e751fd6dbe5388256985",
+    "custodyAddress": "5fe2feb60784fcf7889968086988c4ce93b318e1f6f8173d33c2a72f894d91af",
+    "colorHex": "29f3ac9d0bf78f7f4b6e1c94bd1adfe60afdac07d06b27b4096e47ecd5a2ded0",
     "amount": "500"
   },
-  "ranAt": "2026-07-03T10:32:43.031Z",
+  "ranAt": "2026-07-08T14:57:48.687Z",
   "stack": {
     "node": "midnightntwrk/midnight-node:1.0.0",
     "indexer": "midnightntwrk/indexer-standalone:4.3.3",

--- a/experiments/stateless-shielded-custody/evidence/w3-witness-spend.json
+++ b/experiments/stateless-shielded-custody/evidence/w3-witness-spend.json
@@ -3,15 +3,15 @@
   "name": "witness-spend",
   "description": "node acceptance of witness-QSCI contract spends (S5 settle-it)",
   "verdict": "PASS",
-  "txHash": "0097444fac9a43ebb0e592188a0036d346437e69357601efa9456dc97316bbc5b4",
+  "txHash": "00e18429467f7e2b5576eb43f24cb7c13377b15eba3380e48329aa4a1fb4d3d33f",
   "note": "Node ACCEPTED a contract shielded spend whose QSCI came from the witness — the S5 \"structurally impossible\" reading is refuted on this stack; stateless custody is live.",
   "details": {
-    "custodyAddress": "1b3b5d00835d1c87e23647e4dd5cc12117023f2d929f5a01452cdff40cf72834",
+    "custodyAddress": "a0dfd9b1d57afea4b179ca50902f2c913209e2d5a38172f1079214f529a2db87",
     "phase1": {
-      "mintTx": "0089bc01997f587ec4441fadf1a42d078d2cc201980cc1873deba1eeb84794f791",
-      "depositTx": "007525908655e504eafac1b63bea00d01cf532ad38d78933b00dd5c46f0f010eee",
-      "mtIndex": "78",
-      "spendTx": "0097444fac9a43ebb0e592188a0036d346437e69357601efa9456dc97316bbc5b4",
+      "mintTx": "00ab01ffdd88ffa4547b558c5964e1a4c04368e8b17399d50a65144e7f4daa7527",
+      "depositTx": "007da82bff7a284cb16b28410009c2d25c321c96d4c62775023d067dfddd76419a",
+      "mtIndex": "31",
+      "spendTx": "00e18429467f7e2b5576eb43f24cb7c13377b15eba3380e48329aa4a1fb4d3d33f",
       "resultSurfaceProbes": [
         {
           "surface": "private.result",
@@ -44,8 +44,8 @@
         "outputs": [
           {
             "coinInfo": {
-              "type": "d44437de470c643c68404f913e48c8634bdd2b3d6bb929667f91cb94da1087a4",
-              "nonce": "17ca75c6301ef5218b6a9706de9d923da039511f5f65d25138a2599de222a200",
+              "type": "11081650ed91a6113d78a7a47a89a2283112b2d4e6688c75e9caf88130ef8ab4",
+              "nonce": "29137e62ed90a2041d1620ea02875a958374a78cdf4b58feadeb9b8fea014600",
               "value": "500"
             },
             "recipient": {
@@ -58,9 +58,9 @@
       }
     },
     "phase2": {
-      "mintTx": "000bec4a304c07b67077057b5415986dffac931ab212fa07f1df4ebcd9e2bc5645",
-      "depositTx": "00532a8fd036726e39c904f397d7e677200e9b41f400a372807c7047c3ce056fc7",
-      "spendTx": "000c2ae4e02a946d53222f3658e3718112db3bde18b0ffb9dcedd7ecdb607cf1f1",
+      "mintTx": "00b1780f5c52c0c733686faeb532b259299742119a62cd4b7fa7220311a0519f69",
+      "depositTx": "004c7565b2e696a6da358ded79b22ec01297820bf9a9256328d34a18ed15dedb55",
+      "spendTx": "00722f45e2f7b49e49d5b21eb16699eba899a4e96756390ef3cf7f7d2d075743cd",
       "resultSurface": "private.result",
       "resultSurfaceProbes": [
         {
@@ -94,8 +94,8 @@
         "outputs": [
           {
             "coinInfo": {
-              "type": "faac05703fff9a1f132c3f35107534756647b9e70daaee1b5dd33e53e85106ba",
-              "nonce": "159aebc6a3a73bb483b143101e9ba0dcdec5098a866ddb05308ee84189bbcd00",
+              "type": "c7a49d48f23713add112f41d699675784c0663587b712c902c1234fb1d69ea5e",
+              "nonce": "af2218d80873a2f9e982a30d46916fb7aa359cabab14e372ce8af58812757e00",
               "value": "150"
             },
             "recipient": {
@@ -106,124 +106,84 @@
           },
           {
             "coinInfo": {
-              "type": "faac05703fff9a1f132c3f35107534756647b9e70daaee1b5dd33e53e85106ba",
-              "nonce": "cc592d7f1ac50e4fe547931581ea066a4e65e60cffb6320ae010fab75067e200",
+              "type": "c7a49d48f23713add112f41d699675784c0663587b712c902c1234fb1d69ea5e",
+              "nonce": "abc726e63f7fa2876b72de85dc2df448e0424d7ef79346d2844ef510c07f1000",
               "value": "250"
             },
             "recipient": {
               "is_left": false,
               "left": "0000000000000000000000000000000000000000000000000000000000000000",
-              "right": "1b3b5d00835d1c87e23647e4dd5cc12117023f2d929f5a01452cdff40cf72834"
-            }
-          },
-          {
-            "coinInfo": {
-              "type": "faac05703fff9a1f132c3f35107534756647b9e70daaee1b5dd33e53e85106ba",
-              "nonce": "d936367b0fe032871e0ade687ba1626365a18ab3e2f5df3b7048554f0c61f800",
-              "value": "250"
-            },
-            "recipient": {
-              "is_left": false,
-              "left": "0000000000000000000000000000000000000000000000000000000000000000",
-              "right": "1b3b5d00835d1c87e23647e4dd5cc12117023f2d929f5a01452cdff40cf72834"
+              "right": "a0dfd9b1d57afea4b179ca50902f2c913209e2d5a38172f1079214f529a2db87"
             }
           }
         ]
       },
       "changeCandidates": [
-        "82",
-        "83",
-        "84"
+        "35",
+        "36"
       ],
       "spendTxPosition": {
-        "startIndex": 82,
-        "endIndex": 85,
-        "blockHeight": 536,
+        "startIndex": 35,
+        "endIndex": 37,
+        "blockHeight": 61,
         "status": "SUCCESS",
         "raw": {
-          "id": 94,
-          "hash": "064ee7395e9d58523825b2531b1de8b7ca953cbc8d2b5988ba8d26e6050f27ab",
-          "startIndex": 82,
-          "endIndex": 85,
+          "id": 38,
+          "hash": "595709934fc10100b9254d1c0af87a51fb9184508190560d299b505caac10160",
+          "startIndex": 35,
+          "endIndex": 37,
           "transactionResult": {
             "status": "SUCCESS"
           },
           "block": {
-            "height": 536,
-            "hash": "660c9e55e4868d7a02003b8a98603d091453116cfa8c8239f14ceb602bacd0ca"
+            "height": 61,
+            "hash": "d5e70eb24c4f271d3735e48e87c645702dd319eadbcfb5614e036afae209f0cd"
           }
         }
       },
       "changeSpendAttempts": [
         {
-          "mtIndex": "82",
-          "outcome": "rejected",
-          "classification": {
-            "outcome": "prover-rejected",
-            "errorCode": "prove-400",
-            "note": "The proof server rejected the witness as unsatisfiable (HTTP 400) — for spends this is the wrong-mt_index signature: the Merkle path does not match the coin commitment. No transaction was submitted."
-          },
-          "error": {
-            "name": "Error",
-            "message": "Unexpected error submitting scoped transaction '<unnamed>': Error: 'prove' returned an error: Error: Failed Proof Server response: url=\"http://127.0.0.1:6300/prove\", code=\"400\", status=\"Bad Request\"",
-            "stack": "Error: Unexpected error submitting scoped transaction '<unnamed>': Error: 'prove' returned an error: Error: Failed Proof Server response: url=\"http://127.0.0.1:6300/prove\", code=\"400\", status=\"Bad Request\"\n    at scoped (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/stateless-shielded-custody/node_modules/@midnight-ntwrk/midnight-js-contracts/src/internal/transaction.ts:266:23)\n    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at async StatelessCustody.spendStateless (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/stateless-shielded-custody/src/wallet/custody.ts:149:15)\n    at async <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/stateless-shielded-custody/src/tests/w3-witness-spend.ts:118:19)\n    at async runScenario (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/stateless-shielded-custody/src/tests/runner.ts:7:5)\n    at async <anonymous> (/Users/nicolasdiprima/work/iog/midnight/passport/arc-passport/experiments/stateless-shielded-custody/src/tests/w3-witness-spend.ts:34:1)",
-            "causeChain": [
-              {
-                "name": "Error",
-                "tag": null,
-                "message": "Unexpected error submitting scoped transaction '<unnamed>': Error: 'prove' returned an error: Error: Failed Proof Server response: url=\"http://127.0.0.1:6300/prove\", code=\"400\", status=\"Bad Request\""
-              },
-              {
-                "name": "Error",
-                "tag": null,
-                "message": "'prove' returned an error: Error: Failed Proof Server response: url=\"http://127.0.0.1:6300/prove\", code=\"400\", status=\"Bad Request\""
-              }
-            ]
-          }
-        },
-        {
-          "mtIndex": "83",
+          "mtIndex": "35",
           "outcome": "accepted",
-          "txId": "0029fd81bc85b8f7bf67e46de7cd78dd3eefbdd9822960b92289173599e83bc6ba"
+          "txId": "009639fd6336ec27fbd8a19e1f4117bcb27196471612e839a2e06f38fb7026336c"
         }
       ],
-      "changeSpendTx": "0029fd81bc85b8f7bf67e46de7cd78dd3eefbdd9822960b92289173599e83bc6ba",
-      "appendBackupTx": "0091c7eb9831363d34d21646b071e499ce1c60df78ec372721530b7dd94d749933"
+      "changeSpendTx": "009639fd6336ec27fbd8a19e1f4117bcb27196471612e839a2e06f38fb7026336c",
+      "appendBackupTx": "008253a5b007113b873300ada24408d25377e69e869392708b15ecda8ed44fb924"
     },
     "phase3": {
-      "depositTx": "00191dfd0a2a8dc122cbd5d82c7fc61464366b90ea65f430e55e19eab159b1e594",
-      "firstSpendTx": "00181bf74afbc5ea2099d7debf074fc6b4d247755ec6d6c83c06a7dc7bf3b4f447",
-      "insertCoinMtIndex": "89",
+      "depositTx": "00cc547651e10df8def36dda8f38441bc2aeaa10e981f1af520051f0bda362274e",
+      "firstSpendTx": "000a310783d8cd400beb3751bab38e7c207174d5a7705aa9a26e6f7f5d5df21d4f",
+      "insertCoinMtIndex": "40",
       "firstSpendCandidates": [
-        "88",
-        "89",
-        "90"
+        "40",
+        "41"
       ],
       "firstSpendPosition": {
-        "startIndex": 88,
-        "endIndex": 91,
-        "blockHeight": 559,
+        "startIndex": 40,
+        "endIndex": 42,
+        "blockHeight": 83,
         "status": "SUCCESS",
         "raw": {
-          "id": 99,
-          "hash": "6e1d7a46b41994da604cc6dfd70916cdd0b5e059fdf61e31e07f8a58c8b325a0",
-          "startIndex": 88,
-          "endIndex": 91,
+          "id": 43,
+          "hash": "fd5f4a0b6a4ffa5898c7401611543f0ddf60ca15b5fc0ad2d775ab9992ccf7ad",
+          "startIndex": 40,
+          "endIndex": 42,
           "transactionResult": {
             "status": "SUCCESS"
           },
           "block": {
-            "height": 559,
-            "hash": "143f90343bffd765e9844aa3cb7cf96828faecfa225e6170f6f41ed6138e43b6"
+            "height": 83,
+            "hash": "9d4e62f2c54354b92100a97d226b0d271218556de0b5b5890332d10be6783beb"
           }
         }
       },
       "mtIndexInsideWindow": true,
-      "changeSpendTx": "00bcb1213219c2cc2989a7199130840d636deacd56453444d66506fbd752ddb4ab",
+      "changeSpendTx": "0045b7c957ef43cb9892439a7103796db6b593d81c95f041a9c5d982998d735b13",
       "changeSpendOutcome": "accepted"
     }
   },
-  "ranAt": "2026-07-03T11:17:38.865Z",
+  "ranAt": "2026-07-08T15:04:14.717Z",
   "stack": {
     "node": "midnightntwrk/midnight-node:1.0.0",
     "indexer": "midnightntwrk/indexer-standalone:4.3.3",

--- a/experiments/stateless-shielded-custody/evidence/w5-third-party-deposit.json
+++ b/experiments/stateless-shielded-custody/evidence/w5-third-party-deposit.json
@@ -3,15 +3,15 @@
   "name": "third-party-deposit",
   "description": "third-party deposit via advertised key + owner discovery from chain data",
   "verdict": "PARTIAL",
-  "txHash": "00f51d4244acd8375eefd023e057eea9cb3a23d7d3c736a74fab0cb1bf7aaca2c6",
+  "txHash": "00cbf033a557c0413a718d16e2e89d8284cae104809001ca2886f58c3cfc833ed6",
   "note": "Deposit, decrypt, and spend all worked, but the contract-address → tx indexer lookup is missing — the discovery loop needs an indexer surface or block scan (C17 sync finding). See details.contractTxLookup.",
   "details": {
-    "custodyAddress": "1d24abfcb7b02e91c1bdc021899fa4694058170997e0ec0125cb02ad707e7193",
-    "mintTx": "008aded4bf27848c24e55bc6dfeea4af649c76ec4dcbff5190497e5dc7f58d5cae",
-    "advertisedKeyHex": "d140d328938a47a715977143a4acd225ccddbdf4b84bc39456b714dd3128e028",
-    "depositTx": "006ef6582ff356a17ea26a7d9b00306ceb856e8f39a545b02f178bd9cc0e8c06cb",
+    "custodyAddress": "78fafde3fb2e7abc05ca9a85960233b722a834418e3ad68987a09073366080f1",
+    "mintTx": "00f85d9e8ea05e8a2d7a00fabf9e3a5cf531ba62f23b03dc40d299cd22bf2beb2a",
+    "advertisedKeyHex": "d176f726bd7f314a86b5cca7b85b53c95a3b23befe9ea508a3675e5f18d9fb47",
+    "depositTx": "0029ed82438fdd88e79ec1f765bf7b06b3e385957d4009450e21b7276169a4f654",
     "discoveredCoin": {
-      "colorHex": "215d850d9a9dc379c0b01451143b6cb94ef2bd858a125b13a08ff0b39ef4eb99",
+      "colorHex": "c232f5d73ae22de5722e251f3c4d67e31650bb089283587d0a612dbe6de16ede",
       "value": "350",
       "matches": true
     },
@@ -26,22 +26,22 @@
       {
         "source": "fallback: depositor-supplied txId",
         "candidates": [
-          "65"
+          "44"
         ]
       }
     ],
     "spendAttempts": [
       {
         "source": "fallback: depositor-supplied txId",
-        "mtIndex": "65",
+        "mtIndex": "44",
         "outcome": "accepted",
-        "txId": "00f51d4244acd8375eefd023e057eea9cb3a23d7d3c736a74fab0cb1bf7aaca2c6"
+        "txId": "00cbf033a557c0413a718d16e2e89d8284cae104809001ca2886f58c3cfc833ed6"
       }
     ],
-    "mtIndexSource": "fallback: depositor-supplied txId @ index 65",
-    "spendTx": "00f51d4244acd8375eefd023e057eea9cb3a23d7d3c736a74fab0cb1bf7aaca2c6"
+    "mtIndexSource": "fallback: depositor-supplied txId @ index 44",
+    "spendTx": "00cbf033a557c0413a718d16e2e89d8284cae104809001ca2886f58c3cfc833ed6"
   },
-  "ranAt": "2026-07-03T11:00:38.835Z",
+  "ranAt": "2026-07-08T15:07:38.052Z",
   "stack": {
     "node": "midnightntwrk/midnight-node:1.0.0",
     "indexer": "midnightntwrk/indexer-standalone:4.3.3",

--- a/experiments/stateless-shielded-custody/evidence/w6-leak-audit.json
+++ b/experiments/stateless-shielded-custody/evidence/w6-leak-audit.json
@@ -5,27 +5,27 @@
   "verdict": "PASS",
   "note": "The insertCoin control leaks its coin (nonce/colour) into the raw transaction and the indexer per-call state (positive control confirms the scanner); the stateless path shows NO coin artefact on any observer surface scanned. The QSCI-publicity leak is a storage-pattern consequence, not a ledger inevitability.",
   "details": {
-    "custodyAddress": "f56c7249331c7911e9aad0a061fd220167f6d33cf3d765fd2f4d1eab1716ec48",
+    "custodyAddress": "ffd140929d61ea2982a9db18663e5b02026db327246573a1f51af79de26db7e7",
     "contractStateBytes": 21,
     "txFetchProbes": {
       "controlDeposit": [
-        "raw: ok (37370 chars)",
-        "contractActions: ok (21710 chars)",
-        "identifiers: GraphQL error \"Unknown field \\\"identifiers\\\" on type \\\"Transaction\\\".\""
-      ],
-      "controlSpend": [
-        "raw: ok (68952 chars)",
+        "raw: ok (37376 chars)",
         "contractActions: ok (21702 chars)",
         "identifiers: GraphQL error \"Unknown field \\\"identifiers\\\" on type \\\"Transaction\\\".\""
       ],
+      "controlSpend": [
+        "raw: ok (48710 chars)",
+        "contractActions: ok (21694 chars)",
+        "identifiers: GraphQL error \"Unknown field \\\"identifiers\\\" on type \\\"Transaction\\\".\""
+      ],
       "statelessDeposit": [
-        "raw: ok (37284 chars)",
-        "contractActions: ok (22544 chars)",
+        "raw: ok (37290 chars)",
+        "contractActions: ok (22536 chars)",
         "identifiers: GraphQL error \"Unknown field \\\"identifiers\\\" on type \\\"Transaction\\\".\""
       ],
       "statelessSpend": [
-        "raw: ok (68074 chars)",
-        "contractActions: ok (22544 chars)",
+        "raw: ok (47790 chars)",
+        "contractActions: ok (22536 chars)",
         "identifiers: GraphQL error \"Unknown field \\\"identifiers\\\" on type \\\"Transaction\\\".\""
       ]
     },
@@ -146,15 +146,15 @@
     "needles": {
       "control": {
         "label": "control",
-        "nonceHex": "007d7ed4d3db2000c6fedc01b0bd99e1383377ebb94e2e7f1bd961796690e434",
-        "colorHex": "e8ff33fcad741e40804f4c636029d3baf13a6b872529947219cf84ea45207499",
+        "nonceHex": "70bbdd04dd2d8459452a786a12d0fcfbc18ac1f0913077d29ccab959d64a60cd",
+        "colorHex": "7595c3e644ff8f423533a980137ef455e76528e8a1fadd90d97c88ca70b5546a",
         "valueHexBE": "00000000000000000000000000000258",
         "valueHexLE": "58020000000000000000000000000000"
       },
       "stateless": {
         "label": "stateless",
-        "nonceHex": "f9c905c500ff952821eb8ac7bbb1495e30b4b0dcafdf2d738a3edafc801c2e2e",
-        "colorHex": "cf4d4481b5eccf08b99328bed243eab00da0ea5efd477c36ee1e58e21881a373",
+        "nonceHex": "fca29dcb5790a3fccb5929ce0ccb852b571ac82d765d1d7a7e8e88d187375c35",
+        "colorHex": "f9931bcca2ea5344ca9f421960332ad5bc08f42bf2f17c4fd3876a52ec2c3068",
         "valueHexBE": "00000000000000000000000000000258",
         "valueHexLE": "58020000000000000000000000000000"
       }
@@ -162,7 +162,7 @@
     "controlLeaksInState": true,
     "statelessHits": []
   },
-  "ranAt": "2026-07-03T11:04:48.341Z",
+  "ranAt": "2026-07-08T15:11:36.872Z",
   "stack": {
     "node": "midnightntwrk/midnight-node:1.0.0",
     "indexer": "midnightntwrk/indexer-standalone:4.3.3",

--- a/experiments/stateless-shielded-custody/src/tests/w1-compile-disclosure.ts
+++ b/experiments/stateless-shielded-custody/src/tests/w1-compile-disclosure.ts
@@ -63,15 +63,23 @@ function extractNatures(output: string): string[] {
   return natures;
 }
 
-// Classify each disclosure clause by what the compiler says is published:
+// Classify each disclosure clause by what the compiler says is disclosed,
+// and through which channel:
+//   return — a circuit return value ("the value returned from …" /
+//     "returning this value from …"): caller-visible through the
+//     communication commitment, not an observer surface. The design hands
+//     the change coin back to the caller on purpose (custody is
+//     client-side), so these clauses are expected on the change path; W6
+//     settles that nothing coin-shaped lands on observer surfaces.
 //   hash — a commitment/nullifier link ("… given by a hash of the witness
 //     value"): hiding, the design's assumption.
 //   bit — a boolean ("the boolean value of … a comparison involving …"):
 //     1-bit facts such as has-change / sufficient-balance, plus the change
 //     conditional branch. Real but bounded leakage; catalogued as a finding.
-//   other — anything else, which would include raw-field publication and
-//     fails the probe.
-function classifyNature(nature: string): 'hash' | 'bit' | 'other' {
+//   other — anything else, which would include raw-field publication to the
+//     transcript and fails the probe.
+function classifyNature(nature: string): 'return' | 'hash' | 'bit' | 'other' {
+  if (/value returned from|returning this value from/.test(nature)) return 'return';
   if (/hash of|commitment|nullifier/.test(nature)) return 'hash';
   if (/boolean value|conditional|branch/.test(nature)) return 'bit';
   return 'other';
@@ -106,7 +114,7 @@ console.log(`   exit=${main.code}`);
 
 const allRejected = results.every((r) => r.rejected);
 const allNatures = results.flatMap((r) => r.disclosureNatures);
-const byClass = { hash: [] as string[], bit: [] as string[], other: [] as string[] };
+const byClass = { return: [] as string[], hash: [] as string[], bit: [] as string[], other: [] as string[] };
 for (const n of allNatures) byClass[classifyNature(n)].push(n);
 
 const verdict = allRejected && mainCompiled && byClass.other.length === 0 ? 'PASS' : 'FAIL';
@@ -120,16 +128,20 @@ writeEvidence({
   note:
     verdict === 'PASS'
       ? `Compiler-forced disclosures decompose into ${byClass.hash.length} hiding-hash clause(s) ` +
-        `(commitment/nullifier links) and ${byClass.bit.length} single-bit clause(s) (has-change / ` +
-        'sufficient-balance comparisons and the change branch). No clause forces raw ' +
-        'nonce/colour/value publication, and the main contract compiles with the disclosures ' +
-        'declared. The bit-level clauses are a catalogued finding: each stateless spend leaks ' +
-        'a handful of comparison bits. On-chain confirmation of what is actually published is W6.'
+        `(commitment/nullifier links), ${byClass.bit.length} single-bit clause(s) (has-change / ` +
+        `sufficient-balance comparisons and the change branch), and ${byClass.return.length} ` +
+        'caller-return clause(s) (the kept change coin handed back through the communication ' +
+        'commitment — deliberate, custody is client-side; not an observer surface). No clause ' +
+        'forces raw nonce/colour/value publication to the transcript, and the main contract ' +
+        'compiles with the disclosures declared. The bit-level clauses are a catalogued finding: ' +
+        'each stateless spend leaks a handful of comparison bits. On-chain confirmation of what ' +
+        'is actually published is W6.'
       : 'Unexpected disclosure shape or compile outcome — read details and the .compiler.txt files.',
   details: {
     probes: results,
     mainContractCompiled: mainCompiled,
-    disclosuresByClass: { hash: byClass.hash.length, bit: byClass.bit.length, other: byClass.other.length },
+    disclosuresByClass: { return: byClass.return.length, hash: byClass.hash.length, bit: byClass.bit.length, other: byClass.other.length },
+    returnChannelClauses: [...new Set(byClass.return)],
     bitLevelClauses: [...new Set(byClass.bit)],
     otherClauses: byClass.other,
     compactVersion: spawnSync('compact', ['compile', '--version'], { encoding: 'utf-8' }).stdout?.trim(),

--- a/experiments/stateless-shielded-custody/src/tests/w3-witness-spend.ts
+++ b/experiments/stateless-shielded-custody/src/tests/w3-witness-spend.ts
@@ -10,9 +10,9 @@
 //
 //   Phase 1 — full-amount spend (no change): deposit 500, spend 500 to the
 //     user. Node accept ⇒ witness-QSCI custody is REAL on this node tag.
-//   Phase 2 — change chain: deposit 400, spend 150 (change 250 re-owned to
-//     the contract in-tx, returned to the caller through the private call
-//     result), re-capture the change (candidate mt_index retry over the
+//   Phase 2 — change chain: deposit 400, spend 150 (change 250 routed back
+//     to the contract by sendShielded itself, returned to the caller through
+//     the private call result), re-capture the change (candidate mt_index retry over the
 //     2-commitment spend tx), spend the change. Proves custody SURVIVES
 //     spends without ever touching public state. Change blob appended to
 //     the inbox afterwards (append_backup) to keep the recovery channel
@@ -146,8 +146,8 @@ await runScenario('w3-witness-spend', async () => {
 
   // ── Phase 3 — control comparator for the change chain ────────────────────
   // Discriminates whether a phase-2 failure is stateless-specific or a
-  // generic wall for spending a sendImmediateShielded-created change coin:
-  // the S6/insertCoin lifecycle verified the change's MAP entry but never
+  // generic wall for spending a sendShielded-created change coin: the
+  // S6/insertCoin lifecycle verified the change's MAP entry but never
   // SPENT the change. Run the identical chain through the public path.
   step('phase 3 (control): deposit_public 400, spend 150, then spend the 250 change');
   const phase3: Record<string, unknown> = {};


### PR DESCRIPTION
## What this is

The first building block of the account custody standard: a MIP draft
specifying **how a Compact contract custodies values and assets** (Night
and shielded Zswap coins), and nothing else. Authorisation is abstracted
to a single seam; key management, device lifecycle, grants, and recovery
are companion building blocks that will follow separately. Small pieces,
independently reviewable, each backed by evidence we already hold.

MPS-0018 (our asset-custody problem statement, now upstream) recommends
a multi-key account contract MIP as "the keystone the others hang from".
This PR delivers the custody half of that keystone. The split is
deliberate: the custody surface is settled by ledger mechanics and
validated experimentally, while the authorisation surface is still an
active upstream conversation (in-circuit address ownership in the
token-standards thread, a proposed stdlib caller-identity primitive,
threshold and MPC constraints). Binding the settled part to the
unsettled part would hold both hostage.

## What the draft specifies

- **Unshielded custody, color-generic**: Night is treated as one
  unshielded color among many (it is the ledger's all-zero color, and
  contracts can mint further unshielded colors); permissionless deposit
  with an explicit per-color balance mirror (lower-bound semantics),
  authorised withdrawal to user addresses.
- **Stateless shielded custody**: a held coin's description never enters
  public ledger state. Deposits pair the protocol coin claim with an
  encrypted inbox entry addressed to an on-ledger account encryption
  key; spends supply the coin description as a private witness from a
  wallet-local coin store. Observers learn that the contract acted,
  never the amounts, token types, balances, or conforming
  counterparties.
- **The change rule (normative)**: the coin recorded as held after a
  partial spend must be the one that survives the transaction.
  `sendShielded` already routes change back to the contract as a live,
  self-owned output, so the baseline realisation persists the send
  result's change directly; routing change onward in the same
  transaction via `sendImmediateShielded` is admitted, in which case
  that call's `.sent` coin is the survivor. The stranded-change defect
  we reported upstream (library code persisted a coin whose nullifier
  the same transaction had burnt) has been resolved by removing the
  redundant re-send; the rule is stated at the surviving-coin level so
  both realisations conform.
- **The authorisation seam**: fixed observable semantics (call-bound
  proof, abort on failure, round monotonicity, no wallet-supplied
  identity such as `ownPublicKey()`), with the credential scheme left to
  the account standard.
- Eight invariants and a conformance test suite that must run against a
  real node, including a byte-level observer leak audit with a positive
  control.

## Evidence base

- #89 validated the stateless shielded pattern end to end on a
  production node (W1 to W6), including the leak audit and the change
  defect reproduction. The draft's Rationale R3/R4 tables come from
  there.
- After the upstream change-handling fix merged
  (OpenZeppelin/compact-contracts#661), the #89 experiment was updated
  to the baseline realisation and the full suite re-ran green on a
  fresh localnet, including cross-transaction spends of retained change
  through both custody patterns: the evidence the upstream simulator
  regression tests cannot produce. This PR carries that update.
- The account-custody prototype (#82) validated the Night surface and a
  working seam instantiation.
- The evidence is experiment-grade, not yet peer-reviewed; cryptographer
  review is an explicit acceptance criterion in Path to Active.

## Upstream refresh (done before drafting)

The MIP corpus, discussions, and open PRs were re-swept before writing:

- The MPS-0018 keystone slot is unclaimed; no open upstream PR collides
  with this draft.
- MIP-0011 (native shielded token, merged upstream) is complementary:
  issuance, not custody. The draft adopts its spend-path discipline and
  caller-authentication prohibition; its change-handling wording matches
  the baseline realisation, so no clarifying note is needed.
- MPS-0027 (domain separation) is upstream with a number, so the draft
  registers its one tag against that registry.
- The institutional custody problem statements (MPS-0016/0024/0025) can
  reuse this asset surface under their own authorisation regimes; the
  draft says so in R6.

## Also in this PR

- The stateless custody experiment updated to the upstream-simplified
  change handling (both spend paths hold the send result's change
  directly; disclosure probe and classifier recast around the new
  pattern) with regenerated evidence and findings from the localnet
  re-run.
- `docs/mps-mip/README.md`: the building-block decomposition and the
  submission process.
- Canonical-upstream banners on the two local MPS copies (MPS-0018,
  MPS-0027). The MPS-0027 divergence between our copy and the upstream
  numbered file was flagged by an external contributor; the banners
  settle which copy governs.

## Out of scope, on purpose

Credential schemes, device sets, revocation epochs, scoped grants,
recovery mechanisms, Dust and fees, token issuance, and name discovery.
Each has its own home; the draft lists them explicitly and specifies
only the seam they attach to.
