### PR TITLE
Sdk spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+
+# Local, not shared
+.midnight-expert/

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -1,9 +1,11 @@
 # Midnight Passport SDK — Architecture Approaches (Draft)
 
 > **Status:** draft · 2026/07/20
-> **Companion to:** [`sdk-requirements.md`](./sdk-requirements.md). Requirement
-> references (§) point there; component references (`[C…]`) and promises
-> (`[P…]`) point to [`../../docs/plans`](../../docs/plans).
+> **Companion to:** [`sdk-requirements.md`](./sdk-requirements.md) (the
+> *what/why*) and [`development-workflow.md`](./development-workflow.md)
+> (how we build it). Requirement references (§) point to the requirements
+> doc; component references (`[C…]`) and promises (`[P…]`) point to
+> [`../../docs/plans`](../../docs/plans).
 > **Purpose:** lay out candidate architectures for the SDK, recommend one,
 > and map every requirement onto it. Decisions still open are marked
 > **[open]** with a stated lean.

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -1,0 +1,460 @@
+# Midnight Passport SDK — Architecture Approaches (Draft)
+
+> **Status:** draft · 2026/07/20
+> **Companion to:** [`sdk-requirements.md`](./sdk-requirements.md). Requirement
+> references (§) point there; component references (`[C…]`) and promises
+> (`[P…]`) point to [`../../docs/plans`](../../docs/plans).
+> **Purpose:** lay out candidate architectures for the SDK, recommend one,
+> and map every requirement onto it. Decisions still open are marked
+> **[open]** with a stated lean.
+
+## 1. Framing — one core, three faces
+
+The SDK is not one API. It presents **three consumer faces** over a single
+ACC-centric core:
+
+| Face | Consumer | Package |
+|---|---|---|
+| **Wallet** | Official UI (MNF), CLI | `@midnight-ntwrk/mn-passport-core` + adapters |
+| **Agent** | AI agents (OWS) | agent adapter (§3.8) |
+| **dApp** | Partner dApps | `@midnight-ntwrk/mn-passport-connect` (thin, §3.9) |
+
+The through-line that keeps them coherent: **scoped grants
+([C10]/[C11]/[C12]) are the universal authorisation currency.** Devices,
+agents, and dApps are all principals holding scoped grants on the ACC; they
+differ only in how a grant is *issued and gated* — device by passkey
+ceremony (§2.2), agent by OWS policy engine (§3.8), dApp by user consent
+plus ceremony (§3.9). One primitive, three issuance paths. The ACC ([C1]) is
+the seat of identity; everything else is a mediated interaction with it.
+
+## 2. Reference stack
+
+Every candidate shares this layering; they differ only in how the core
+(shaded) is built.
+
+```mermaid
+flowchart TB
+  UI["Official UI (MNF)"] --> FLOWS
+  CLI["CLI / scripts"] --> FLOWS
+  AGENT["AI agent"] --> CONNECT
+  DAPP["Partner dApp"] --> CONNECT["@midnight-ntwrk/mn-passport-connect — thin, C23"]
+
+  subgraph CORE["@midnight-ntwrk/mn-passport-core — kernel + surface"]
+    FLOWS["Flow surfaces: onboard, connect, devices, grants, recover, assets, agents"] --> CMD["Command + state surface"]
+    CMD --> KERNEL["Kernel: ACC session, ceremony gate, witness lifecycle, grant registry"]
+    KERNEL --> SEAMS["Seams: signer, prover-router, storage/sync, indexer, recovery, DID, agent/OWS, dApp-connection"]
+  end
+
+  CONNECT -. "C23 protocol" .-> KERNEL
+  SEAMS --> ADAPT["Platform adapters: browser, node"]
+  ADAPT --> EXT["External: wallet-infra provider, attested TEE prover, vendor keystore, indexer"]
+  KERNEL --> CHAIN["Midnight chain / ACC"]
+```
+
+## 3. The three approaches
+
+Three ingredients are settled by the requirements, not in question:
+**(i)** typed, multi-package packaging with a clean wallet/dApp split;
+**(ii)** a kernel secret-boundary (one place touches decrypted secrets);
+**(iii)** a reactive state model so consumers can't recreate the
+prototype's state mess. The approaches differ only in **how many of these
+you adopt at v1** — an ambition ladder, not rival designs.
+
+### Approach 1 — Thin typed wrappers
+Typed ACC bindings + an `Account` facade + injected providers. No kernel,
+no reactive surface; the consumer wires everything. Essentially the
+prototype, cleaned and typed.
+*Buys:* kills the `any`-typing and browser/node duplication.
+*Leaves unsolved:* secret containment and state discipline — the two
+deeper prototype failures. **Reject as target** (it is, however, migration
+step 0).
+
+### Approach 2 — Layered core + provider adapters *(recommended v1)*
+Typed `Account` facade (imperative methods) + provider **seams** as adapter
+packages + a **minimal kernel boundary**: only the kernel decrypts secrets
+and enforces the ceremony. Reads are observable; writes are imperative (no
+full command bus yet).
+*Buys:* the critical security boundary, substitutable providers ([P8]),
+clean packaging — buildable for the October target.
+*Cost:* less state-flow discipline than Approach 3; disciplined by
+convention until the command bus lands.
+
+### Approach 3 — Kernel + adapters + reactive command bus *(target end-state)*
+Every seam has an **adapter** registered with the kernel; every mutation
+is a **command** through one pipeline (authorise → build → prove → submit →
+confirm), reactive state as the primary API. An adapter holding only a
+grant handle *structurally* cannot device-authorise.
+*Buys:* strongest secret containment (bounded blast radius per adapter)
+and state discipline; the natural home for agent access (§3.8) as an
+untrusted adapter.
+*Cost:* most upfront design; over-built if adapters stay few.
+
+### Recommendation
+**Build Approach 2 for v1, with the kernel boundary and seam interfaces
+already shaped like Approach 3 — so 3 is an evolution, not a rewrite.**
+Concretely: ship imperative flows over a real kernel secret-boundary and
+adapter-packaged providers now; promote seams to registered adapters
+and writes to a command bus as the agent and multi-consumer load justify
+it. Approach 1 is rejected as a destination because it fixes only the
+shallowest of the prototype's three failures.
+
+## 4. The recommended shape in detail
+
+### 4.1 Kernel (the trusted core — keep it small)
+The only code that ever holds decrypted secrets. Owns:
+- the **ACC session** and typed contract bindings;
+- the **witness / secret lifecycle** — decrypt under ceremony, expose an
+  *ephemeral handle* to build/prove, best-effort zeroise after ([C7]);
+- the **ceremony gate** (§2.2) — passkey PRF or password KDF;
+- the **private-state envelope** — seal/open, keyed independently of any
+  sync channel (§3.6);
+- the **grant registry** — which principals may act, at what scope.
+
+Invariant: secrets leave the kernel only as (a) an in-circuit witness to a
+local prover, (b) an attested preimage to a TEE prover, or (c) ciphertext
+to storage/sync. Never in plaintext to an adapter, a dApp, or an agent.
+
+### 4.2 Seams (adapters in the full model)
+Each is an interface with 2–3 interchangeable adapters; the provider-free
+default is always present (§2.1, [P8]):
+
+| Seam | Adapters | Req |
+|---|---|---|
+| Signer / custody | managed anchor · local in-circuit Jubjub · interim hash-preimage | §2.1, §2.3 |
+| Prover (router) | in-tab wasm · attested-TEE remote · provider-routed | §2.5 |
+| Storage / sync | vendor keystore (native) · shared provider #58 · local-only | §3.6 |
+| Indexer / view-key | hosted · self-hosted | §3.6 |
+| Recovery | guardians + paper key | §3.4 |
+| DID | `did:midnight` | §3.7 |
+| Agent / OWS | OWS policy engine + credential | §3.8 |
+| dApp-connection | C23 wallet side | §3.2 |
+| External wallet connect (client) | EIP-6963/1193 · Solana Wallet Standard · CIP-30 · Midnight connector | §3.10 |
+
+### 4.3 Command + state surface
+- **Reads:** an observable projection of ACC state + session (devices,
+  grants, balances, names), rebuilt from indexer + local storage — the
+  source of truth, replacing the prototype's per-render `ctx` bag and
+  module singletons.
+- **Writes:** commands through one pipeline, emitting an event per stage
+  (proof provenance, §2.5, is a first-class event here). Instance-scoped
+  and disposable — multi-account, no globals.
+
+### 4.4 Packaging
+
+Dependency rule: everything points **inward** to `@midnight-ntwrk/mn-passport-core`'s
+interfaces; nothing points outward. `@midnight-ntwrk/mn-passport-connect` links neither the
+core nor any adapter — only shared protocol types — so a dApp can never
+pull the kernel into its bundle.
+
+**Foundation**
+
+- **`@midnight-ntwrk/mn-passport-protocol`** — the shared wire types and the C23 connection
+  protocol (EIP-6963 discovery, CAIP-25-shaped requests,
+  Sign-In-with-Passport messages). Deliberately dependency-light so *both*
+  the wallet side and the thin dApp connector share it without either
+  pulling in the other. No logic — just contracts.
+- **`@midnight-ntwrk/mn-passport-contract`** — typed bindings and the exported pure
+  commitment circuits over the **externally-owned, versioned ACC artefact**
+  (§8.2). Wraps the contract team's published build (compiled module, ZK
+  asset manifest, generated types) and owns the connect-time version guard
+  (the compatibility contract). The SDK never owns or compiles the
+  contract.
+
+**Core**
+
+- **`@midnight-ntwrk/mn-passport-core`** — the platform-neutral heart. Contains the **kernel**
+  (ACC session, ceremony gate, witness / secret lifecycle, private-state
+  envelope, grant registry), the **command + state surface**, the **flow
+  surfaces** (onboard, connect, devices, grants, recover, assets, agents),
+  and the **seam interfaces** (signer, prover, storage/sync, indexer,
+  recovery, DID, agent, dApp-connection). Holds **no** platform code (`fs`,
+  `window`, `fetch`) and **no** concrete provider — only interfaces; this is
+  what keeps it portable and unit-testable. Depends on `@midnight-ntwrk/mn-passport-contract`
+  and `@midnight-ntwrk/mn-passport-protocol`.
+
+**Platform adapters** — dedupe the prototype's `providers.ts` ≈
+`node/wallet.ts` split into one core plus two thin wirings.
+
+- **`@midnight-ntwrk/mn-passport-adapter-browser`** — wires the seams to browser APIs:
+  `FetchZkConfigProvider` (ZK assets over HTTP), WebAuthn **PRF passkeys**
+  for the ceremony, the in-tab wasm prover (Web Worker), browser storage /
+  vendor keystore, `fetch` and `WebSocket`. The default target — Passport
+  is browser-first. Consumed by the Official UI (MNF) and web dApps
+  embedding the wallet.
+- **`@midnight-ntwrk/mn-passport-adapter-node`** — wires the same seams to Node.js so the SDK
+  runs **server-side**: filesystem ZK-asset loading (`NodeZkConfigProvider`),
+  disk-backed private state (LevelDB), the `ws` WebSocket, Node crypto, and
+  a **non-WebAuthn ceremony / signer** (WebAuthn is browser-only, so on Node
+  the presence factor is a file / env or hardware key, or — for an agent —
+  a policy-gated credential rather than a passkey). Consumers: the **CLI**,
+  automated / E2E tests, backend services, and **agent runtimes** (an OWS
+  agent or MCP server runs in a Node process and cannot perform a passkey
+  ceremony, which is why the agent path is policy-gated, §3.8). This is the
+  package that makes the CLI and agent faces possible.
+
+**Seam adapters** — `@midnight-ntwrk/mn-passport-adapter-*`, each implementing one core seam
+interface and depending only on that interface plus its own provider SDK;
+the provider-free default always ships.
+
+- **`adapter-signer-managed`** — managed custody (§2.1, §2.6): the wallet-infra
+  provider (embedded WaaS or extension) authenticates the user and gates the
+  ACC device secret via a `signMessage` presence gesture; ACC calls run via
+  midnight-js. The provider is the auth / presence layer, not the
+  contract-call signer. v1 target: the §2.3 cryptographic binding.
+- **`adapter-signer-local`** — decentralised custody: the PRF-derived Jubjub
+  device key verified in-circuit, plus the interim hash-preimage signer
+  behind the same interface until Schnorr lands (§2.3).
+- **`adapter-prover-wasm`** — the in-tab wasm prover (lifted from the prototype
+  worker) for small-k circuits (§2.5).
+- **`adapter-prover-remote`** — the remote-proving client: provider-routed and
+  attested-TEE paths, verifying remote attestation **before** sending any
+  preimage (§2.5).
+- **`adapter-storage-vendor`** — native vendor-keystore sync adapter (§3.6).
+- **`adapter-storage-shared`** — the shared private-storage provider (#58)
+  adapter; also the source for dApp witness provisioning (§3.9).
+- **`adapter-recovery`** — guardian + paper-key total-loss recovery
+  (§3.4, [C14]/[C15]).
+- **`adapter-did`** — `did:midnight` create / resolve (§3.7).
+- **`adapter-agent-ows`** — the OWS-compatible `ChainSigner` / policy surface
+  over the grant primitive (§3.8).
+- **`adapter-dapp-connection`** — the wallet side of C23: answers discovery,
+  Sign-In-with-Passport, and scoped-grant requests (§3.2).
+- **`adapter-wallet-connect`** — the wallet-connector **client**: Passport
+  connecting *out* to external wallets (Lace, 1am, Gero, MetaMask, Rabby,
+  Phantom), one adapter per standard (§3.10). The opposite direction to
+  `adapter-dapp-connection`; foreign-curve wallets attach via the §2.3 binding.
+
+**dApp side**
+
+- **`@midnight-ntwrk/mn-passport-connect`** — the **thin** connector a third-party developer
+  installs (§3.9). Implements the dApp end of C23 over `@midnight-ntwrk/mn-passport-protocol`:
+  Sign-In-with-Passport, scoped-grant requests, and requesting
+  Passport-provisioned witnesses. Minimal footprint, own threat model;
+  talks C23 *to* the wallet across a trust boundary and **must not link
+  `@midnight-ntwrk/mn-passport-core`** or any adapter.
+
+```mermaid
+flowchart LR
+  PROTO["@midnight-ntwrk/mn-passport-protocol"]
+  CONTRACT["@midnight-ntwrk/mn-passport-contract"]
+  CORE["@midnight-ntwrk/mn-passport-core"]
+  CAPS["@midnight-ntwrk/mn-passport-adapter-*"]
+  BROW["@midnight-ntwrk/mn-passport-adapter-browser"]
+  NODE["@midnight-ntwrk/mn-passport-adapter-node"]
+  CONNECT["@midnight-ntwrk/mn-passport-connect"]
+
+  CORE --> CONTRACT
+  CORE --> PROTO
+  CAPS --> CORE
+  BROW --> CORE
+  BROW --> CAPS
+  NODE --> CORE
+  NODE --> CAPS
+  CONNECT --> PROTO
+```
+*Arrows read "depends on". `@midnight-ntwrk/mn-passport-connect` reaches only
+`@midnight-ntwrk/mn-passport-protocol` — never the core or an adapter.*
+
+### 4.5 Private storage and backup
+
+The mobile-web constraints (§8.5) force this model; resolve it in three
+moves.
+
+**1. Classify state by what it takes to get it back on a new device.**
+
+| Tier | Examples | On a new device |
+|---|---|---|
+| **Regenerable** | device key (passkey PRF), chain-visible state (view-key + indexer) | Re-derived / re-synced — no stored copy needed |
+| **Irreplaceable** | genuinely user-supplied private inputs / dApp witness data | **Cannot be regenerated — recoverable *only* from a durable backup. The data the storage system exists to protect.** |
+| **Recovery material** | recovery secret / shares | Preserved and restored by the recovery protocol ([C14]/[C15], guardians) — not the private-state backup |
+| **Cache / metadata** | name, ACC address, grant refs, sync cursor | Rebuilt from chain |
+
+The **irreplaceable** tier is the crown jewels: neither on-chain nor
+re-derivable, so if the local store is evicted *before* a durable backup
+exists it is gone permanently — potentially locking the user out of their
+private state. Its backup is the **critical path**, not a footnote. Two
+levers keep it small and safe:
+
+- **Shrink it by derivation.** Every secret that *can* be derived from the
+  passkey-PRF root under a domain-separated salt (as the device key already
+  is) should be — moving it into the *regenerable* tier, where it needs no
+  backup. Only truly user-supplied data stays irreplaceable.
+- **Preserve recovery material via the recovery protocol** ([C14]/[C15]),
+  not local backup — guardians / paper key are its durability story.
+
+**2. Local store — IndexedDB, ciphertext only.** IndexedDB is the durable
+local substrate on every mobile engine (OPFS for large *non-secret* assets
+such as staged ZK params). It holds only **ciphertext**: each entry is
+`{version, nonce, ciphertext}`, keyed per account / context. A per-entry
+data key is wrapped by a **ceremony-derived** key (passkey PRF, or password
+KDF); plaintext and the wrapping key materialise only transiently inside
+the kernel after a §2.2 ceremony. So device theft or an IndexedDB read
+(XSS, extracted backup) yields ciphertext only — and the wrapping key MUST
+be independent of any channel the backup also uses (the §3.6 lock-and-key
+rule: passkey PRF that syncs to the same vendor cloud as the ciphertext
+hands the vendor lock and key together).
+
+**3. Backup — mandatory and redundant for the irreplaceable tier.**
+IndexedDB is an evictable cache that mobile browsers do not replicate across
+devices (§8.5), so the irreplaceable tier MUST have a durable backup, and
+the SDK should treat *a confirmed durable backup exists* as a precondition
+before the user accrues irreplaceable state. Redundant paths over the
+Storage/sync seam:
+
+- **Portable (web + cross-ecosystem):** the shared private-storage provider
+  (#58) holds the ciphertext copy — the durable source of truth; the
+  provider sees ciphertext only.
+- **Native:** vendor keystore (§3.6) as the on-platform fast path.
+- **User-held:** an exported encrypted backup / recovery phrase.
+- Regenerable and cache/metadata tiers are never backed up — re-derived
+  from the passkey PRF and rebuilt from the indexer.
+
+On a recovery epoch bump ([C14]), rotate the data keys, re-seal, and
+re-upload. **Net properties:** for regenerable and metadata state, eviction
+≠ loss; for the irreplaceable tier, eviction ≠ loss **only if a durable
+backup exists** — which is why its backup is mandatory, not a floor.
+Provider compromise ≠ disclosure (ciphertext only); device theft ≠
+disclosure (needs the ceremony).
+
+## 5. Security architecture
+
+The user's concern with the prototype was security; this is the layer that
+answers it. The design is a set of **trust boundaries** with explicit rules
+for what may cross each.
+
+```mermaid
+flowchart TB
+  subgraph TCB["Trusted core — sees decrypted secrets"]
+    KERNEL["Kernel: witness lifecycle, envelope keys, ceremony, grant registry"]
+  end
+  subgraph INPROC["In-process, secret-free"]
+    CAPS["Adapters: signer, prover-router, storage, indexer, recovery, DID"]
+  end
+  subgraph UNTRUSTED["Untrusted principals"]
+    DAPP["dApps via connector"]
+    AGENT["Agents — OWS, policy-gated"]
+  end
+  subgraph ANCHORS["External trust anchors"]
+    DYN["Wallet-infra provider — provider trust"]
+    TEE["TEE prover — remote attestation"]
+    VK["Vendor keystore — platform E2E"]
+    IDX["Indexer — sees view-key data"]
+  end
+  KERNEL -->|"scoped handles only"| CAPS
+  CAPS -->|"ciphertext, proofs, scoped ops"| ANCHORS
+  DAPP -->|"C23: consented, scoped"| KERNEL
+  AGENT -->|"policy-gated grant ops"| KERNEL
+  CAPS -->|"attested preimage only"| TEE
+```
+
+Each external anchor carries **one explicit trust assumption**: the
+wallet-infra provider is provider-trust; the remote prover is acceptable
+*only* under verified remote attestation (§2.5); the vendor keystore is
+platform E2E and must not also hold the envelope key (§3.6); the indexer
+sees whatever the view-key discloses ([C17]).
+
+A ceremony-gated write, end to end:
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant UI
+  participant Cmd as Command pipeline
+  participant Kernel
+  participant Prover as Prover router
+  participant Chain
+  UI->>Cmd: dispatch(withdraw, args)
+  Cmd->>Kernel: authorise(principal)
+  Kernel->>User: ceremony (passkey / password)
+  User-->>Kernel: presence
+  Kernel->>Kernel: decrypt witness (ephemeral)
+  Kernel->>Cmd: unproven tx + witness handle
+  Cmd->>Prover: prove(preimage)
+  Note over Prover: route — in-tab wasm / attested TEE / provider
+  Prover-->>Cmd: proof
+  Cmd->>Chain: submit
+  Chain-->>Cmd: confirmed
+  Cmd-->>UI: state projection + events
+```
+
+For an **agent** write, the `authorise` step resolves to an OWS
+policy-engine check against a standing grant instead of a human ceremony
+(§3.8) — the one exception to the per-transaction ceremony rule.
+
+## 6. Requirement → architecture map
+
+| Requirement | Lives in |
+|---|---|
+| Custody paths (§2.1) | Signer seam + kernel |
+| Ceremony (§2.2) | Kernel ceremony gate |
+| Signing / ECDSA binding (§2.3) | Signer seam; binding committed as an ACC device entry (kernel) |
+| Provider model (§2.4) | Seam interfaces + adapter packages |
+| Proving paths (§2.5) | Prover-router seam |
+| Onboarding (§3.1) | Onboard flow → kernel (deploy ACC) + signer, storage, DID seams |
+| dApp auth / authz (§3.2) | dApp-connection seam (wallet side) + grant registry |
+| Cross-chain MCS (§3.3) | Deferred post-v1 ([C25]); seam stub |
+| Recovery (§3.4) | Recovery seam + kernel (epoch re-auth) |
+| Multi-device (§3.5) | Kernel grant registry + signer seam |
+| Storage / sync (§3.6) | Storage/sync seam + kernel envelope |
+| DID (§3.7) | DID seam |
+| Agents / OWS (§3.8) | Agent seam (OWS `ChainSigner`/policy over the grant primitive) |
+| dApp connector (§3.9) | `@midnight-ntwrk/mn-passport-connect` package |
+
+## 7. What we lift from the prototype (quarry, not refactor)
+
+The prototype (`demo/mn-passport-foundations`) is a **validated quarry**,
+not the SDK skeleton. Lift:
+- `account.compact` and its seam design (epoch invalidation, `round` replay
+  counter, single `require_device`/`require_grant` auth seam, exported pure
+  commitment circuits) → **seeds the contract team's ACC** (§8.2); the SDK
+  consumes its published build via `@midnight-ntwrk/mn-passport-contract`.
+- the witness pipeline shape ([C7]) → kernel witness lifecycle.
+- the browser prover (`wasmProver.ts` + worker split) → prover-wasm
+  adapter.
+
+Rebuild (do not port): the app orchestration (god components, logic in JSX
+closures), the `any`-typed provider boundary, the module-global singletons,
+and the in-memory-only private state. The `require_device` body remains the
+single swap-point where hash-preimage gives way to Jubjub Schnorr and the
+§2.3 binding.
+
+## 8. Open decisions and questions
+
+1. **Core ambition — decided.** Approach 2 for v1 with Approach-3-shaped
+   seams, evolving to Approach 3.
+2. **ACC source ownership — decided.** The contract is **not owned by the
+   SDK**; it lives in a separate repository (or the same repository under a
+   different team). The SDK consumes a **versioned, published ACC artefact**
+   (compiled contract module, ZK assets, generated types) and owns only the
+   typed bindings over it. This decouples SDK releases from contract
+   recompilation and insulates the SDK from transientHash / toolchain
+   version instability ([C8]), which the contract team manages. Implies a
+   **compatibility contract**: an SDK version resolves against a supported
+   ACC version range (with its language / runtime pin).
+3. **v1 seam scope [open].** *Lean:* real at v1 — signer (managed +
+   interim local), prover (wasm + provider-routed; TEE next), storage
+   (local + vendor-native; #58 as it lands), indexer, dApp-connection,
+   agent/OWS. Interface-stubbed at v1 — fee/sponsor ([C24]), full recovery
+   helper ([C15]), cross-chain ([C25]).
+4. **Agent seam [open].** *Lean:* **implement** an OWS-compatible
+   `ChainSigner`/policy surface over the grant primitive (grant authoriser
+   = the OWS-managed key) rather than **consume** `ows-core`'s key/vault
+   model, keeping the ACC the seat of truth.
+5. **Mobile web storage & persistence [open question — verify].** The UI
+   targets mobile browser / installed PWA. Current-knowledge findings (to
+   re-verify against current iOS/Android): there is **no arbitrary
+   local-file read/write** on mobile browsers — the File System Access
+   pickers are desktop-Chromium only. Durable storage is **IndexedDB** (all
+   engines) plus **OPFS** (origin-private sandbox, iOS Safari 15.2+ /
+   Android) for larger blobs; both hold ciphertext under the ceremony
+   envelope (§2.2). The real risk is **eviction**: iOS ITP caps
+   script-writable storage at ~7 days of inactivity, so local private state
+   can be deleted. `navigator.storage.persist()` and **installing the PWA
+   (Add to Home Screen)** improve durability, more reliably on Android than
+   iOS. OS keystore / real files stay native-only (reinforces §3.6:
+   vendor-keystore is a native adapter). **Design consequence:** on mobile
+   web, local storage MUST be treated as a *reconstructable cache*, not the
+   source of truth — the ACC is authoritative, the device key re-derives
+   from the passkey PRF (§2.1), and cross-device sync (§3.6) plus recovery
+   ([C14]) must cover eviction. *To verify:* current iOS `persist()` grant
+   behaviour and installed-PWA storage durability.

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -356,6 +356,242 @@ backup exists** — which is why its backup is mandatory, not a floor.
 Provider compromise ≠ disclosure (ciphertext only); device theft ≠
 disclosure (needs the ceremony).
 
+### 4.6 Library composition — container view and worked examples
+
+§4.4's graph shows *dependency edges*; this shows the same packages as a
+**layered stack** (what sits on what), then works through concrete tasks so
+the composition is visible.
+
+> **Illustrative API.** The snippets below are indicative shapes to show
+> which library does what and how they compose — signatures are **not**
+> fixed and will be set when the packages are specced.
+
+**Container view.** Top tier calls down; nothing calls up. An adapter fills
+a `core` seam; `connect` is deliberately off to the side, reaching only the
+foundation packages (never `core`).
+
+```mermaid
+flowchart TB
+  subgraph T0["Consumers"]
+    UI["Official UI · CLI"]
+    AGENT["AI agent runtime"]
+    DAPP["Partner dApp"]
+  end
+  subgraph T1["Entry libraries"]
+    CORE["mn-passport-core — kernel + flows + seams (wallet / agent side)"]
+    CONNECT["mn-passport-connect — thin (dApp side)"]
+  end
+  subgraph T2["Adapters — fill core's seams"]
+    SIGN["adapter-signer-*"]
+    PROVE["adapter-prover-*"]
+    STORE["adapter-storage-*"]
+    FEE["adapter-fee-capacity-exchange"]
+    AGT["adapter-agent-ows"]
+    WC["adapter-wallet-connect"]
+  end
+  subgraph T3["Foundation"]
+    CONTRACT["mn-passport-contract — typed ACC bindings"]
+    PROTO["mn-passport-protocol — C23 types"]
+  end
+  subgraph T4["External / ecosystem"]
+    MJS["midnight-js + ledger"]
+    WASM["zkir-v2 wasm"]
+    PROV["wallet-infra provider · remote prover"]
+    DCA["dapp-connector-api"]
+  end
+  CHAIN["Midnight chain / the user's ACC"]
+
+  UI --> CORE
+  AGENT --> CORE
+  DAPP --> CONNECT
+  CORE --> T2
+  CORE --> CONTRACT
+  CORE --> PROTO
+  CONNECT --> PROTO
+  CONNECT --> CONTRACT
+  CONNECT -. "C23 over the wire" .-> CORE
+  SIGN --> PROV
+  PROVE --> WASM
+  PROVE --> PROV
+  FEE --> PROV
+  WC --> DCA
+  CORE --> MJS
+  CONTRACT --> MJS
+  MJS --> CHAIN
+```
+
+#### Example 1 — Onboarding (wallet side): deploy the ACC, claim the name
+
+Libraries: `core` (orchestrates the flow + ceremony), `adapter-signer-local`
+(device authoriser), `adapter-prover-wasm` (proof), `mn-passport-contract`
+(ACC bindings, under `core`).
+
+```ts
+import { Passport }      from '@midnight-ntwrk/mn-passport-core';
+import { passkeySigner } from '@midnight-ntwrk/mn-passport-adapter-signer-local';
+import { wasmProver }    from '@midnight-ntwrk/mn-passport-adapter-prover-wasm';
+
+const passport = await Passport.create({
+  signer: passkeySigner(),   // WebAuthn PRF → in-circuit Jubjub (§2.1 decentralised)
+  prover: wasmProver(),      // in-tab, low-k (§2.5)
+  // storage / indexer / fees: provider-free defaults unless overridden
+});
+
+const account = await passport.onboard({ name: 'alice' });  // → alice.passport.night
+```
+
+Who did what: `core` runs the single onboarding ceremony; `signer` derives
+the device authoriser; `prover` proves the deploy in-tab; `mn-passport-contract`
+(inside `core`) shapes the ACC `deploy` call; `core` then claims the name via
+the C2 name service. **Progressive decentralisation is one line:** swap
+`signer: providerSigner(providerWallet)` (§2.6) for the managed path —
+same flow, same ACC.
+
+#### Example 2 — dApp side: sign in + request a scoped grant (two-sided split)
+
+Libraries: `mn-passport-connect` + `mn-passport-protocol` on the dApp side;
+they meet the user's `core` (`adapter-dapp-connection`) only over C23.
+
+```ts
+// in a partner dApp — installs ONLY the thin connector, never core
+import { connectPassport } from '@midnight-ntwrk/mn-passport-connect';
+
+const session = await connectPassport.signIn();        // Sign-In-with-Passport (C23); no keys cross
+const grant   = await connectPassport.requestGrant({   // scoped grant (C10/C11)
+  operation: 'withdraw', token: NIGHT, cap: 100n,
+});
+```
+
+Who did what: `connect` speaks the dApp end of C23 using `protocol` types; the
+user's `core` (wallet side) shows the consent ceremony (§2.2) and writes the
+grant to the ACC, which enforces it on-chain (C12). `connect` and `core` share
+no code — only the `protocol` contract over the wire.
+
+#### Example 3 — Pay a Passport account: the deposit (§3.12), `connect` + `contract`, no `core`
+
+Libraries: `mn-passport-connect` (exposes the deposit function),
+`mn-passport-contract` (deposit-circuit bindings + ZK assets).
+
+```ts
+import { depositTo } from '@midnight-ntwrk/mn-passport-connect';
+
+// resolve alice.passport.night → her ACC, call the deposit circuit;
+// proven, balanced and fee-paid by the SENDER's own wallet
+const { txId } = await depositTo('alice.passport.night', { token: NIGHT, amount: 25n });
+```
+
+Who did what: `connect` resolves the name (C2) and drives the deposit;
+`mn-passport-contract` supplies the deposit-circuit bindings. `core` is **not**
+imported — this is the live proof of the "connector links `protocol` +
+`contract`, never the kernel" rule (§4.4).
+
+#### Example 4 — Zero-DUST (sponsored) contract call: adapter composition in the pipeline
+
+Libraries: `core` (build + authorise + submit), `adapter-fee-capacity-exchange`
+(sponsor), `adapter-prover-*` (proof).
+
+```ts
+import { Passport }            from '@midnight-ntwrk/mn-passport-core';
+import { capacityExchangeFees } from '@midnight-ntwrk/mn-passport-adapter-fee-capacity-exchange';
+
+const passport = await Passport.create({ /* signer, prover, */ fees: capacityExchangeFees() });
+
+// user holds zero DUST — the fee adapter fetches LP quotes (pure API),
+// composes the sponsor's DUST-supplying partial tx, then the call proceeds
+await passport.account.grantWithdraw({ token: NIGHT, amount: 10n, to: recipient });
+```
+
+Who did what: `core` builds and authorises the call (device-secret witness,
+ceremony); `adapter-fee-capacity-exchange` fetches LP quotes and composes the
+partial transaction (§3.11); `adapter-prover-*` proves it; `core` balances with
+the sponsor leg and submits. Same `grantWithdraw` call whether fees come from
+the user's DUST or a sponsor — the adapter is invisible to the flow.
+
+#### Example 5 — The `protocol` library: one wire-contract, both sides type-checked
+
+`protocol` has **no runtime** — it is *only* the shared message types both
+ends of the C23 conversation compile against. That is exactly why it is hard
+to picture: you never call it, you import types from it. Concretely, a grant
+request:
+
+```ts
+// ── @midnight-ntwrk/mn-passport-protocol ──  types + constants only, zero logic
+export const PROTOCOL_VERSION = 1;
+export interface GrantRequest {
+  version:   typeof PROTOCOL_VERSION;
+  operation: 'withdraw' | 'transfer';
+  token:     TokenId;
+  cap:       bigint;
+  expiresAt: number;
+}
+export interface GrantResponse { granted: boolean; grantId?: string }
+```
+
+```ts
+// ── dApp side (mn-passport-connect) BUILDS the request ──
+import { PROTOCOL_VERSION, type GrantRequest } from '@midnight-ntwrk/mn-passport-protocol';
+
+const req: GrantRequest = {                 // ← type-checked against the shared shape
+  version: PROTOCOL_VERSION,
+  operation: 'withdraw', token: NIGHT, cap: 100n,
+  expiresAt: Date.now() + 3_600_000,
+};
+transport.send(req);                        // over the wire (postMessage / EIP-6963 channel)
+```
+
+```ts
+// ── wallet side (inside mn-passport-core) HANDLES it ──
+import { type GrantRequest, type GrantResponse } from '@midnight-ntwrk/mn-passport-protocol';
+
+async function onGrantRequest(msg: GrantRequest): Promise<GrantResponse> {
+  // msg is the SAME type the dApp built — validate, ceremony-gate (§2.2), write to the ACC
+}
+```
+
+Why it earns its own library — the part a diagram can't show:
+
+- **Both sides import `GrantRequest` from `protocol`; neither imports the
+  other.** Change the shape in `protocol` (say `cap` becomes
+  `{ token; amount }`) and **typecheck breaks on the dApp builder and the
+  wallet handler at the same time** — they cannot silently drift apart. That
+  lockstep *is* the job.
+- **It is what lets `connect` stay `core`-free.** The only thing the thin
+  dApp package and the wallet share is these types. If they lived in `core`,
+  `connect` would have to depend on `core` — dragging the kernel into every
+  dApp bundle (§4.4). A logic-free shared package is what makes the trust
+  boundary enforceable rather than aspirational.
+- **No logic means no trust surface.** `protocol` ships types plus constants
+  (version, error codes, topic names) and nothing executable — importing it
+  on either side adds a *contract*, not attack surface.
+
+Mental model: it is the `.proto` / OpenAPI schema of the wallet↔dApp
+conversation — the shared definition two independent parties agree on, owned
+by neither. (Per §4.4 it likely *extends* Midnight's `dapp-connector-api`
+types with the Passport-specific messages, and may ship as a module rather
+than a standalone package at v1.)
+
+**Two version axes — do not conflate them.** `protocol` versioning is *not*
+the SDK↔contract compatibility; they are independent:
+
+| Axis | Between | Owned by |
+|---|---|---|
+| **Wire** | the dApp's connector and the user's wallet (off-chain C23 messages) | `mn-passport-protocol` (`PROTOCOL_VERSION`) |
+| **Binding** | the SDK's contract bindings and the deployed ACC (on-chain circuit shape) | `mn-passport-contract` (§8.2 compatibility contract) |
+
+A dApp built last quarter (`connect@1.2`, protocol v1) can hit a
+freshly-updated wallet (`core@1.9`, protocol v2) — the *wire* axis, which
+`protocol` negotiates because the two parties upgrade independently.
+Separately, that wallet's SDK 1.54 carries `mn-passport-contract` bindings
+for on-chain ACC v1.20 and guards the match at connect time (§8.2) — the
+*binding* axis. "Contract v1.20 with SDK 1.54" is the binding axis;
+`protocol` never sees it.
+
+Across the five: (1) wallet-side orchestration with adapters injected, (2) the
+cross-boundary two-sided split, (3) a thin-package chain call that never touches
+`core`, (4) adapter composition inside the write pipeline, and (5) the shared
+wire-contract that keeps the two sides of the split in lockstep without either
+depending on the other.
+
 ## 5. Security architecture
 
 The user's concern with the prototype was security; this is the layer that

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -49,7 +49,7 @@ flowchart TB
 
   CONNECT -. "C23 protocol" .-> KERNEL
   SEAMS --> ADAPT["Platform adapters: browser, node"]
-  ADAPT --> EXT["External: wallet-infra provider, attested TEE prover, vendor keystore, indexer"]
+  ADAPT --> EXT["External: wallet-infra provider, TEE prover (enclave), vendor keystore, indexer"]
   KERNEL --> CHAIN["Midnight chain / ACC"]
 ```
 
@@ -113,7 +113,7 @@ The only code that ever holds decrypted secrets. Owns:
 - the **grant registry** — which principals may act, at what scope.
 
 Invariant: secrets leave the kernel only as (a) an in-circuit witness to a
-local prover, (b) an attested preimage to a TEE prover, or (c) ciphertext
+local prover, (b) an enclave-encrypted preimage to a TEE prover, or (c) ciphertext
 to storage/sync. Never in plaintext to an adapter, a dApp, or an agent.
 
 ### 4.2 Seams (adapters in the full model)
@@ -123,7 +123,7 @@ default is always present (§2.1, [P8]):
 | Seam | Adapters | Req |
 |---|---|---|
 | Signer / custody | managed anchor · local in-circuit Jubjub · interim hash-preimage | §2.1, §2.3 |
-| Prover (router) | in-tab wasm (low k) · provider-routed (proof returned, Passport broadcasts) · direct attested-TEE (prove + broadcast) | §2.5 |
+| Prover (router) | in-tab wasm (low k) · provider-routed (proof returned, Passport broadcasts) · direct TEE, encrypt-to-enclave (prove + broadcast) | §2.5 |
 | Storage / sync | vendor keystore (native) · shared provider #58 · local-only | §3.6 |
 | Indexer / view-key | hosted · self-hosted | §3.6 |
 | Recovery | guardians + paper key | §3.4 |
@@ -146,16 +146,18 @@ flowchart TB
   K -- yes --> WASM["1 · in-tab WASM prover (Web Worker)\nwitness never leaves the device"]
   K -- no --> R{"remote variant"}
   R --> PROV["2a · provider-routed\nwallet-infra provider → its proving vendor\nproof returned → Passport balances + broadcasts"]
-  R --> TEE["2b · direct attested-TEE proof server\nattestation verified BEFORE preimage sent\nserver proves AND broadcasts → Passport awaits confirmation"]
+  R --> TEE["2b · direct TEE proof server\npreimage encrypted to enclave key BEFORE send\nserver proves AND broadcasts → Passport awaits confirmation"]
   WASM -. "capability failure (OOM / timeout / params)" .-> R
 ```
 
-Rules carried by the router (all normative in §2.5): attestation is
-verified **before** any preimage leaves the device on both remote variants
-(transitively including the provider's vendor on 2a); in 2b the fee-payer /
-balancing order is an explicit prerequisite ([C24]); and proof provenance —
-where it was proved *and who submitted it* — is surfaced truthfully to the
-user as a first-class pipeline event (§4.3).
+Rules carried by the router (all normative in §2.5): the preimage is
+**encrypted to the prover's enclave key before it leaves the device** on
+both remote variants — the SDK does *not* verify enclave attestation
+(that is the provider's / upstream's responsibility; the SDK trusts the
+enclave key it is given); in 2b the fee-payer / balancing order is an
+explicit prerequisite ([C24]); and proof provenance — where it was proved
+*and who submitted it* — is surfaced truthfully to the user as a
+first-class pipeline event (§4.3).
 
 ### 4.3 Command + state surface
 - **Reads:** an observable projection of ACC state + session (devices,
@@ -236,9 +238,10 @@ the provider-free default always ships.
   worker) for small-k circuits (§2.5).
 - **`adapter-prover-remote`** — the remote-proving client for high-k
   circuits, two modes (§2.5): **provider-routed** (proof returned; Passport
-  balances and broadcasts) and **direct attested-TEE** (the server proves
-  *and broadcasts*; Passport awaits confirmation). Verifies remote
-  attestation **before** sending any preimage in both modes.
+  balances and broadcasts) and **direct TEE** (the server proves *and
+  broadcasts*; Passport awaits confirmation). **Encrypts the preimage to
+  the prover's enclave key before sending** in both modes; enclave
+  attestation is the provider's responsibility, not the adapter's.
 - **`adapter-storage-vendor`** — native vendor-keystore sync adapter (§3.6).
 - **`adapter-storage-shared`** — the shared private-storage provider (#58)
   adapter; also the source for dApp witness provisioning (§3.9).
@@ -617,7 +620,7 @@ flowchart TB
   end
   subgraph ANCHORS["External trust anchors"]
     DYN["Wallet-infra provider — provider trust"]
-    TEE["TEE prover — remote attestation"]
+    TEE["TEE prover — provider-attested; SDK encrypts to its enclave key"]
     VK["Vendor keystore — platform E2E"]
     IDX["Indexer — sees view-key data"]
   end
@@ -625,12 +628,13 @@ flowchart TB
   CAPS -->|"ciphertext, proofs, scoped ops"| ANCHORS
   DAPP -->|"C23: consented, scoped"| KERNEL
   AGENT -->|"policy-gated grant ops"| KERNEL
-  CAPS -->|"attested preimage only"| TEE
+  CAPS -->|"enclave-encrypted preimage only"| TEE
 ```
 
 Each external anchor carries **one explicit trust assumption**: the
 wallet-infra provider is provider-trust; the remote prover is acceptable
-*only* under verified remote attestation (§2.5); the vendor keystore is
+because the preimage is encrypted to its enclave key (§2.5) — the provider
+attests the enclave, the SDK does not; the vendor keystore is
 platform E2E and must not also hold the envelope key (§3.6); the indexer
 sees whatever the view-key discloses ([C17]).
 
@@ -651,7 +655,7 @@ sequenceDiagram
   Kernel->>Kernel: decrypt witness (ephemeral)
   Kernel->>Cmd: unproven tx + witness handle
   Cmd->>Prover: prove(preimage)
-  Note over Prover: route by k — in-tab wasm | provider-routed | attested-TEE (2b: server broadcasts)
+  Note over Prover: route by k — in-tab wasm | provider-routed | TEE encrypt-to-enclave (2b: server broadcasts)
   Prover-->>Cmd: proof
   Cmd->>Chain: submit
   Chain-->>Cmd: confirmed

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -3,9 +3,10 @@
 > **Status:** draft · 2026/07/20
 > **Companion to:** [`sdk-requirements.md`](./sdk-requirements.md) (the
 > *what/why*) and [`development-workflow.md`](./development-workflow.md)
-> (how we build it). Requirement references (§) point to the requirements
-> doc; component references (`[C…]`) and promises (`[P…]`) point to
-> [`../../docs/plans`](../../docs/plans).
+> (how we build it); the reduced first cut is
+> [`beta-scope.md`](./beta-scope.md). Requirement references (§) point to the
+> requirements doc; component references (`[C…]`) and promises (`[P…]`) point
+> to [`../../docs/plans`](../../docs/plans).
 > **Purpose:** lay out candidate architectures for the SDK, recommend one,
 > and map every requirement onto it. Decisions still open are marked
 > **[open]** with a stated lean.

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -121,7 +121,7 @@ default is always present (§2.1, [P8]):
 | Seam | Adapters | Req |
 |---|---|---|
 | Signer / custody | managed anchor · local in-circuit Jubjub · interim hash-preimage | §2.1, §2.3 |
-| Prover (router) | in-tab wasm · attested-TEE remote · provider-routed | §2.5 |
+| Prover (router) | in-tab wasm (low k) · provider-routed (proof returned, Passport broadcasts) · direct attested-TEE (prove + broadcast) | §2.5 |
 | Storage / sync | vendor keystore (native) · shared provider #58 · local-only | §3.6 |
 | Indexer / view-key | hosted · self-hosted | §3.6 |
 | Recovery | guardians + paper key | §3.4 |
@@ -129,6 +129,31 @@ default is always present (§2.1, [P8]):
 | Agent / OWS | OWS policy engine + credential | §3.8 |
 | dApp-connection | C23 wallet side | §3.2 |
 | External wallet connect (client) | EIP-6963/1193 · Solana Wallet Standard · CIP-30 · Midnight connector | §3.10 |
+| Fee / DUST sponsorship | user-held DUST · Capacity Exchange LP marketplace | §3.11, [C24] |
+
+#### 4.2.1 The prover router (§2.5)
+
+The one seam with real routing logic, so it is drawn out. The routing input
+is the circuit's **k** (against a measured, per-device-class threshold);
+the split below k is a **trust** choice, and the two remote variants differ
+in **who broadcasts**:
+
+```mermaid
+flowchart TB
+  CMD["proving request (preimage embeds witness)"] --> K{"k ≤ device threshold?"}
+  K -- yes --> WASM["1 · in-tab WASM prover (Web Worker)\nwitness never leaves the device"]
+  K -- no --> R{"remote variant"}
+  R --> PROV["2a · provider-routed\nwallet-infra provider → its proving vendor\nproof returned → Passport balances + broadcasts"]
+  R --> TEE["2b · direct attested-TEE proof server\nattestation verified BEFORE preimage sent\nserver proves AND broadcasts → Passport awaits confirmation"]
+  WASM -. "capability failure (OOM / timeout / params)" .-> R
+```
+
+Rules carried by the router (all normative in §2.5): attestation is
+verified **before** any preimage leaves the device on both remote variants
+(transitively including the provider's vendor on 2a); in 2b the fee-payer /
+balancing order is an explicit prerequisite ([C24]); and proof provenance —
+where it was proved *and who submitted it* — is surfaced truthfully to the
+user as a first-class pipeline event (§4.3).
 
 ### 4.3 Command + state surface
 - **Reads:** an observable projection of ACC state + session (devices,
@@ -206,9 +231,11 @@ the provider-free default always ships.
   behind the same interface until Schnorr lands (§2.3).
 - **`adapter-prover-wasm`** — the in-tab wasm prover (lifted from the prototype
   worker) for small-k circuits (§2.5).
-- **`adapter-prover-remote`** — the remote-proving client: provider-routed and
-  attested-TEE paths, verifying remote attestation **before** sending any
-  preimage (§2.5).
+- **`adapter-prover-remote`** — the remote-proving client for high-k
+  circuits, two modes (§2.5): **provider-routed** (proof returned; Passport
+  balances and broadcasts) and **direct attested-TEE** (the server proves
+  *and broadcasts*; Passport awaits confirmation). Verifies remote
+  attestation **before** sending any preimage in both modes.
 - **`adapter-storage-vendor`** — native vendor-keystore sync adapter (§3.6).
 - **`adapter-storage-shared`** — the shared private-storage provider (#58)
   adapter; also the source for dApp witness provisioning (§3.9).
@@ -223,6 +250,12 @@ the provider-free default always ships.
   connecting *out* to external wallets (Lace, 1am, Gero, MetaMask, Rabby,
   Phantom), one adapter per standard (§3.10). The opposite direction to
   `adapter-dapp-connection`; foreign-curve wallets attach via the §2.3 binding.
+- **`adapter-fee-capacity-exchange`** — the Fee seam's sponsored fill
+  (§3.11): wraps the upstream Capacity Exchange SDK — LP quote requests
+  (pure API, off-chain), quote selection, composition of the LP's partial
+  transaction (DUST intent + payment leg) with the user's dApp intent, and
+  quote expiry / replay / abandonment handling. User-held DUST remains the
+  provider-free default in core.
 
 **dApp side**
 
@@ -370,7 +403,7 @@ sequenceDiagram
   Kernel->>Kernel: decrypt witness (ephemeral)
   Kernel->>Cmd: unproven tx + witness handle
   Cmd->>Prover: prove(preimage)
-  Note over Prover: route — in-tab wasm / attested TEE / provider
+  Note over Prover: route by k — in-tab wasm | provider-routed | attested-TEE (2b: server broadcasts)
   Prover-->>Cmd: proof
   Cmd->>Chain: submit
   Chain-->>Cmd: confirmed
@@ -399,6 +432,8 @@ policy-engine check against a standing grant instead of a human ceremony
 | DID (§3.7) | DID seam |
 | Agents / OWS (§3.8) | Agent seam (OWS `ChainSigner`/policy over the grant primitive) |
 | dApp connector (§3.9) | `@midnight-ntwrk/mn-passport-connect` package |
+| External wallets (§3.10) | `adapter-wallet-connect` + §2.3 binding (kernel) |
+| DUST sponsorship (§3.11) | Fee seam (`adapter-fee-capacity-exchange`); the balance stage of the command pipeline |
 
 ## 7. What we lift from the prototype (quarry, not refactor)
 
@@ -434,8 +469,10 @@ single swap-point where hash-preimage gives way to Jubjub Schnorr and the
 3. **v1 seam scope [open].** *Lean:* real at v1 — signer (managed +
    interim local), prover (wasm + provider-routed; TEE next), storage
    (local + vendor-native; #58 as it lands), indexer, dApp-connection,
-   agent/OWS. Interface-stubbed at v1 — fee/sponsor ([C24]), full recovery
-   helper ([C15]), cross-chain ([C25]).
+   agent/OWS. Interface-stubbed at v1 — full recovery helper ([C15]),
+   cross-chain ([C25]). Fee/sponsor ([C24]) was stub-leaning, but §3.11
+   (Capacity Exchange) is now a named requirement — whether
+   `adapter-fee-capacity-exchange` is real at v1 tracks the upstream launch.
 4. **Agent seam [open].** *Lean:* **implement** an OWS-compatible
    `ChainSigner`/policy surface over the grant primitive (grant authoriser
    = the OWS-managed key) rather than **consume** `ows-core`'s key/vault

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -148,7 +148,7 @@ flowchart TB
   K -- no --> R{"remote variant"}
   R --> PROV["2a · provider-routed\nwallet-infra provider → its proving vendor\nproof returned → Passport balances + broadcasts"]
   R --> TEE["2b · direct TEE proof server\npreimage encrypted to enclave key BEFORE send\nserver proves AND broadcasts → Passport awaits confirmation"]
-  WASM -. "capability failure (OOM / timeout / params)" .-> R
+  WASM -. "capability failure → PROPOSE remote (manual consent)" .-> R
 ```
 
 Rules carried by the router (all normative in §2.5): the preimage is
@@ -156,9 +156,13 @@ Rules carried by the router (all normative in §2.5): the preimage is
 both remote variants — the SDK does *not* verify enclave attestation
 (that is the provider's / upstream's responsibility; the SDK trusts the
 enclave key it is given); in 2b the fee-payer / balancing order is an
-explicit prerequisite ([C24]); and proof provenance — where it was proved
+explicit prerequisite ([C24]); proof provenance — where it was proved
 *and who submitted it* — is surfaced truthfully to the user as a
-first-class pipeline event (§4.3).
+first-class pipeline event (§4.3); and **the in-tab → remote fallback is
+consent-gated** — a capability failure *proposes* the remote prover and the
+transaction pauses for explicit user confirmation (moving off-device is a
+privacy downgrade, §2.5), after which the SDK shows a standing reminder that
+remote proving is active.
 
 ### 4.3 Command + state surface
 - **Reads:** an observable projection of ACC state + session (devices,

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -168,8 +168,9 @@ user as a first-class pipeline event (§4.3).
 
 Dependency rule: everything points **inward** to `@midnight-ntwrk/mn-passport-core`'s
 interfaces; nothing points outward. `@midnight-ntwrk/mn-passport-connect` links neither the
-core nor any adapter — only shared protocol types — so a dApp can never
-pull the kernel into its bundle.
+core nor any adapter — only the shared protocol types and the contract
+bindings (for §3.12 deposits) — so a dApp can never pull the kernel into
+its bundle.
 
 **Foundation**
 
@@ -262,9 +263,13 @@ the provider-free default always ships.
 - **`@midnight-ntwrk/mn-passport-connect`** — the **thin** connector a third-party developer
   installs (§3.9). Implements the dApp end of C23 over `@midnight-ntwrk/mn-passport-protocol`:
   Sign-In-with-Passport, scoped-grant requests, and requesting
-  Passport-provisioned witnesses. Minimal footprint, own threat model;
-  talks C23 *to* the wallet across a trust boundary and **must not link
-  `@midnight-ntwrk/mn-passport-core`** or any adapter.
+  Passport-provisioned witnesses. Also exposes the **deposit function**
+  (§3.12: resolve name → connect to the recipient's ACC → call the deposit
+  circuit) — the one direct chain interaction, riding
+  `mn-passport-contract` rather than the C23 channel. Minimal footprint,
+  own threat model; talks C23 *to* the wallet across a trust boundary and
+  **must not link `@midnight-ntwrk/mn-passport-core`** or any adapter
+  (`mn-passport-contract` is a foundation dependency, permitted).
 
 ```mermaid
 flowchart LR
@@ -284,9 +289,11 @@ flowchart LR
   NODE --> CORE
   NODE --> CAPS
   CONNECT --> PROTO
+  CONNECT --> CONTRACT
 ```
 *Arrows read "depends on". `@midnight-ntwrk/mn-passport-connect` reaches only
-`@midnight-ntwrk/mn-passport-protocol` — never the core or an adapter.*
+`@midnight-ntwrk/mn-passport-protocol` and `@midnight-ntwrk/mn-passport-contract`
+(deposit bindings, §3.12) — never the core or an adapter.*
 
 ### 4.5 Private storage and backup
 
@@ -434,6 +441,7 @@ policy-engine check against a standing grant instead of a human ceremony
 | dApp connector (§3.9) | `@midnight-ntwrk/mn-passport-connect` package |
 | External wallets (§3.10) | `adapter-wallet-connect` + §2.3 binding (kernel) |
 | DUST sponsorship (§3.11) | Fee seam (`adapter-fee-capacity-exchange`); the balance stage of the command pipeline |
+| Deposit mechanism (§3.12) | `mn-passport-contract` deposit bindings, surfaced via `mn-passport-connect` (dApps) and expected of ecosystem wallets |
 
 ## 7. What we lift from the prototype (quarry, not refactor)
 

--- a/sdk/docs/architecture.md
+++ b/sdk/docs/architecture.md
@@ -245,8 +245,9 @@ the provider-free default always ships.
 - **`adapter-recovery`** — guardian + paper-key total-loss recovery
   (§3.4, [C14]/[C15]).
 - **`adapter-did`** — `did:midnight` create / resolve (§3.7).
-- **`adapter-agent-ows`** — the OWS-compatible `ChainSigner` / policy surface
-  over the grant primitive (§3.8).
+- **`adapter-agent-ows`** — wraps WingRiders' `ows-core` (its Midnight
+  plugin) and maps OWS agent access onto Passport scoped grants; the agent's
+  "key" is a grant authoriser on the ACC, never the account key (§3.8).
 - **`adapter-dapp-connection`** — the wallet side of C23: answers discovery,
   Sign-In-with-Passport, and scoped-grant requests (§3.2).
 - **`adapter-wallet-connect`** — the wallet-connector **client**: Passport
@@ -331,10 +332,12 @@ such as staged ZK params). It holds only **ciphertext**: each entry is
 data key is wrapped by a **ceremony-derived** key (passkey PRF, or password
 KDF); plaintext and the wrapping key materialise only transiently inside
 the kernel after a §2.2 ceremony. So device theft or an IndexedDB read
-(XSS, extracted backup) yields ciphertext only — and the wrapping key MUST
-be independent of any channel the backup also uses (the §3.6 lock-and-key
-rule: passkey PRF that syncs to the same vendor cloud as the ciphertext
-hands the vendor lock and key together).
+(XSS, extracted backup) yields ciphertext only. **Decided:** the wrapping
+key is the **passkey (PRF)**, falling back to a **password (KDF)** on
+devices without passkey/PRF support (§2.2). Residual lock+key risk — passkey
+and ciphertext in the same vendor cloud — is mitigated by routing the backup
+copy through the portable #58 provider rather than the vendor keystore
+(§3.6); any remaining exposure is an accepted risk in the security register.
 
 **3. Backup — mandatory and redundant for the irreplaceable tier.**
 IndexedDB is an evictable cache that mobile browsers do not replicate across
@@ -675,7 +678,7 @@ policy-engine check against a standing grant instead of a human ceremony
 | Multi-device (§3.5) | Kernel grant registry + signer seam |
 | Storage / sync (§3.6) | Storage/sync seam + kernel envelope |
 | DID (§3.7) | DID seam |
-| Agents / OWS (§3.8) | Agent seam (OWS `ChainSigner`/policy over the grant primitive) |
+| Agents / OWS (§3.8) | `adapter-agent-ows` wrapping WingRiders `ows-core`, mapped to ACC scoped grants |
 | dApp connector (§3.9) | `@midnight-ntwrk/mn-passport-connect` package |
 | External wallets (§3.10) | `adapter-wallet-connect` + §2.3 binding (kernel) |
 | DUST sponsorship (§3.11) | Fee seam (`adapter-fee-capacity-exchange`); the balance stage of the command pipeline |
@@ -719,10 +722,14 @@ single swap-point where hash-preimage gives way to Jubjub Schnorr and the
    cross-chain ([C25]). Fee/sponsor ([C24]) was stub-leaning, but §3.11
    (Capacity Exchange) is now a named requirement — whether
    `adapter-fee-capacity-exchange` is real at v1 tracks the upstream launch.
-4. **Agent seam [open].** *Lean:* **implement** an OWS-compatible
-   `ChainSigner`/policy surface over the grant primitive (grant authoriser
-   = the OWS-managed key) rather than **consume** `ows-core`'s key/vault
-   model, keeping the ACC the seat of truth.
+4. **Agent seam — decided: consume WingRiders `ows-core`.** Adopt
+   `ows-core` (its Midnight plugin) as the OWS implementation rather than
+   reimplement it; `adapter-agent-ows` wraps it and maps OWS agent access
+   onto Passport **scoped grants** (§3.8). Reconciliation with
+   contract-custody: the "key" OWS manages for an agent is a **grant
+   authoriser** on the ACC (a lesser, scoped, revocable key), so the ACC
+   stays the seat of authority and the agent never holds the account key.
+   `ows-core` is tracked as an upstream dependency (currency + cooldown).
 5. **Mobile web storage & persistence [open question — verify].** The UI
    targets mobile browser / installed PWA. Current-knowledge findings (to
    re-verify against current iOS/Android): there is **no arbitrary

--- a/sdk/docs/beta-scope.md
+++ b/sdk/docs/beta-scope.md
@@ -1,0 +1,136 @@
+# Midnight Passport SDK — Beta (v1) scope
+
+> **Status:** draft · 2026/07/24
+> **Reduces:** [`sdk-requirements.md`](./sdk-requirements.md) and
+> [`architecture.md`](./architecture.md) to the smallest slice that ships a
+> usable beta. Every in-scope item points to its full-scope section; every
+> deferral says where it will come from later. Built the way
+> [`development-workflow.md`](./development-workflow.md) describes.
+
+## 1. Purpose
+
+Ship a reduced beta that does two things well:
+
+1. proves **full account setup** works end to end on the **managed path**, and
+2. lets a first reference dApp — a **marketing experience**, fully off-chain
+   for now — sign a user in and read their profile.
+
+Everything not needed for those two is explicitly deferred (§4). The beta is
+deliberately the *managed, provider-backed* path only: it is the fastest way
+to something real in users' hands and it is what the account-custody
+prototype already demonstrated.
+
+## 2. In scope
+
+**(1) Full account setup** — deploy the Account Custody Contract (ACC) and
+claim the name (`alice.passport.night`). Covers onboarding (§3.1), the ACC
+(§1.1 / C1) and the name service (§2 / C2). The DUST fees for these setup
+transactions are **sponsored by the provider** (see item 3), so a zero-DUST
+user can onboard with no faucet or separate fee mechanism.
+
+**(2) Managed path only** — the account is set up and used through the
+**wallet-infrastructure provider** (the managed custody path, §2.1 / §2.6).
+The decentralised, self-custody path (in-circuit Jubjub device keys, §2.1
+decentralised / §2.3) is **out of beta**. Passkeys are **always** used to
+confirm transactions (§2.2): the provider's own login is passkey-based, and
+that passkey is the presence gate on every managed-path action. What is
+deferred is the decentralised *use* of the passkey (deriving an in-circuit
+device key), not the passkey itself.
+
+**(3) Proving via the provider's remote proof server only** — all proofs
+route to the provider's remote prover (§2.5 **path 2a**, provider-routed).
+Beta does **not** do in-tab WASM proving or a direct TEE prover, and it does
+**not** run the k-threshold router: everything goes to the provider
+regardless of circuit size. The SDK encrypts the witness to that prover's
+enclave (§2.5); the provider returns the proof. The same provider path also
+**sponsors the DUST fees** — including the account-setup transactions (item
+1) — so beta needs no separate fee/sponsor mechanism (Capacity Exchange,
+§3.11, stays out of beta).
+
+**(4) dApp connect — sign-in + profile read only** — the connector (§3.9)
+implements **Sign-In-with-Passport** and returns the user's **profile: the
+ACC contract address plus the alias (name)**. That is the whole surface in
+beta. No witness provisioning (#58), no scoped-grant issuance or spending,
+no deposits.
+
+**Reference dApp — a marketing experience (fully off-chain for now).** It
+installs `mn-passport-connect`, signs the user in, and reads
+`{ name, account }` to identify and personalise for the user (for example,
+gating or tailoring the experience per Passport account). It runs entirely
+off-chain: it never spends, never asks for a grant, and never touches
+witness state. That read-only shape is exactly why it is a safe first
+integration and a good dogfooding partner.
+
+## 3. The active slice (packages and adapters)
+
+Live in beta:
+
+- `mn-passport-core` — a slim build: the onboarding flow and the connect
+  answer, the kernel, the seams.
+- `mn-passport-contract` — ACC bindings for deploy and the calls onboarding
+  needs.
+- `mn-passport-connect` + `mn-passport-protocol` — the dApp side, sign-in and
+  profile read only.
+- `adapter-signer-managed` — the provider-backed custody path.
+- `adapter-prover-remote` — pinned to the provider's remote proof server
+  (path 2a).
+
+Not built for beta: `adapter-signer-local`, `adapter-prover-wasm`,
+`adapter-agent-ows`, `adapter-wallet-connect`, `adapter-fee-capacity-exchange`,
+and the witness-provisioning half of the connector.
+
+```mermaid
+flowchart TB
+  DAPP["marketing experience (off-chain)"] --> CONNECT["mn-passport-connect: sign-in + profile"]
+  CONNECT -. "returns { name, account }" .-> DAPP
+  USER["user"] --> CORE["mn-passport-core (managed)"]
+  CORE --> SIGN["adapter-signer-managed — provider"]
+  CORE --> PROVE["adapter-prover-remote — provider's remote prover (2a)"]
+  CORE --> CONTRACT["mn-passport-contract: deploy ACC + claim name"]
+  CONTRACT --> CHAIN["Midnight chain / ACC"]
+  CONNECT -. "C23" .-> CORE
+```
+
+## 4. Out of scope for beta (deferred, with pointers)
+
+| Deferred | Comes from |
+|---|---|
+| Decentralised / self-custody path (in-circuit Jubjub) | §2.1 decentralised, §2.3 |
+| In-tab WASM proving; direct TEE prover | §2.5 paths 1 and 2b |
+| Witness provisioning to dApps | #58 · §3.6 / §3.9 |
+| Scoped grants (issue / spend) beyond sign-in | §3.2 · C10–C12 |
+| Agents / OWS | §3.8 |
+| External wallet connections | §3.10 |
+| DUST sponsorship / Capacity Exchange | §3.11 |
+| Deposit mechanism (paying a Passport account) | §3.12 |
+| Recovery (lost-device / total-loss) | §3.4 · C13–C15 |
+| DID (`did:midnight`) | §3.7 |
+| Multi-device beyond the provider's own | §3.5 |
+
+Beta leans on the **provider** for anything managed it happens to offer
+(recovery, multi-device); Passport's own versions of those come after beta.
+
+## 5. Open questions to close before beta ships
+
+- **Provider remote-prover readiness.** Item (3) assumes the provider's
+  remote proof-server integration (with fee sponsorship) exists. If it is not
+  ready, beta proving and fee-paying are blocked or need an interim (a local
+  proof server + a stopgap fee payer). Confirm the timeline with the
+  provider.
+- **Managed key binding.** In the prototype the managed device secret is a
+  random, browser-local value that does not port across devices (§2.6,
+  demo-grade). Acceptable for beta? If a beta user needs the same account on
+  a second device, the portable §2.3 binding is needed sooner rather than
+  later.
+
+## 6. Delivery
+
+Beta is anchored to a single GitHub issue and planned into small,
+reviewable PRs via `mn-skills-spec-driver` (development-workflow §3). Rough
+tranches:
+
+1. Managed onboarding — ACC deploy + name claim, proofs via the provider's
+   remote prover.
+2. Connect — Sign-In-with-Passport returning `{ name, account }`.
+3. Marketing-experience integration against the connector (off-chain).
+4. Hardening and the beta demo.

--- a/sdk/docs/beta-scope.md
+++ b/sdk/docs/beta-scope.md
@@ -45,7 +45,11 @@ regardless of circuit size. The SDK encrypts the witness to that prover's
 enclave (§2.5); the provider returns the proof. The same provider path also
 **sponsors the DUST fees** — including the account-setup transactions (item
 1) — so beta needs no separate fee/sponsor mechanism (Capacity Exchange,
-§3.11, stays out of beta).
+§3.11, stays out of beta). Because beta proves remotely by default (there
+is no in-tab option yet), there is no in-tab → remote switch to consent to;
+instead the reduced-privacy posture (the witness goes to the provider's
+enclave) is disclosed at onboarding and shown as a standing reminder, per
+§2.5.
 
 **(4) dApp connect — sign-in + profile read only** — the connector (§3.9)
 implements **Sign-In-with-Passport** and returns the user's **profile: the

--- a/sdk/docs/development-workflow.md
+++ b/sdk/docs/development-workflow.md
@@ -1,0 +1,353 @@
+# Development workflow — the `mn-skills` family
+
+> **Status:** draft · 2026/07/24
+> **Companion to:** [`sdk-requirements.md`](./sdk-requirements.md) (the *what/why*)
+> and [`architecture.md`](./architecture.md) (the *how*). This document is the
+> *how we build it* — the Claude-harness skills that drive SDK development and
+> how they orchestrate a spec from plan to merged PR.
+
+**Naming, to avoid a collision:** development-time skills are prefixed
+**`mn-skills-*`**; the shipped runtime packages are **`@midnight-ntwrk/mn-passport-*`**
+(§4.4 of the architecture). `mn-skills-*` build the SDK; `mn-passport-*` *are*
+the SDK.
+
+---
+
+## 1. Rationale
+
+A development workflow has to do two things, and it is easy to build one that
+only does the first:
+
+1. **Produce and check code** — plan the work, write it, and review it for
+   design conformance, security, and style.
+2. **Close two feedback loops** — *does it actually run?* and *did we just
+   learn the docs are wrong?*
+
+The second is where the real surprises live. On this project specifically,
+the two largest course-corrections during planning were exactly those loops
+firing: discovering how the managed flow *actually* executes a contract call
+(a "does it run" finding), and correcting the managed-path model in the docs
+afterwards (a "the docs were wrong" finding). A workflow with no first-class
+home for either will drift — the code stops matching reality, and the docs
+stop matching the code.
+
+Two principles fall out and shape everything below:
+
+- **Skills assist and judge; hooks/CI enforce.** Anything that must be
+  *guaranteed* — a PR always has a description, the security register never
+  gets pushed, dependencies respect the cooldown — lives in the deterministic
+  layer (hooks/CI), because the harness runs it, not the model. Skills draft,
+  review, and advise; they never *guarantee*. Mixing the two produces a skill
+  that "usually" adds a description.
+- **`sdk/docs` is the source of truth; conformance gives it teeth; doc-sync
+  keeps it true.** Per-feature specs are *derived from* the requirements and
+  architecture. `mn-skills-conformance` checks code against those docs, so
+  they must stay current — which is `mn-skills-doc-sync`'s job. Without the
+  sync loop, conformance quietly validates against stale truth.
+
+---
+
+## 2. The skills
+
+All prefixed `mn-skills-`. Each entry: what it does, when it fires, and what
+existing tooling it leans on (we wire, we do not reinvent).
+
+### Spine
+
+**`mn-skills-spec-driver`** — plan, then loop.
+- *Plan phase* (harness plan mode): a per-feature spec → an ordered set of
+  **tranches, each sized to one small/medium PR**, each with an acceptance
+  gate. PR boundaries are decided here, up front — not bolted on later. The
+  plan phase also **requires the spec's GitHub issue** (from
+  `midnightntwrk/passport/issues`); if the spec names none, it **stops and
+  asks for it** before planning — no untraceable work.
+- *Loop phase* (harness `/loop`): per tranche → implement → run the review
+  lenses → `mn-skills-pr-open` → **stop for human review/merge** → next
+  tranche. On each tranche's completion or slip it updates **`STATE.md`**
+  (§3) so the progress and backlog view stays current.
+
+### Review lenses (run per tranche, parallelisable, each also invokable alone)
+
+**`mn-skills-conformance`** — the design guard. Checks the change against the
+requirements + architecture: seam/adapter structure, package-dependency rules
+(`connect` never links `core`; deposits ride `contract` — arch §4.4), the
+normative MUSTs (ceremony gate §2.2, deposit-not-address §3.12,
+attestation-before-preimage §2.5), naming, and the two version axes. Its
+checklist is *derived from* `sdk/docs`. Consulted at plan time so the plan
+aligns; enforced at review time so the code does.
+
+**`mn-skills-security-audit`** — key-management review. Two outputs:
+1. *Blocking findings* — fixable mismanagement (secret in the wrong place,
+   witness not zeroised, missing ceremony gate) → fix now.
+2. *Residual-risk register* — "insecure but not resolvable right now" items,
+   each with **risk → why it can't be fixed yet → mitigations**, appended to
+   a **gitignored** register (§4). This is the demo's hand-written
+   `DECISIONS.md` "Known gaps" list, automated and maintained per PR.
+
+**`mn-skills-code-style`** — project coding preferences. Grounded in
+`.claude/rules/` (British English + Oxford comma, `YYYY/MM/DD` dates, Rust
+style) plus TS conventions, and the **Midnight** brand for any UI —
+Midnight Passport is a Midnight-branded product, not an IOG-branded one.
+Judgment layer (prose in comments/docs, brand adherence, i18n,
+error-taxonomy consistency); the mechanical part (format/lint) is
+backstopped in CI.
+
+**`mn-skills-verify`** — *does it run?* Drives the affected flow end-to-end
+rather than trusting that review passed. Leans on the repo's existing
+`midnight-verify` (`/verify`, devnet, contract/witness/sdk testers) and
+`midnight-cq` (test runner, test-quality). A change that passes conformance,
+security, and style but does not prove or submit is not done. Open
+validations it cannot close (e.g. a `[PROVISIONAL]` item awaiting a real
+account) are recorded in the **verify register** (§4), owned here jointly
+with doc-sync.
+
+### Feedback
+
+**`mn-skills-doc-sync`** — *did we learn the docs are wrong?* When
+implementation diverges from `sdk/docs` (reality contradicts an assumption),
+the defined path is: update the requirements/architecture **and record the
+decision as an ADR**. Closes the loop that conformance depends on. Leans on
+the repo's existing ADR / `arcsop` machinery. Owns the **verify register** of
+provisional decisions and open validations that still need re-checking.
+
+### Ship
+
+**`mn-skills-pr-open`** — small/medium sizing check (flags a split if the
+diff is too large) and the **PR description** ("what's being built" + link to
+the spec tranche **and the spec's GitHub issue** — `Refs #NN`, or `Closes #NN`
+on the tranche that finishes it). **Prepares** the branch, commits, and
+description, then **stops for explicit human confirmation before
+pushing/opening** — the loop never performs the outward action on its own.
+
+### Watchers (fire on a schedule / on dependency changes, not per tranche)
+
+**`mn-skills-deps`** — upstream drift and supply-chain hygiene. Midnight
+breaks often, and the SDK pins midnight-js / ledger / zkir / compact **and**
+the ACC artefact (arch §8.2). This skill:
+- **Never adopts a package version younger than 7 days.** A version published
+  less than 7 days ago sits in a **cooldown quarantine** — the window in which
+  a supply-chain compromise of an underlying library is most often caught and
+  yanked. Adoption (new dependency or version bump) waits out the 7 days.
+  Checked against registry publish time (`npm view <pkg> time`). The only
+  override is an urgent security patch, taken as a *conscious, recorded*
+  decision — never silently.
+- Pins **exact versions** with a committed lockfile; verifies versions with
+  `npm view`, never from memory; adds **no custom registry config**
+  (`@midnight-ntwrk/*` are on public npm).
+- Maintains the **compatibility matrix** — the two version axes (wire:
+  `mn-passport-protocol`; binding: `mn-passport-contract` ↔ deployed ACC,
+  arch §4.6) — and flags when an upstream bump requires a matrix update.
+Leans on `release-notes` and `troubleshooting`.
+
+**`mn-skills-devenv`** — guards the dev environment. Passkeys require an
+**HTTPS / secure context even locally** (a `localhost` HTTP redirect will not
+do), alongside devnet + proof server + compact CLI. Leans on
+`midnight-tooling:*` (devnet, proof-server, doctor).
+
+### Deferred (named, not built yet)
+
+**`mn-skills-release`** — version bump + changelog + publishing the
+compatibility matrix. Publish-time; sequence after the core loop is proven.
+
+### Not skills
+
+- **Generic bug / quality review** — the harness's `/code-review` and
+  `/review` already do this; the lenses above encode *our* rules, which a
+  generic reviewer cannot know.
+- **The merge decision** — human.
+- **Per-feature spec *authoring*** — currently the plan phase of
+  `mn-skills-spec-driver`; split into its own skill only if authoring proves
+  heavy.
+
+Fold-ins (not new skills): error-taxonomy + proof-provenance → conformance;
+UX / a11y / i18n + brand → code-style.
+
+---
+
+## 3. Orchestrating a spec
+
+The unit of work is a **per-feature spec derived from `sdk/docs`** (the big
+docs are the source; a feature spec is what gets driven).
+
+0. **Derive the spec** — from the relevant requirements + architecture
+   sections into a concrete feature spec (scope, decisions, tranches), naming
+   its **GitHub issue**.
+1. **Plan** — `mn-skills-spec-driver` turns it into PR-sized, gated tranches;
+   if the spec named no issue, it **stops and asks** before planning.
+2. **Loop** — for each tranche:
+   a. `mn-skills-devenv` confirms the environment is ready.
+   b. Implement the tranche.
+   c. Run the lenses in parallel: `conformance`, `security-audit`,
+      `code-style`, `verify`. Blocking findings are fixed before proceeding.
+   d. Registers update: security-audit → security register; verify/doc-sync →
+      verify register (both gitignored).
+   e. If conformance finds the code diverging from the docs for a *good*
+      reason, `mn-skills-doc-sync` updates `sdk/docs` + records an ADR — the
+      docs are corrected, not the code bent to a stale doc.
+   f. `mn-skills-pr-open` prepares the branch + description, links the PR to
+      the spec's GitHub issue, and **stops**.
+   g. The hooks/CI gate runs; a human reviews and merges.
+3. **Repeat** until the spec's tranches are done. `STATE.md` reflects done /
+   in-progress / backlog throughout; anything not completed lands in the
+   backlog with a reason, never silently dropped.
+
+Running alongside, on their own cadence: `mn-skills-deps` (drift + cooldown +
+matrix) and `mn-skills-devenv`.
+
+### Diagram — the orchestration loop
+
+*(All skills prefixed `mn-skills-`; shortened in nodes.)*
+
+```mermaid
+flowchart TB
+  DOCS["sdk/docs: requirements + architecture (source of truth)"]
+  SPEC["per-feature spec (derived)"]
+  PLAN["spec-driver · PLAN: PR-sized gated tranches"]
+  IMPL["implement tranche"]
+  PR["pr-open: prepare branch + description — STOP for human"]
+  GATE["hooks / CI gate"]
+  HUMAN["human review / merge"]
+  DONE["feature complete"]
+
+  ISSUE["GitHub issue (midnightntwrk/passport)"] --> SPEC
+  DOCS --> SPEC --> PLAN --> IMPL
+  IMPL --> CONF["conformance (vs docs)"]
+  IMPL --> SEC["security-audit"]
+  IMPL --> STYLE["code-style"]
+  IMPL --> VERIFY["verify (runs the flow)"]
+  CONF --> PR
+  SEC --> PR
+  STYLE --> PR
+  VERIFY --> PR
+  PR --> GATE --> HUMAN
+  HUMAN -->|next tranche| IMPL
+  HUMAN -->|done| DONE
+  HUMAN -. updates .-> STATE["sdk/STATE.md: done / backlog (committed)"]
+
+  SEC -. appends .-> SREG[".mn-skills/security-register.md (gitignored)"]
+  VERIFY -. open items .-> VREG[".mn-skills/verify-register.md (gitignored)"]
+  CONF -. divergence .-> SYNC["doc-sync: update docs + ADR"]
+  SYNC -. corrects .-> DOCS
+
+  DEPS["deps: 7-day cooldown + compat matrix"] -. drift .-> DOCS
+  DEVENV["devenv: HTTPS + devnet ready"] -. gate .-> IMPL
+```
+
+### Diagram — the family by role
+
+```mermaid
+flowchart LR
+  subgraph DRIVE["Drive"]
+    D1["spec-driver"]
+  end
+  subgraph LENSES["Per-tranche lenses"]
+    C1["conformance"]
+    C2["security-audit"]
+    C3["code-style"]
+    C4["verify"]
+  end
+  subgraph FEEDBACK["Feedback"]
+    F1["doc-sync"]
+  end
+  subgraph SHIP["Ship"]
+    S1["pr-open"]
+  end
+  subgraph WATCH["Watchers"]
+    W1["deps"]
+    W2["devenv"]
+  end
+  subgraph ENFORCE["Enforce — hooks / CI"]
+    E1["description · diff-size · gitignore · format+lint · 7-day dep cooldown"]
+  end
+
+  DRIVE --> LENSES --> SHIP --> ENFORCE
+  LENSES --> FEEDBACK
+  WATCH -.-> DRIVE
+```
+
+### `STATE.md` — progress and backlog
+
+`sdk/STATE.md` is the human-readable, **committed** record of SDK development
+— distinct from the gitignored registers (§4), because progress is meant to
+be shared, not hidden. `mn-skills-spec-driver` maintains it as tranches land
+or slip, in three parts:
+
+- **Done** — completed tranches / PRs, each with its issue and PR links.
+- **In progress** — the tranche currently in the loop.
+- **Backlog** — tranches planned but **not completed** (deferred, blocked, or
+  descoped), each with a reason and its issue. This is where non-completed
+  tasks live so nothing is silently dropped.
+
+Because every entry carries an issue number (below), "what's done / what
+remains" is always traceable to the issue tracker.
+
+### Issue traceability
+
+Every per-feature spec **must name a GitHub issue** from
+[`midnightntwrk/passport/issues`](https://github.com/midnightntwrk/passport/issues).
+The chain runs **issue → spec → tranches → PRs → `STATE.md`**:
+
+- A spec without an issue → `mn-skills-spec-driver`'s plan phase **stops and
+  asks** before starting work.
+- `mn-skills-pr-open` links each PR back to that issue (`Refs #NN`, or
+  `Closes #NN` on the finishing tranche).
+- The hooks/CI gate checks the PR references its issue (§4).
+- `STATE.md` entries carry the issue number, closing the loop.
+
+---
+
+## 4. Enforcement layer (hooks / CI)
+
+Deterministic guarantees, run by the harness/CI rather than judged by a skill:
+
+- **PR description present**, referencing its spec tranche **and its GitHub
+  issue** (`Refs`/`Closes #NN`).
+- **Diff-size guardrail** — a soft warning past a threshold (advisory, so it
+  does not fight a legitimately larger change), pointing back to
+  `mn-skills-pr-open`'s split suggestion.
+- **Registers gitignored** — `.mn-skills/` is git-ignored; the security and
+  verify registers live there and never push.
+- **`STATE.md` committed** — `sdk/STATE.md` is *not* under `.mn-skills/`;
+  progress and backlog are shared project state, tracked in the repo.
+- **Format + lint** pass.
+- **7-day dependency cooldown** — CI rejects a lockfile that introduces a
+  package version published less than 7 days ago, unless an override marker
+  (with a recorded reason) is present.
+
+`.mn-skills/` joins the repo's existing gitignored working dirs (`.planning/`,
+`.serena/`).
+
+---
+
+## 5. Conventions adopted
+
+Stated so the doc is decisive; each is revisitable.
+
+- **Prefix** `mn-skills-` for every development skill.
+- **Specs are per-feature**, derived from `sdk/docs`; the big docs are the
+  source of truth.
+- **Two gitignored registers** under `.mn-skills/`: the *security register*
+  (owned by `security-audit`) and the *verify register* of provisional /
+  open-validation items (owned by `doc-sync`, fed by `verify`). Persistent
+  and appended — accepted risks and open validations accumulate and are
+  re-checked, not regenerated.
+- **The loop stops before outward actions** — it prepares PRs; it does not
+  push or open them without explicit human go.
+- **Enforcement in hooks/CI, judgment in skills.**
+- **Packaged as one `mn-skills` plugin** — the skills and their backing
+  hooks travel together.
+- **Every spec names a GitHub issue**; planning refuses to start without one.
+  Traceability runs issue → spec → tranches → PRs → `STATE.md`.
+- **`STATE.md` (committed)** tracks done / in-progress / backlog; the two
+  registers (gitignored) track residual risks and open validations.
+
+---
+
+## 6. Open items
+
+- Whether `mn-skills-verify` is a distinct skill or simply "the loop always
+  runs `/verify` before `pr-open`". Drafted here as distinct (it wraps
+  existing tooling and owns register entries), revisitable.
+- The exact diff-size threshold for the advisory guardrail.
+- Whether per-feature spec authoring warrants its own skill or stays inside
+  `spec-driver`'s plan phase.

--- a/sdk/docs/development-workflow.md
+++ b/sdk/docs/development-workflow.md
@@ -72,7 +72,7 @@ existing tooling it leans on (we wire, we do not reinvent).
 requirements + architecture: seam/adapter structure, package-dependency rules
 (`connect` never links `core`; deposits ride `contract` — arch §4.4), the
 normative MUSTs (ceremony gate §2.2, deposit-not-address §3.12,
-attestation-before-preimage §2.5), naming, and the two version axes. Its
+encrypt-preimage-to-enclave §2.5), naming, and the two version axes. Its
 checklist is *derived from* `sdk/docs`. Consulted at plan time so the plan
 aligns; enforced at review time so the code does.
 

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -164,7 +164,7 @@ Processes the SDK delegates behind provider interfaces:
 | Cross-chain (MCS) | Upstream MCS threshold-Schnorr | — (owned upstream) | [C25] |
 | Private storage / device-sync | Vendor keystore (native) or shared provider (#58) | Local-only (no cross-device sync) | [C16] · §3.6 |
 | Sync / indexing | Hosted indexer | Self-hosted indexer | [C17] |
-| Proving | Provider-routed (provider → its proving vendor, proof returned) · direct attested-TEE proof server (prove + broadcast) | In-tab WASM prover (low k) | [C6] · §2.5 |
+| Proving | Provider-routed (provider → its proving vendor, proof returned) · direct TEE proof server, encrypt-to-enclave (prove + broadcast) | In-tab WASM prover (low k) | [C6] · §2.5 |
 | Fees / DUST | Capacity Exchange LP marketplace (§3.11) | User-held DUST | [C24] |
 
 **Custody setup — waves.** At launch the wallet-infrastructure provider
@@ -188,7 +188,8 @@ secret / key material decrypted under the §2.2 ceremony. Path choice is
 therefore a privacy decision first and a performance decision second. The
 seam itself is the ledger's two-method `ProvingProvider` (`check`,
 `prove`), so every path is drop-in behind one interface; the SDK's
-contribution is the routing policy and the attestation check.
+contribution is the routing policy and, on the remote paths, encrypting the
+preimage to the prover's enclave.
 
 **Routing is a k-threshold decision tree**, not a flat menu:
 
@@ -213,19 +214,29 @@ contribution is the routing policy and the attestation check.
      explicit prerequisites ([C24]: who balances and signs fees before the
      server submits — Passport pre-balancing, or a sponsor at the server).
 
-**Attestation (both remote variants).** The witness leaves the device in 2a
-and 2b — and in 2b the server additionally sees the full transaction. The
-remote prover MUST run in a TEE and the SDK MUST verify remote attestation
-(enclave measurement + freshness, against a pinned known-good value)
-**before** any preimage is sent. An unattested "TEE prover" is just a
-plaintext hosted prover and is not an acceptable path. For 2a the same
-requirement applies transitively to the provider's vendor — pin down what
-that vendor attests to (§2.6).
+**Confidentiality to the enclave (both remote variants).** The witness
+leaves the device in 2a and 2b — and in 2b the server additionally sees the
+full transaction — so it must reach the prover **encrypted to the enclave**.
+That encryption is the SDK's job: it seals the preimage to the remote
+prover's **enclave public key** before it leaves the device, so the server
+operator (outside the enclave) sees only ciphertext and only code running
+inside the enclave can decrypt and prove.
+
+**The SDK does not perform remote attestation.** Verifying enclave
+measurements, freshness, and vendor-specific quotes is deliberately out of
+scope — too heavy for the SDK. Establishing that the enclave key genuinely
+belongs to a real TEE running trusted code is the **provider's / upstream's
+responsibility**; the SDK consumes a trusted enclave key from that layer
+(for 2a, from the provider's proving vendor — §2.6). *Residual risk
+(accepted; security register):* confidentiality then rests on the
+**provenance of that enclave key** — a non-enclave key substituted upstream
+would defeat the encryption. That trust is delegated by design, not
+verified in the SDK.
 
 Routing inputs remain (a) custody path, (b) circuit k, (c) device
 capability, and (d) privacy posture, with a fallback ladder (in-tab →
 remote on capability failure). The prover actually used MUST be surfaced
-truthfully to the user ("proved in this browser" / "proved in an attested
+truthfully to the user ("proved in this browser" / "proved in a remote
 enclave" / "proved by the provider") — and in 2b, that the transaction was
 **submitted by the proof server** — proof provenance is a user-facing
 guarantee, not a diagnostic.
@@ -302,11 +313,13 @@ existing seams — no redesign:
 The managed path then reduces to **Passport = build + orchestrate +
 broadcast; provider = prove (+ fee-pay)**. Two caveats travel with it:
 
-- **Privacy / attestation.** The proving payload embeds the witness, so
-  remote proving sends the witness to the provider's prover. This preserves
-  privacy only if that prover is an **attested TEE** (§2.5); a plain hosted
-  prover is provider-trust. Pin down which the provider's remote proof
-  server is.
+- **Privacy / enclave encryption.** The proving payload embeds the witness,
+  so remote proving sends it to the provider's prover **encrypted to the
+  prover's enclave key** (§2.5) — that encryption is the SDK's job.
+  Attestation that the enclave is genuine is the **provider's**
+  responsibility, not the SDK's; confidentiality then rests on the
+  provenance of the enclave key (accepted residual risk). Pin down the
+  provider's enclave-key provisioning.
 - **Fees are not proving.** A proof server proves; it does not pay DUST.
   "Just broadcast" holds only once the provider's wallet (or a sponsor) has
   balanced and fee-paid the transaction ([C24]).

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -60,7 +60,7 @@ presents multiple options behind stable interfaces and orchestrates
 whichever a deployment (or user) selects:
 
 - **Managed path (launch)** — wallet management is delegated to a
-  **wallet-infrastructure provider** (Dynamic at launch), which for
+  **wallet-infrastructure provider**, which for
   **Midnight** offers an embedded Midnight wallet (WaaS) or connects an
   extension (1am) and supplies auth (social / email / passkey), unified
   balances, external-wallet connectors, on-ramps, and fee abstraction. In
@@ -162,8 +162,8 @@ Processes the SDK delegates behind provider interfaces:
 | Cross-chain (MCS) | Upstream MCS threshold-Schnorr | — (owned upstream) | [C25] |
 | Private storage / device-sync | Vendor keystore (native) or shared provider (#58) | Local-only (no cross-device sync) | [C16] · §3.6 |
 | Sync / indexing | Hosted indexer | Self-hosted indexer | [C17] |
-| Proving | Managed-provider (bundled) · attested-remote TEE proof server | In-tab WASM prover (small-k circuits) | [C6] · §2.5 |
-| Fees | Sponsor service | User-held DUST | [C24] |
+| Proving | Provider-routed (provider → its proving vendor, proof returned) · direct attested-TEE proof server (prove + broadcast) | In-tab WASM prover (low k) | [C6] · §2.5 |
+| Fees / DUST | Capacity Exchange LP marketplace (§3.11) | User-held DUST | [C24] |
 
 **Custody setup — waves.** At launch the wallet-infrastructure provider
 holds the anchor key in a **TEE / secure enclave** (single enclave-held
@@ -172,128 +172,141 @@ setup — distributed key shares, no single point of assembly — is a
 second-wave feature**; it hardens the managed anchor without changing the
 §2.3 binding to the on-chain Jubjub key, so it is transparent to the ACC
 and to consumers. *On **Midnight** the provider's embedded custody is its
-**WaaS wallet** (`DynamicWaasMidnightConnectors`), which the prototype uses;
+**WaaS wallet** (its embedded-WaaS Midnight connector), which the prototype
+uses;
 an extension (1am) is the alternative. Either way, in the prototype the
 provider is the auth / presence gate over a browser-local device secret, not
 yet the cryptographic ACC anchor — see §2.6.*
 
 ### 2.5 Proving paths
 
-Proof generation ([C6]) is a **Prover seam** the SDK routes across three
-paths spanning a privacy / capability spectrum. What crosses the boundary
-is the proving *preimage*, which embeds the **witness** — the secret / key
-material decrypted under the §2.2 ceremony. Path choice is therefore a
-privacy decision first and a performance decision second. The seam itself
-is the ledger's two-method `ProvingProvider` (`check`, `prove`), so all
-three paths are drop-in behind one interface; the SDK's contribution is the
-routing policy and the attestation check.
+Proof generation ([C6]) is a **Prover seam** the SDK routes. What crosses
+the boundary is the proving *preimage*, which embeds the **witness** — the
+secret / key material decrypted under the §2.2 ceremony. Path choice is
+therefore a privacy decision first and a performance decision second. The
+seam itself is the ledger's two-method `ProvingProvider` (`check`,
+`prove`), so every path is drop-in behind one interface; the SDK's
+contribution is the routing policy and the attestation check.
 
-- **Managed-provider proving (launch, zero-config).** On the managed path
-  (§2.1) proving comes bundled with the wallet-infrastructure provider
-  integration. Trust follows the provider; nothing to stage, no device
-  cost.
-- **In-tab WASM prover (small-k circuits).** The `zkir-v2` prover runs in a
-  Web Worker on the user's device; the witness **never leaves the device**
-  — the strongest privacy posture, and the literal expression of [P8].
-  Bounded by device capability: suited to small-k circuits (the Night,
-  grant, device, and recovery paths — sub-MB keys, seconds), not the
-  large-k shielded path (tens of MB of keys, tens of seconds, memory
-  pressure). Requires one-time per-origin staging of SRS slices and keys.
-  Validated end-to-end in the account-custody prototype.
-- **Attested remote proof server (TEE).** A hosted proof server running in
-  a Trusted Execution Environment. The witness leaves the device, but only
-  into an **attested** enclave over an encrypted channel: the SDK MUST
-  verify remote attestation (enclave measurement + freshness, against a
-  pinned known-good value) **before** any preimage is sent. An unattested
-  "TEE prover" is just a plaintext hosted prover and is not an acceptable
-  path. Carries the large-k circuits the in-tab path cannot, without
-  surrendering witness confidentiality to a plaintext third party.
+**Routing is a k-threshold decision tree**, not a flat menu:
 
-Routing is a policy over (a) custody path, (b) circuit size / k, (c) device
+1. **k low enough → in-tab WASM prover.** The `zkir-v2` prover runs in a
+   Web Worker on the user's device; the witness **never leaves the device**
+   — the strongest privacy posture, and the literal expression of [P8].
+   Suited to the small-k circuits (the Night, grant, device, and recovery
+   paths — sub-MB keys, seconds); requires one-time per-origin staging of
+   SRS slices and keys. Validated end-to-end in the account-custody
+   prototype. The k-threshold is a **measured, configurable** value per
+   device class, not a constant baked into the SDK.
+2. **k too high → remote proving**, two variants:
+   - **2a. Provider-routed.** The wallet-infrastructure provider
+     routes the proving payload to its remote proof-server vendor and
+     returns the **proof**; Passport balances (fees, [C24]) and
+     **broadcasts from Passport** (the §2.6 target flow).
+   - **2b. Direct remote proof server (prove + broadcast).** Passport calls
+     the remote proof server itself; the server proves **and broadcasts the
+     transaction**, and Passport **waits for on-chain confirmation** rather
+     than receiving the proof back. Passport must hand over everything the
+     broadcast needs — which makes fee-balancing order and the fee-payer
+     explicit prerequisites ([C24]: who balances and signs fees before the
+     server submits — Passport pre-balancing, or a sponsor at the server).
+
+**Attestation (both remote variants).** The witness leaves the device in 2a
+and 2b — and in 2b the server additionally sees the full transaction. The
+remote prover MUST run in a TEE and the SDK MUST verify remote attestation
+(enclave measurement + freshness, against a pinned known-good value)
+**before** any preimage is sent. An unattested "TEE prover" is just a
+plaintext hosted prover and is not an acceptable path. For 2a the same
+requirement applies transitively to the provider's vendor — pin down what
+that vendor attests to (§2.6).
+
+Routing inputs remain (a) custody path, (b) circuit k, (c) device
 capability, and (d) privacy posture, with a fallback ladder (in-tab →
-attested-remote on capability failure). The prover actually used MUST be
-surfaced truthfully to the user ("proved in this browser" / "proved in an
-attested enclave" / "proved by the provider") — proof provenance is a
-user-facing guarantee, not a diagnostic.
+remote on capability failure). The prover actually used MUST be surfaced
+truthfully to the user ("proved in this browser" / "proved in an attested
+enclave" / "proved by the provider") — and in 2b, that the transaction was
+**submitted by the proof server** — proof provenance is a user-facing
+guarantee, not a diagnostic.
 
 ### 2.6 The managed path in detail
 
 The decentralised path is specified surface by surface below; this is its
 managed counterpart, grounded in the launch provider's actual Midnight
-integration (Dynamic, `@dynamic-labs/midnight`).
+integration.
 
 **Finding — the managed flow executes real ACC contract calls, with the
 provider as the auth / presence layer over the ACC (not the contract-call
-signer).** Grounded in the prototype's Dynamic flow (branch
+signer).** Grounded in the prototype's managed flow (branch
 `demo/mn-passport-dynamic-flow`, `experiments/account-custody-prototype`).
-Dynamic offers Midnight through *both* extension connectors
-(`MidnightWalletConnectors`, e.g. 1am) and an **embedded WaaS wallet**
-(`DynamicWaasMidnightConnectors`); the prototype uses the embedded WaaS
-path. In it, Dynamic supplies social-login auth, the embedded Midnight
+The provider offers Midnight through *both* extension connectors (e.g.
+1am) and an **embedded WaaS wallet**; the prototype uses the embedded WaaS
+path. In it, the provider supplies social-login auth, the embedded Midnight
 wallet (addresses / balances / keys), and a `signMessage` **presence
 gesture**. The ACC **device secret** (the hash-preimage witness) is gated by
-that Dynamic login, and ACC contract calls — deploy, deposit, grants,
+that provider login, and ACC contract calls — deploy, deposit, grants,
 recover — then run through **midnight-js exactly as on the decentralised
 path**, balanced and submitted by the demo's genesis fee wallet (a C24
-shortcut) — **Dynamic is not in the contract-call path at all**. So the
+shortcut) — **the provider is not in the contract-call path at all**. So the
 managed path needs only `signMessage` to *authorise* the ACC (the device
 secret does the in-circuit auth); it never asks the provider to sign the
 contract call. What it leaves unproven is who **balances and submits** the
 contract transaction in production — see the reconciliation gap below.
 
-| Surface | Managed path (Dynamic) |
+| Surface | Managed path (launch provider) |
 |---|---|
-| Onboarding | Dynamic auth (social / email / passkey) via `DynamicContextProvider`; embedded Midnight wallet via `DynamicWaasMidnightConnectors` (or an extension via `MidnightWalletConnectors`). |
-| Custody / signing | ACC device secret gated by the Dynamic login (a `signMessage` gesture); ACC contract calls run via midnight-js. The provider authenticates and holds the embedded wallet; it does **not** sign the contract calls. |
+| Onboarding | Provider auth (social / email / passkey) via its app context; embedded Midnight wallet via its embedded-WaaS connector (or an extension via its wallet connectors). |
+| Custody / signing | ACC device secret gated by the provider login (a `signMessage` gesture); ACC contract calls run via midnight-js. The provider authenticates and holds the embedded wallet; it does **not** sign the contract calls. |
 | Addresses | Unshielded `wallet.address`; shielded / DUST via `additionalAddresses`; `getShieldedAddresses()` → coin + encryption public keys. |
 | Assets | `getBalances()` / `getShieldedBalance()` / …; `sendBalance({toAddress, amount})`, pool-routed (no cross-pool transfers). |
-| Proving | Provider routes to a remote prover vendor (§2.5 managed path). |
-| Ceremony | Dynamic's `signMessage` / passkey gate (§2.2). |
-| External wallets / on-ramps | Dynamic connectors (§3.10 managed variant). |
+| Proving | Provider routes to its remote proving vendor (§2.5 path 2a). |
+| Ceremony | The provider's `signMessage` / passkey gate (§2.2). |
+| External wallets / on-ramps | Provider connectors (§3.10 managed variant). |
 
 **Reconciliation with the ACC — ACC-centric and demonstrated, with one
 caveat.** The managed flow produces a real ACC with device-secret auth and
 the full contract-call set, so the managed path *is* ACC-centric — one
 account model, progressive decentralisation preserved. *Authorisation* is
-settled: it is the device secret, not a provider signature, so Dynamic never
-signs the contract call. **But fee-payment and submission are a separate
-question the demo dodges:** the contract transaction is balanced and
-submitted by the **genesis wallet** (C24 out of scope), *not* by Dynamic. So
-whether the managed (Dynamic) wallet can itself **balance and submit an
-arbitrary ACC contract transaction** — beyond `sendBalance` transfers — is
-**not proven** and is a verify item ([C24]: in production the managed wallet
-or a sponsor must pay DUST and submit).
+settled: it is the device secret, not a provider signature, so the provider
+never signs the contract call. **But fee-payment and submission are a
+separate question the demo dodges:** the contract transaction is balanced
+and submitted by the **genesis wallet** (C24 out of scope), *not* by the
+provider. So whether the managed (provider-held) wallet can itself
+**balance and submit an arbitrary ACC contract transaction** — beyond
+`sendBalance` transfers — is **not proven** and is a verify item ([C24]: in
+production the managed wallet or a sponsor must pay DUST and submit).
 
 *Remaining gap (the prototype is demo-grade here).* Its device secret is a
-**random, browser-local** value merely *gated* by the Dynamic login — not
-cryptographically derived from or bound to the Dynamic key, and not portable
+**random, browser-local** value merely *gated* by the provider login — not
+cryptographically derived from or bound to the provider's key, and not
+portable
 (cross-browser reconnect deliberately fails). The v1 target is the true §2.3
 binding: the managed key cryptographically anchors the ACC authoriser so it
 is portable and recoverable, not just an auth gate over a local secret.
 
-**Target managed proving + submit flow (Dynamic remote proof server,
-forthcoming).** Dynamic is working towards incorporating a remote proof
-server. Once it lands, the managed path splits cleanly along the existing
-seams — no redesign:
+**Target managed proving + submit flow (provider remote proof server,
+forthcoming).** The provider is working towards incorporating a remote
+proof server. Once it lands, the managed path splits cleanly along the
+existing seams — no redesign:
 
 1. **Build** — Passport builds the unproven ACC contract call and holds the
    witness (device secret + private inputs).
-2. **Prove** — offloaded to Dynamic's remote proof server
-   (`adapter-prover-remote`, §2.5) → returns the proof.
-3. **Balance / fees** — Dynamic's embedded wallet (or a sponsor) adds DUST
-   fee inputs and signs ([C24]).
+2. **Prove** — offloaded to the provider's remote proof server
+   (`adapter-prover-remote`, §2.5 path 2a) → returns the proof.
+3. **Balance / fees** — the provider's embedded wallet (or a sponsor) adds
+   DUST fee inputs and signs ([C24]).
 4. **Broadcast** — Passport submits the assembled, proven, balanced
    transaction to the node (a trivial submit provider).
 
 The managed path then reduces to **Passport = build + orchestrate +
-broadcast; Dynamic = prove (+ fee-pay)**. Two caveats travel with it:
+broadcast; provider = prove (+ fee-pay)**. Two caveats travel with it:
 
 - **Privacy / attestation.** The proving payload embeds the witness, so
-  remote proving sends the witness to Dynamic's prover. This preserves
+  remote proving sends the witness to the provider's prover. This preserves
   privacy only if that prover is an **attested TEE** (§2.5); a plain hosted
-  prover is provider-trust. Pin down which Dynamic's remote proof server is.
+  prover is provider-trust. Pin down which the provider's remote proof
+  server is.
 - **Fees are not proving.** A proof server proves; it does not pay DUST.
-  "Just broadcast" holds only once Dynamic's wallet (or a sponsor) has
+  "Just broadcast" holds only once the provider's wallet (or a sponsor) has
   balanced and fee-paid the transaction ([C24]).
 
 ## 3. Functional surfaces
@@ -499,6 +512,76 @@ peer, fund / bridge from its Cardano side, and bind its Cardano identity.
 The `adapter-wallet-connect` client (architecture §4.2) feeds all three:
 binding → signer / §2.3, funding → [C25], coexistence → the §3.9 surface.
 Which mode(s) ship first is a v1 delivery-scope question.
+
+### 3.11 DUST sponsorship — Capacity Exchange
+
+Fees on Midnight are paid in DUST, which is non-transferable — the
+zero-DUST user is the [C24] problem. **Capacity Exchange** is the
+ecosystem's answer: a DUST-sponsorship marketplace in which liquidity
+providers (LPs), running open-source servers, sell DUST capacity so a user
+holding zero DUST can still transact. The SDK MUST support it as the
+sponsored fill of the **Fee seam** (`adapter-fee-capacity-exchange`), with
+user-held DUST as the provider-free default.
+
+**Flow (current upstream design — explicitly pre-launch, not the final
+launch workflow):**
+
+1. A dApp action requires DUST the user does not hold.
+2. The SDK requests quotes from LPs — **pure API, no on-chain transaction**
+   (upstream flags this as critical for launch usability).
+3. LPs return quotes: "I'll sponsor X DUST if you pay Y in token Z."
+4. The user selects a quote.
+5. The LP returns a **partial Midnight transaction**: an intent supplying
+   the DUST, plus an intent encoding the payment the LP expects (e.g. a
+   zSwap offer / payment leg).
+6. The SDK attaches the user's own dApp intent, supplies the input funds so
+   the transaction balances, and submits — ceremony-gated (§2.2), since the
+   composed transaction spends the user's token Z.
+
+This is intent composition on the ledger's `Intent` primitive — [C24]
+already names `dust_actions` as the protocol primitive, and the abstraction
+Passport presents over intents is the [C22] workstream. Steps 2–4 are
+off-chain; nothing touches the chain until the user commits.
+
+**Adapter requirements** (tracking the upstream "Sponsor" spec, in
+progress):
+
+- **One-method surface** — a dApp (or Passport flow) calls one method and
+  reliably gets a sponsored transaction back.
+- **Quote lifecycle** — expiry, replay protection, and handling for users
+  who abandon after selecting a quote.
+- **Token filtering** — only offer payment tokens the user actually holds
+  (needs the balance surface).
+- **LP preferences / whitelists** — which LPs to solicit and trust;
+  substitutable per [P8]. Upstream's fast-follow is a wallet-native API
+  where preferences make the UX mostly invisible — that wallet-native
+  surface is Passport's natural home.
+- **Quote-request privacy** — a quote request discloses spend-intent
+  metadata (amount class, payment token) to every solicited LP before any
+  commitment; solicit the minimum set per the whitelist.
+- **Packaging** — upstream ships a JS SDK plus an optional React
+  quote-selection component; the adapter wraps the upstream SDK, and the
+  official UI may consume or re-brand the selection component (upstream's
+  success criterion is that integrators can brand and customise copy).
+
+**Limits and phases:**
+
+- Capacity Exchange solves zero-DUST for a user who holds *some* payable
+  token. The fully-empty user at onboarding (ACC deploy + name claim,
+  §3.1) still needs a sponsor / faucet answer — [C24] remains open for that
+  case.
+- **Bridge-assisted payment** (multisig-operated bridge; in principle any
+  bridge) is upstream work-in-progress and composes with §3.10's
+  fund / bridge mode.
+- **Phase 2 (upstream roadmap):** wallet-native sponsor transactions and
+  preference management, and **passive LP leasing via auction** — a user
+  deposits "DUST rights" into a contract, active LPs bid, and the user
+  earns the bid proceeds. For Passport that is a future *earn* surface over
+  the user's DUST rights; out of v1 scope, noted so the Fee seam does not
+  preclude it.
+- Interplay with §2.5 path 2b: a sponsored partial transaction is one
+  candidate answer to "who balances and fee-pays before a prove+broadcast
+  server submits".
 
 ## 4. Reference implementations (UI / App)
 

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -1,0 +1,522 @@
+# Midnight Passport SDK — High-Level Requirements (Draft)
+
+> **Scope of this document.** High-level requirements and design
+> principles — the *what* and *why* of the SDK. Detailed component specs,
+> architecture, and diagrams are separate documents under `sdk/docs/`.
+
+> **Status:** draft · 2026/07/17
+> **Audience:** Passport prototype team, Midnight Foundation, partner wallet
+> and dApp developers.
+> **Traceability:** each requirement is anchored to a component canvas
+> (`[C…]`, [components](../../docs/plans/components/README.md)) or promise (`[P…]`,
+> [PROMISES.md](../../docs/plans/PROMISES.md)) so this document inherits
+> decisions already recorded there.
+
+## 1. Purpose
+
+The Passport SDK is the primary programmatic surface for Midnight Passport.
+It is the **main connector to the Account Custody Contract (ACC, [C1])**:
+every capability below is ultimately a mediated interaction with a user's
+account object on-chain.
+
+The SDK is an **orchestrator, not a monolith**. It owns the flows and the
+interfaces; heavy or trust-sensitive machinery lives behind substitutable
+providers.
+
+### 1.1 The Account Custody Contract (ACC)
+
+The **Account Custody Contract** is the centre of the Passport
+architecture — the on-chain object that *is* the user's account. Identity
+in Passport is the ACC, not any key: keys are revocable authorisers *of*
+the account, while the ACC is the durable identity that outlives them.
+This inversion is what makes seedless onboarding, multi-device, revocation,
+and recovery possible at all ([C1], and the custody model in [C4]).
+
+A single per-user ACC holds:
+
+- the **device set** — the authoriser keys that may act for the account
+  ([C5], [C9]);
+- the **name binding** — the account's `passport.night` sub-domain ([C2]);
+- **grants** — scoped, revocable capabilities issued to dApps and to the
+  user's own sessions ([C10], [C11], [C12]);
+- the user's **Midnight-native assets**, held statelessly in the contract
+  per the resolved custody model ([C4]).
+
+**The SDK interacts primarily with the ACC.** Almost every functional
+surface in §3 resolves to a read of, or an authorised state transition on,
+the user's ACC — onboarding deploys it, device and grant management mutate
+it, recovery re-authorises against it, and dApp connections write grants
+into it. Providers (§2.4) sit *beside* this relationship, supplying
+authorisers, storage, or settlement; they never replace the ACC as the
+seat of the account. Everything downstream in this document should be read
+against that centre.
+
+## 2. Design principles
+
+### 2.1 Multiple custody paths, progressive decentralisation
+
+The SDK does not bind to a single custody or authentication path. It
+presents multiple options behind stable interfaces and orchestrates
+whichever a deployment (or user) selects:
+
+- **Managed path (launch)** — wallet management is delegated to a
+  **wallet-infrastructure provider** (Dynamic at launch), which for
+  **Midnight** offers an embedded Midnight wallet (WaaS) or connects an
+  extension (1am) and supplies auth (social / email / passkey), unified
+  balances, external-wallet connectors, on-ramps, and fee abstraction. In
+  the prototype's managed flow the provider is the **auth / presence layer
+  over the ACC**: it gates the ACC device secret, and ACC contract calls run
+  through midnight-js. Detailed surface by surface in §2.6. ([C9] managed
+  branch.)
+- **Decentralised path (target)** — the passkey-derived on-device key
+  (WebAuthn + PRF) is verified directly in-circuit by the ACC ([C1], [C5],
+  [C9]). No external provider sits in the trust path.
+
+**Progressive decentralisation is a first-class requirement.** Users start
+on the centralised solution and migrate toward decentralised components as
+they mature. Because identity lives in the ACC — not in any key — migration
+is an *authoriser swap*: add the decentralised device key to the account's
+device set, then retire the provider-held authoriser. Account identity,
+name, grants, and assets are untouched. The SDK MUST expose this migration
+as a supported flow, per path, per process (custody, recovery, signing).
+
+Providers are an option, never a dependency ([P8]'s substitutability:
+indexer [C17], helper [C15], sponsor [C24]). The provider-free path MUST
+remain viable at every release.
+
+### 2.2 User-presence ceremony on every transaction
+
+**Every transaction confirmation requires a passkey or password ceremony.**
+This is not (only) UX policy — it is how the witness-security model works:
+
+- Each connected dApp's private state / witness material is stored
+  **encrypted at rest** in wallet local storage ([C16], [C7]).
+- The decryption key is derived from the user ceremony — passkey (PRF
+  evaluation, preferred) or password (KDF fallback where PRF is
+  unavailable).
+- Witness decryption therefore *cannot happen* without user presence: no
+  silent signing, no ambient authority. A compromised app process without
+  the user cannot produce a proof.
+- Decrypted witness material is held in memory only for the duration of
+  proof generation ([C6], [C7]) and zeroised after.
+
+This holds on **both** custody paths: on the managed path the provider's
+enclave enforces the same passkey gate before its key shares participate;
+on the decentralised path the ceremony gates local witness decryption
+directly.
+
+### 2.3 Signing and external-identity binding
+
+**Account operations verify Schnorr-on-Jubjub in-circuit ([C5],
+unchanged for now).** Today Jubjub is the only curve with native Compact
+built-ins (`ecMulGenerator`, `ecMul`, `ecAdd`); P-256 / secp256k1 ECDSA
+inside a Compact circuit would require foreign-field arithmetic the
+language does not *currently* express, at ~15K–25K constraints per
+verification against a few hundred native (see
+[`p256-passkey-nightstream-prototype.md`](../../docs/reference/machine-investigation/p256-passkey-nightstream-prototype.md)).
+
+> **Landing soon.** ECDSA support is on the roadmap for both Compact and
+> the ledger. Once in-circuit ECDSA verification is available at
+> acceptable cost, the binding pattern below stops being a workaround and
+> becomes a *choice* — external ECDSA identities could then be verified
+> directly, or the account primitive itself could move to ECDSA. The
+> binding pattern is the correct design **until that lands**, and remains
+> valid after it as the cheap-routine-signing option regardless.
+
+The broader ECDSA ecosystem — WebAuthn passkeys (hardware-locked to P-256),
+the wallet-infrastructure provider's enclave-held ECDSA key, secp256k1
+wallets, secure enclaves, and HSMs — attaches through a **one-time signed
+binding** rather than a curve switch:
+
+- **ECDSA is the identity gate, Jubjub is the signing mechanism.** At
+  enrolment, the external ECDSA identity signs a binding message
+  authorising a Jubjub account key; the binding is committed against the
+  ACC as a typed device entry. Routine transactions verify cheap native
+  Schnorr — ECDSA never enters the routine proof path.
+- **Decentralised path** — the passkey's P-256 credential binds the
+  PRF-derived Jubjub device key.
+- **Managed path** — the v1 target is that the managed wallet's key
+  cryptographically anchors an ACC authoriser (portable, recoverable). In
+  the prototype the provider instead *gates* a browser-local device secret
+  via a `signMessage` presence gesture (§2.2), and that device secret
+  authorises ACC operations in-circuit. See §2.6 for the managed path in
+  full and the demo-grade gap to the true binding.
+- **External wallets** — an external wallet on any foreign scheme
+  (secp256k1, Ed25519) attaches as an authoriser through the same binding;
+  this is the mechanism behind external wallet connections (§3.10).
+
+This preserves the account-authorisation MIP draft, the validated
+`redjubjub-wallet` / `redjubjub-wallet-rs` experiments, the FROST threshold
+profile, and the `midnight-did-jubjub-schnorr` alignment (§3.7), while
+giving every ECDSA-native integration a first-class attachment point.
+
+### 2.4 Provider model
+
+Processes the SDK delegates behind provider interfaces:
+
+| Process | Launch provider | Decentralised counterpart | Anchors |
+|---|---|---|---|
+| Wallet management / signing | Wallet-infrastructure provider — embedded WaaS or extension wallet; auth / presence gate over the ACC device secret (§2.6) | On-device passkey-PRF Jubjub key, in-circuit verification | [C5], [C9] |
+| Account recovery | Provider recovery flows | Stateless guardians + paper keys | [C13], [C14], [C15] |
+| External wallet connectivity | Wallet-infrastructure provider (wallet connectors, on-ramps) | dApp-connection surface, cross-chain intents | [C23], [C25] |
+| Cross-chain (MCS) | Upstream MCS threshold-Schnorr | — (owned upstream) | [C25] |
+| Private storage / device-sync | Vendor keystore (native) or shared provider (#58) | Local-only (no cross-device sync) | [C16] · §3.6 |
+| Sync / indexing | Hosted indexer | Self-hosted indexer | [C17] |
+| Proving | Managed-provider (bundled) · attested-remote TEE proof server | In-tab WASM prover (small-k circuits) | [C6] · §2.5 |
+| Fees | Sponsor service | User-held DUST | [C24] |
+
+**Custody setup — waves.** At launch the wallet-infrastructure provider
+holds the anchor key in a **TEE / secure enclave** (single enclave-held
+key, passkey-gated). The provider's **MPC / threshold-signature (TSS)
+setup — distributed key shares, no single point of assembly — is a
+second-wave feature**; it hardens the managed anchor without changing the
+§2.3 binding to the on-chain Jubjub key, so it is transparent to the ACC
+and to consumers. *On **Midnight** the provider's embedded custody is its
+**WaaS wallet** (`DynamicWaasMidnightConnectors`), which the prototype uses;
+an extension (1am) is the alternative. Either way, in the prototype the
+provider is the auth / presence gate over a browser-local device secret, not
+yet the cryptographic ACC anchor — see §2.6.*
+
+### 2.5 Proving paths
+
+Proof generation ([C6]) is a **Prover seam** the SDK routes across three
+paths spanning a privacy / capability spectrum. What crosses the boundary
+is the proving *preimage*, which embeds the **witness** — the secret / key
+material decrypted under the §2.2 ceremony. Path choice is therefore a
+privacy decision first and a performance decision second. The seam itself
+is the ledger's two-method `ProvingProvider` (`check`, `prove`), so all
+three paths are drop-in behind one interface; the SDK's contribution is the
+routing policy and the attestation check.
+
+- **Managed-provider proving (launch, zero-config).** On the managed path
+  (§2.1) proving comes bundled with the wallet-infrastructure provider
+  integration. Trust follows the provider; nothing to stage, no device
+  cost.
+- **In-tab WASM prover (small-k circuits).** The `zkir-v2` prover runs in a
+  Web Worker on the user's device; the witness **never leaves the device**
+  — the strongest privacy posture, and the literal expression of [P8].
+  Bounded by device capability: suited to small-k circuits (the Night,
+  grant, device, and recovery paths — sub-MB keys, seconds), not the
+  large-k shielded path (tens of MB of keys, tens of seconds, memory
+  pressure). Requires one-time per-origin staging of SRS slices and keys.
+  Validated end-to-end in the account-custody prototype.
+- **Attested remote proof server (TEE).** A hosted proof server running in
+  a Trusted Execution Environment. The witness leaves the device, but only
+  into an **attested** enclave over an encrypted channel: the SDK MUST
+  verify remote attestation (enclave measurement + freshness, against a
+  pinned known-good value) **before** any preimage is sent. An unattested
+  "TEE prover" is just a plaintext hosted prover and is not an acceptable
+  path. Carries the large-k circuits the in-tab path cannot, without
+  surrendering witness confidentiality to a plaintext third party.
+
+Routing is a policy over (a) custody path, (b) circuit size / k, (c) device
+capability, and (d) privacy posture, with a fallback ladder (in-tab →
+attested-remote on capability failure). The prover actually used MUST be
+surfaced truthfully to the user ("proved in this browser" / "proved in an
+attested enclave" / "proved by the provider") — proof provenance is a
+user-facing guarantee, not a diagnostic.
+
+### 2.6 The managed path in detail
+
+The decentralised path is specified surface by surface below; this is its
+managed counterpart, grounded in the launch provider's actual Midnight
+integration (Dynamic, `@dynamic-labs/midnight`).
+
+**Finding — the managed flow executes real ACC contract calls, with the
+provider as the auth / presence layer over the ACC (not the contract-call
+signer).** Grounded in the prototype's Dynamic flow (branch
+`demo/mn-passport-dynamic-flow`, `experiments/account-custody-prototype`).
+Dynamic offers Midnight through *both* extension connectors
+(`MidnightWalletConnectors`, e.g. 1am) and an **embedded WaaS wallet**
+(`DynamicWaasMidnightConnectors`); the prototype uses the embedded WaaS
+path. In it, Dynamic supplies social-login auth, the embedded Midnight
+wallet (addresses / balances / keys), and a `signMessage` **presence
+gesture**. The ACC **device secret** (the hash-preimage witness) is gated by
+that Dynamic login, and ACC contract calls — deploy, deposit, grants,
+recover — then run through **midnight-js exactly as on the decentralised
+path**, balanced and submitted by the demo's genesis fee wallet (a C24
+shortcut) — **Dynamic is not in the contract-call path at all**. So the
+managed path needs only `signMessage` to *authorise* the ACC (the device
+secret does the in-circuit auth); it never asks the provider to sign the
+contract call. What it leaves unproven is who **balances and submits** the
+contract transaction in production — see the reconciliation gap below.
+
+| Surface | Managed path (Dynamic) |
+|---|---|
+| Onboarding | Dynamic auth (social / email / passkey) via `DynamicContextProvider`; embedded Midnight wallet via `DynamicWaasMidnightConnectors` (or an extension via `MidnightWalletConnectors`). |
+| Custody / signing | ACC device secret gated by the Dynamic login (a `signMessage` gesture); ACC contract calls run via midnight-js. The provider authenticates and holds the embedded wallet; it does **not** sign the contract calls. |
+| Addresses | Unshielded `wallet.address`; shielded / DUST via `additionalAddresses`; `getShieldedAddresses()` → coin + encryption public keys. |
+| Assets | `getBalances()` / `getShieldedBalance()` / …; `sendBalance({toAddress, amount})`, pool-routed (no cross-pool transfers). |
+| Proving | Provider routes to a remote prover vendor (§2.5 managed path). |
+| Ceremony | Dynamic's `signMessage` / passkey gate (§2.2). |
+| External wallets / on-ramps | Dynamic connectors (§3.10 managed variant). |
+
+**Reconciliation with the ACC — ACC-centric and demonstrated, with one
+caveat.** The managed flow produces a real ACC with device-secret auth and
+the full contract-call set, so the managed path *is* ACC-centric — one
+account model, progressive decentralisation preserved. *Authorisation* is
+settled: it is the device secret, not a provider signature, so Dynamic never
+signs the contract call. **But fee-payment and submission are a separate
+question the demo dodges:** the contract transaction is balanced and
+submitted by the **genesis wallet** (C24 out of scope), *not* by Dynamic. So
+whether the managed (Dynamic) wallet can itself **balance and submit an
+arbitrary ACC contract transaction** — beyond `sendBalance` transfers — is
+**not proven** and is a verify item ([C24]: in production the managed wallet
+or a sponsor must pay DUST and submit).
+
+*Remaining gap (the prototype is demo-grade here).* Its device secret is a
+**random, browser-local** value merely *gated* by the Dynamic login — not
+cryptographically derived from or bound to the Dynamic key, and not portable
+(cross-browser reconnect deliberately fails). The v1 target is the true §2.3
+binding: the managed key cryptographically anchors the ACC authoriser so it
+is portable and recoverable, not just an auth gate over a local secret.
+
+**Target managed proving + submit flow (Dynamic remote proof server,
+forthcoming).** Dynamic is working towards incorporating a remote proof
+server. Once it lands, the managed path splits cleanly along the existing
+seams — no redesign:
+
+1. **Build** — Passport builds the unproven ACC contract call and holds the
+   witness (device secret + private inputs).
+2. **Prove** — offloaded to Dynamic's remote proof server
+   (`adapter-prover-remote`, §2.5) → returns the proof.
+3. **Balance / fees** — Dynamic's embedded wallet (or a sponsor) adds DUST
+   fee inputs and signs ([C24]).
+4. **Broadcast** — Passport submits the assembled, proven, balanced
+   transaction to the node (a trivial submit provider).
+
+The managed path then reduces to **Passport = build + orchestrate +
+broadcast; Dynamic = prove (+ fee-pay)**. Two caveats travel with it:
+
+- **Privacy / attestation.** The proving payload embeds the witness, so
+  remote proving sends the witness to Dynamic's prover. This preserves
+  privacy only if that prover is an **attested TEE** (§2.5); a plain hosted
+  prover is provider-trust. Pin down which Dynamic's remote proof server is.
+- **Fees are not proving.** A proof server proves; it does not pay DUST.
+  "Just broadcast" holds only once Dynamic's wallet (or a sponsor) has
+  balanced and fee-paid the transaction ([C24]).
+
+## 3. Functional surfaces
+
+### 3.1 Onboarding orchestrator
+
+End-to-end account creation from a single ceremony:
+
+1. **Map the credential** — WebAuthn registration plus PRF evaluation to
+   derive key material ([C9]); on the managed path, provider onboarding
+   (email / social) followed by passkey creation.
+2. **Deploy the ACC** for the new account ([C1]).
+3. **Claim the name** — a free, first-come-first-served sub-domain of
+   `passport.night` (e.g. `alice.passport.night`) via the upstream name
+   service ([C2]).
+4. **Anchor the DID** — create the account's `did:midnight` identifier
+   (§3.7).
+
+### 3.2 dApp authentication and authorisation
+
+The SDK is the client half of the dApp connection surface:
+
+- Authenticate to third-party Midnight dApps — Sign-In-with-Passport over
+  the CAIP-25-shaped, EIP-6963-discoverable connection protocol ([C23]).
+- Manage a distinct, **encrypted** private state per dApp ([C16], §2.2).
+- OAuth-style access: grant, scope, and revoke capabilities to dApps as
+  scoped grants, enforced chain-side ([C10], [C11], [C12]).
+- Every dApp-initiated transaction is confirmed by the user ceremony
+  (§2.2); the ceremony decrypts only *that dApp's* witness state.
+
+### 3.3 Cross-chain orchestration (MCS)
+
+- Bridge tokens in and out from external networks by producing user-signed
+  trade intents and consuming settlement confirmations across the upstream
+  Multi-Chain Signature boundary ([C25]).
+- The cross-chain machinery is owned upstream; the SDK integrates against
+  it. Passport-side integration is sequenced post-v1.0 initial release.
+
+### 3.4 Account recovery
+
+- Drive both recovery paths: lost-device revocation ([C13]) and total-loss
+  recovery via stateless guardians and paper keys, over the helper protocol
+  ([C14], [C15]).
+- On the managed path, recovery is delegated to the provider's flows; on
+  the decentralised path it runs against the ACC and on-device key material
+  directly. Migration between the two follows §2.1.
+
+### 3.5 Multi-device management
+
+- Add, list, and remove credentials against the account's device set —
+  including the 1-of-n / last-device guard ([C1], [C9], [C13]).
+- On the decentralised path, device authorisations are verified in-circuit
+  by the ACC; on the managed path they are delegated to the provider.
+
+### 3.6 Private local-storage management
+
+- Persist and manage the wallet's encrypted private state on-device:
+  wrapped key material, sync state, name ownership, and per-dApp witness
+  state ([C16]), plus the view-key / indexer read path ([C17]).
+- The encryption envelope is keyed from the user ceremony (§2.2).
+- **In scope:** the shared private-storage provider —
+  midnightntwrk/passport#58.
+
+**Cross-device sync (backup and recovery).** Local private state must sync
+across a user's devices so a replacement device can be provisioned and so
+state survives device loss — answering the [C16] open question ("does
+wallet state sync, or does each device keep independent storage over a
+shared chain-derived view"). Four normative rules:
+
+- **Minimise what syncs.** Only *non-reconstructable* secrets sync —
+  chiefly per-dApp witness inputs and recovery material. Anything
+  re-derivable is never synced: the device authoriser key is re-derived
+  from the passkey PRF (§2.1) and chain-visible state is rebuilt from the
+  view-key / indexer ([C17]). This is what keeps the blob at a few KB.
+- **Encrypt before sync, under a key the sync channel does not hold.** The
+  blob is sealed under the ceremony envelope (§2.2) before it leaves the
+  device; the transport sees ciphertext only. Critically, the envelope key
+  MUST be independent of any secret that channel already holds — if the
+  passkey both derives the envelope key *and* syncs through the same vendor
+  account, the vendor holds lock and key together and the end-to-end
+  property collapses.
+- **Vendor keystore is one adapter, not the mechanism.** Device-vendor sync
+  (Apple Keychain synchronizable items / iCloud Keychain; Android Block
+  Store or Keystore-backed backup) is attractive — no Passport-operated
+  infrastructure, platform E2E encryption, KB-scale items — but it is a
+  **native-platform capability**: a browser / PWA cannot write sync blobs
+  to it, and it does **not** cross ecosystems (Apple ↔ Android, or either ↔
+  web). It is therefore the native adapter behind a **Storage / sync seam**
+  whose portable counterpart is the shared private-storage provider (#58);
+  the web path uses the latter or accepts no sync. Cross-ecosystem
+  multi-device ([P3]) is satisfied only by the portable adapter.
+- **Sync is not recovery.** Vendor-synced backup is a convenience and a
+  fast-provisioning path; it is not a substitute for total-loss recovery
+  ([C14]/[C15]), which must work even when the vendor account is lost. Keep
+  C14 as the floor and treat vendor sync as an optimisation layered above
+  it — never an undesigned recovery authority.
+
+### 3.7 DID integration
+
+The SDK integrates with the
+[`midnight-did`](https://github.com/midnightntwrk/midnight-did) project —
+the reference implementation of the **`did:midnight`** method ([C3]):
+
+- **Create / update** — the SDK drives DID operations through
+  `@midnight-ntwrk/midnight-did-api`, anchored to the same account the ACC
+  represents. DID creation is part of onboarding (§3.1).
+- **Resolution** — DID documents resolve via the `midnight-did-resolver`
+  services against the indexer; responses follow DID Core
+  (`didDocument`, `didResolutionMetadata`, `didDocumentMetadata`).
+- **Signature alignment** — `midnight-did` ships
+  `@midnight-ntwrk/midnight-did-jubjub-schnorr`; this is the same
+  Schnorr-on-Jubjub primitive as [C5]. The requirement is **one signing
+  primitive** across ACC authorisation and DID operations — the SDK MUST
+  NOT introduce a second key hierarchy for DIDs.
+- **Credentials** — verifiable credentials over DIDs are delivered by
+  `midnight-verifiable-credentials` and connect to the attestation /
+  selective-disclosure components ([C18]–[C21]); the SDK exposes them
+  through the same surface.
+
+Open (tracked in [C3]): the exact relationship between
+`alice.passport.night`, the ACC address, and the `did:midnight` identifier
+— alias vs distinct-layer.
+
+### 3.9 dApp connector (developer-facing)
+
+Passport is **two-sided**. §3.2 is the *wallet* half — the SDK answering
+connection requests on behalf of the account. This surface is the **dApp
+half**: a lightweight connector a third-party developer imports so their
+dApp can rely on Passport — the other end of the same [C23] protocol
+(CAIP-25-shaped, EIP-6963-discoverable). The connector lets a dApp:
+
+- **Log in with Passport** — Sign-In-with-Passport / DecentralisedAuth
+  ([C23]); the dApp obtains an authenticated `alice.passport.night` session
+  and never handles keys.
+- **Request scoped grants** — operation × object × bound ([C10]/[C11]),
+  approved by the user under the ceremony (§2.2) and enforced on-chain by
+  the ACC ([C12]).
+- **Have its contract witnesses provisioned from Passport storage** —
+  instead of the dApp configuring its own `privateStateProvider`, the
+  user's Passport profile supplies witness values when the dApp's
+  `witness.ts` runs for a contract execution (the shared private-storage
+  provider, midnightntwrk/passport#58, over [C16]).
+
+**Security framing of witness provisioning (normative).** Passport-supplied
+private state MUST be **scoped, consented, and ceremony-gated**: a dApp
+reads only the private-state entries the user has granted it, released
+under a §2.2 ceremony, never blanket access to the profile. The shared
+provider is a Passport-mediated, per-dApp, consented read surface — not a
+data handout; otherwise it is a privacy hole.
+
+**Authorisation through-line.** Devices, agents (§3.8), and dApps are all
+principals holding scoped grants on the ACC ([C10]/[C11]/[C12]); they
+differ only in how the grant is issued and gated — device by passkey
+ceremony (§2.2), agent by OWS policy engine (§3.8), dApp by user consent
+plus ceremony. One primitive, three issuance paths.
+
+**Packaging.** The connector is a **separate, thin package**
+(`@midnight-ntwrk/mn-passport-connect`-shaped) with a minimal dependency footprint and its
+own threat model. A dApp MUST NOT pull in the wallet / custody / kernel
+core to integrate; the connector speaks the C23 protocol *to* the wallet
+across a trust boundary and never links against it.
+
+### 3.10 External wallet connections
+
+Passport connects to a user's **existing wallets**. The initial targets
+span three ecosystems and are **not** one integration — they attach by
+different mechanisms:
+
+| Wallet | Ecosystem / curve | Connection standard |
+|---|---|---|
+| Lace | Midnight + Cardano / Ed25519 | Midnight connector · CIP-30 |
+| 1am | Midnight | Midnight connector |
+| Gero | Midnight + Cardano / Ed25519 | Midnight connector · CIP-30 |
+| MetaMask | EVM / secp256k1 | EIP-6963 / EIP-1193 |
+| Rabby | EVM / secp256k1 | EIP-6963 / EIP-1193 |
+| Phantom | Solana / Ed25519 (+ EVM) | Solana Wallet Standard · EIP-6963 |
+
+This introduces a **wallet-connector client** — Passport connecting *out*
+to other wallets — distinct from the dApp connector (§3.9), where Passport
+is the wallet connected *to*. One adapter per standard. The connector may be
+**provider-supplied** (the wallet-infra provider's connectors, §2.4) or
+**direct** — the same managed-vs-decentralised split as custody (§2.1).
+
+**All three integration modes are in scope**; a given wallet may serve more
+than one:
+
+- **Bind as identity / authoriser** — a foreign-curve wallet signs a §2.3
+  binding and becomes a linked identity (and, via a grant authoriser, an
+  authoriser) of the ACC. Enables "connect your existing wallet" onboarding
+  and login. Primary for the foreign-curve wallets (MetaMask, Rabby,
+  Phantom) and the Cardano identities in Lace / Gero. Generalises §2.3
+  beyond ECDSA to any foreign scheme (secp256k1, Ed25519).
+- **Fund / bridge** — use the connected wallet to fund the account or move
+  assets across chains ([C25] / MCS). Applies to the foreign-chain wallets
+  (MetaMask, Phantom, and the Cardano side of Lace / Gero).
+- **Coexist / discover** — the Midnight-native wallets (Lace, 1am, Gero) are
+  peer wallets; Passport is discoverable alongside them through the same
+  connector standard (the §3.9 wallet side) and may import from or hand off
+  to them.
+
+The modes are not exclusive per wallet — e.g. Lace can coexist as a Midnight
+peer, fund / bridge from its Cardano side, and bind its Cardano identity.
+The `adapter-wallet-connect` client (architecture §4.2) feeds all three:
+binding → signer / §2.3, funding → [C25], coexistence → the §3.9 surface.
+Which mode(s) ship first is a v1 delivery-scope question.
+
+## 4. Reference implementations (UI / App)
+
+The first consumers of the SDK, validating its surface. Tracked as
+expectations on the SDK, not as SDK deliverables:
+
+1. **Official UI implementation** built on the Passport SDK (Midnight
+   Foundation).
+2. **A reference Midnight dApp** integrating via the Passport dApp
+   connector (§3.9), exercising Sign-In-with-Passport, scoped-grant
+   requests, and Passport-provisioned contract witnesses.
+
+## 5. References
+
+- Components: [components/README.md](../../docs/plans/components/README.md) ·
+  Promises: [PROMISES.md](../../docs/plans/PROMISES.md)
+- Shared private-storage provider: midnightntwrk/passport#58
+- `did:midnight`: <https://github.com/midnightntwrk/midnight-did>
+- Wallet-infrastructure provider — enclave / passkey-gated custody at
+  launch, MPC / TSS threshold custody in the second wave. Specific provider
+  intentionally unnamed here.

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -236,11 +236,30 @@ verified in the SDK.
 
 Routing inputs remain (a) custody path, (b) circuit k, (c) device
 capability, and (d) privacy posture, with a fallback ladder (in-tab →
-remote on capability failure). The prover actually used MUST be surfaced
-truthfully to the user ("proved in this browser" / "proved in a remote
-enclave" / "proved by the provider") — and in 2b, that the transaction was
-**submitted by the proof server** — proof provenance is a user-facing
-guarantee, not a diagnostic.
+remote), which is **consent-gated, not silent** (see below). The prover
+actually used MUST be surfaced truthfully to the user ("proved in this
+browser" / "proved in a remote enclave" / "proved by the provider") — and
+in 2b, that the transaction was **submitted by the proof server** — proof
+provenance is a user-facing guarantee, not a diagnostic.
+
+**Privacy-downgrade consent (in-tab → remote).** In-tab proving keeps the
+witness on the device; any remote path (2a / 2b) sends it off-device
+(enclave-encrypted, but off-device, and under provider / enclave trust).
+Moving a user from in-tab to a remote prover is therefore a **privacy
+downgrade** and MUST NOT happen silently:
+
+- The SDK MUST capture **explicit, manual user confirmation** before the
+  first switch to a remote prover — including when the fallback ladder
+  would otherwise auto-fall-back on a capability failure (OOM / timeout /
+  missing params). A capability failure *proposes* the switch; it never
+  performs it unattended. The transaction pauses until the user chooses.
+- The confirmation MUST state plainly what changes: the witness leaves the
+  device to the (provider's) enclave, and the trust shifts from
+  "no one but you" to "the provider / enclave".
+- Once a remote prover is active, the SDK MUST **persistently remind** the
+  user of the setup — a standing indicator, not a one-time toast — so the
+  reduced-privacy posture is never silently forgotten, and MUST keep
+  reverting to in-tab (where the device supports it) one tap away.
 
 ### 2.6 The managed path in detail
 

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -449,6 +449,10 @@ dApp can rely on Passport — the other end of the same [C23] protocol
   user's Passport profile supplies witness values when the dApp's
   `witness.ts` runs for a contract execution (the shared private-storage
   provider, midnightntwrk/passport#58, over [C16]).
+- **Transfer assets to a Passport account** — pay a Passport user via the
+  §3.12 deposit mechanism (resolve the recipient → connect to their ACC →
+  call the deposit circuit). The one connector function that is a direct
+  chain interaction rather than a C23 message.
 
 **Security framing of witness provisioning (normative).** Passport-supplied
 private state MUST be **scoped, consented, and ceremony-gated**: a dApp
@@ -501,7 +505,8 @@ than one:
   beyond ECDSA to any foreign scheme (secp256k1, Ed25519).
 - **Fund / bridge** — use the connected wallet to fund the account or move
   assets across chains ([C25] / MCS). Applies to the foreign-chain wallets
-  (MetaMask, Phantom, and the Cardano side of Lace / Gero).
+  (MetaMask, Phantom, and the Cardano side of Lace / Gero). Midnight-side
+  funding lands through the §3.12 deposit mechanism.
 - **Coexist / discover** — the Midnight-native wallets (Lace, 1am, Gero) are
   peer wallets; Passport is discoverable alongside them through the same
   connector standard (the §3.9 wallet side) and may import from or hand off
@@ -582,6 +587,52 @@ progress):
 - Interplay with §2.5 path 2b: a sponsored partial transaction is one
   candidate answer to "who balances and fee-pays before a prove+broadcast
   server submits".
+
+### 3.12 Asset transfers into a Passport account (deposit mechanism)
+
+Because of how the ACC is structured ([C1]/[C4] contract custody), **a
+Passport account is not payable by a plain transfer to an address** —
+funding it is a **contract call**. The SDK MUST expose, and ecosystem
+wallets and dApps MUST support, the following mechanism to send assets to
+a Passport user:
+
+1. **Resolve the recipient** — `alice.passport.night` → the user's ACC
+   contract address, via the name service ([C2]).
+2. **Connect to the user's ACC contract** — using the versioned contract
+   bindings and ZK assets (§8.2 artefact; the sender needs the deposit
+   circuit's assets to prove the call).
+3. **Call the deposit circuit** — `deposit_night` for unshielded assets,
+   `deposit_shielded` for shielded coins; the function routes by asset
+   type. Deposits are **permissionless by ACC design** — anyone may fund
+   an account; no grant, no recipient ceremony, no recipient interaction.
+
+Properties and consequences:
+
+- **The sender pays.** The deposit is the *sender's* transaction: their
+  wallet proves, balances, fee-pays (their own DUST or §3.11 sponsorship),
+  and submits. The recipient does nothing and need not be online.
+- **Heavier than a plain transfer.** A deposit is a proven contract call —
+  the sending wallet must fetch the ACC deposit-circuit assets and generate
+  a proof. This is standard contract-call support, but wallets that only
+  implement address-to-address transfers cannot pay a Passport account —
+  which is exactly why this mechanism is normative in the custody MIP and
+  an ecosystem-adoption requirement, not an SDK-internal detail.
+- **Never present the raw ACC address as a payment address.** Assets sent
+  to the contract address *outside* the deposit circuit are held but
+  unaccounted (they bypass the ACC's balance bookkeeping — a known
+  prototype blind spot). UIs and integrations MUST surface the Passport
+  name / deposit flow, not a copyable contract address.
+- **Who must implement it:** the dApp connector (§3.9) exposes it as a
+  one-call function for dApps (checkout, payouts, refunds); external
+  wallets (§3.10) support it natively so their users can pay
+  `alice.passport.night`; Passport itself uses the same mechanism for
+  Passport→Passport transfers.
+
+Packaging note: the deposit function is a direct chain interaction, not a
+C23 wallet message — it rides the typed contract bindings
+(`mn-passport-contract`), not the kernel. Surfacing it through the dApp
+connector does not breach the "connector never links the core" rule (§3.9):
+the contract package is a foundation dependency, not the custody core.
 
 ## 4. Reference implementations (UI / App)
 

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -2,7 +2,9 @@
 
 > **Scope of this document.** High-level requirements and design
 > principles — the *what* and *why* of the SDK. Detailed component specs,
-> architecture, and diagrams are separate documents under `sdk/docs/`.
+> architecture, and diagrams live in sibling docs under `sdk/docs/`:
+> [`architecture.md`](./architecture.md) (the *how*) and
+> [`development-workflow.md`](./development-workflow.md) (how we build it).
 
 > **Status:** draft · 2026/07/17
 > **Audience:** Passport prototype team, Midnight Foundation, partner wallet

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -3,8 +3,9 @@
 > **Scope of this document.** High-level requirements and design
 > principles — the *what* and *why* of the SDK. Detailed component specs,
 > architecture, and diagrams live in sibling docs under `sdk/docs/`:
-> [`architecture.md`](./architecture.md) (the *how*) and
-> [`development-workflow.md`](./development-workflow.md) (how we build it).
+> [`architecture.md`](./architecture.md) (the *how*),
+> [`development-workflow.md`](./development-workflow.md) (how we build it),
+> and [`beta-scope.md`](./beta-scope.md) (the reduced first version).
 
 > **Status:** draft · 2026/07/17
 > **Audience:** Passport prototype team, Midnight Foundation, partner wallet

--- a/sdk/docs/sdk-requirements.md
+++ b/sdk/docs/sdk-requirements.md
@@ -383,13 +383,17 @@ shared chain-derived view"). Four normative rules:
   re-derivable is never synced: the device authoriser key is re-derived
   from the passkey PRF (§2.1) and chain-visible state is rebuilt from the
   view-key / indexer ([C17]). This is what keeps the blob at a few KB.
-- **Encrypt before sync, under a key the sync channel does not hold.** The
-  blob is sealed under the ceremony envelope (§2.2) before it leaves the
-  device; the transport sees ciphertext only. Critically, the envelope key
-  MUST be independent of any secret that channel already holds — if the
-  passkey both derives the envelope key *and* syncs through the same vendor
-  account, the vendor holds lock and key together and the end-to-end
-  property collapses.
+- **Encrypt before sync.** The blob is sealed under the **ceremony
+  envelope** (§2.2) before it leaves the device. **Decided: the envelope
+  key is the passkey (PRF); on devices without passkey/PRF support it falls
+  back to a password (KDF).** The transport sees ciphertext only. Residual
+  risk: the passkey syncs through the user's vendor account, so backing the
+  ciphertext up to that *same* vendor cloud would hand the vendor lock and
+  key together. **Mitigation:** route the backup copy through the portable
+  #58 shared provider (Passport-mediated), not the vendor keystore, so the
+  vendor holding the passkey never also holds the ciphertext. Where the
+  native vendor-keystore backup path is used regardless, the residual
+  lock+key exposure is an accepted risk (security register).
 - **Vendor keystore is one adapter, not the mechanism.** Device-vendor sync
   (Apple Keychain synchronizable items / iCloud Keychain; Android Block
   Store or Keystore-backed backup) is attractive — no Passport-operated
@@ -431,6 +435,45 @@ the reference implementation of the **`did:midnight`** method ([C3]):
 Open (tracked in [C3]): the exact relationship between
 `alice.passport.night`, the ACC address, and the `did:midnight` identifier
 — alias vs distinct-layer.
+
+### 3.8 Agent access and management (OWS)
+
+The SDK is the entry point for AI agents the user provisions and manages
+from their Passport account, aligned with the **Open Wallet Standard
+(OWS)** — the standard for local wallet storage, delegated agent access,
+and policy-gated signing (agents act **without ever seeing a plaintext
+key**, gated by a pre-signing policy engine).
+
+**Decided: adopt WingRiders' `ows-core` as the OWS implementation** (its
+Midnight plugin) rather than reimplement OWS. Passport's
+`adapter-agent-ows` **wraps `ows-core`** and maps the OWS agent model onto
+Passport's own authority model:
+
+- An agent the user provisions **is an OWS credential bound to a scoped
+  grant on the ACC** ([C10]/[C11]). `ows-core` supplies the agent-facing
+  surface and the pre-signing policy engine; Passport's **scoped grants are
+  the on-chain authority**, enforced by the ACC ([C12]). Issue, scope,
+  monitor, and revoke through the grant lifecycle — the same primitive that
+  backs dApp connections, for a non-human principal.
+- **Two enforcement layers:** the OWS policy engine gates the operation
+  client-side *before* key use; the ACC verifier rejects out-of-scope
+  operations on-chain regardless of the client.
+- **Keys / witness never reach the agent or its LLM context.** The agent
+  holds a policy-gated handle to a **grant authoriser** — a lesser, scoped,
+  revocable key — never the device/account key. This is the reconciliation
+  between `ows-core`'s key/vault model and ACC contract-custody: the "key"
+  OWS manages for an agent is a Passport grant authoriser, not the ACC key,
+  so the ACC stays the seat of authority.
+- **Presence vs delegation.** The §2.2 per-transaction ceremony is the
+  *human-presence* gate; an autonomous agent cannot perform it — that is
+  the point of delegation. The agent path substitutes **policy-gated
+  authority within a scoped grant** for human presence: the grant is issued
+  once under a ceremony, and the OWS policy engine plus on-chain scope bound
+  every subsequent agent action. This is the one exception to the
+  per-transaction ceremony rule.
+- Relates to [C26] (AI agent skills); OWS ships an MCP server that consumes
+  this surface and runs in a Node context (no passkey ceremony — hence
+  policy-gated). `ows-core` is consumed as an upstream dependency.
 
 ### 3.9 dApp connector (developer-facing)
 


### PR DESCRIPTION
# :passport_control: Passport SDK — first draft of the spec docs is up on sdk-spec

Two new documents under sdk/docs/, ready for review:

## :one: sdk-requirements.md — high-level requirements (the what/why)
• The SDK is the main connector to the Account Custody Contract (ACC) — the ACC is the account; keys, dApps, and agents are just revocable authorisers of it
• Two custody paths, progressive decentralisation: managed (wallet-infrastructure provider: social login + embedded wallet + signMessage gate — validated against the prototype's managed-flow branch) and decentralised (passkey PRF → in-circuit verification). Migration between them = authoriser swap, account untouched
• Ceremony rule: every transaction needs a passkey/password gesture — it's what decrypts the per-dApp witness state (one carve-out: policy-gated agents)
• Proving = k-threshold decision tree: low k → in-tab WASM (witness never leaves the device); high k → provider-routed (proof returned, Passport broadcasts) or direct attested-TEE proof server (proves and broadcasts). Attestation verified before any preimage leaves the device
• Functional surfaces: onboarding, dApp auth (Sign-In-with-Passport + scoped grants), recovery, multi-device, encrypted local storage + cross-device sync (vendor keystore / shared provider #58), did:midnight, agents via OWS, dApp-side connector, external wallets (Lace, 1am, Gero, MetaMask, Rabby, Phantom), and DUST sponsorship via Capacity Exchange (LP quote marketplace → fills the C24 zero-DUST gap)

## :two: architecture.md — candidate architectures + recommendation (the how)
• Three approaches assessed; recommendation: layered core + minimal kernel secret-boundary now, evolving to kernel + adapters + command bus — v1 ships fast, end-state needs no rewrite
• Kernel is the only code that ever touches decrypted secrets; everything swappable sits behind seams with 2–3 adapters each (signer, prover-router, storage/sync, fee, DID, agent, …)
• Packages under @midnight-ntwrk/mn-passport-* (core, protocol, contract, connect, adapter-*); the dApp connector is deliberately thin and can never pull the kernel into a dApp bundle
• ACC contract is not owned by the SDK — consumed as a versioned artefact
• Trust-boundary + sequence diagrams, requirement→architecture map, and the open decisions (v1 seam scope, OWS implement-vs-consume, mobile-web storage eviction)

Provider names are intentionally generic throughout ("wallet-infrastructure provider") — no vendor branding in committed docs.