### PR TITLE
Midnames Preview integration for the Passport account contract (refs #100)

### DIFF
--- a/experiments/account-custody-prototype/.gitignore
+++ b/experiments/account-custody-prototype/.gitignore
@@ -1,10 +1,12 @@
 node_modules/
 dist/
+.cache/
 contracts/managed/
 midnight-level-db/
 infra/.env
 deployment.json
 faucet-deployment.json
 identity-registry-deployment.json
+midnames-deployment.json
 *.log
 app/public/zk-params/

--- a/experiments/account-custody-prototype/MIDNAMES-INTEGRATION.md
+++ b/experiments/account-custody-prototype/MIDNAMES-INTEGRATION.md
@@ -1,0 +1,62 @@
+# Passport + Midnames Preview integration
+
+This integration covers the complete localnet acceptance path for Passport
+issue #100. It uses the Midnames `preview` implementation pinned to commit
+`83f8422b0b39113d5c14aa8adc3d42804edaf492`.
+
+## Run it
+
+Prerequisites are Docker, Node.js 22 or newer, Bun, OpenSSL, and the Compact
+toolchain.
+
+```sh
+npm run demo:midnames
+```
+
+That command resets the disposable local chain, compiles the Passport
+contracts, prepares the pinned Midnames contract, runs unit tests, and executes
+the live lifecycle.
+
+## Acceptance flow
+
+1. Start a fresh Midnight node, indexer, and proof server.
+2. Synchronize two distinct localnet wallets.
+3. Fund the external wallet and make DUST available.
+4. Deploy the user's Passport account-custody contract (AAC).
+5. Deploy the Midnames `.night` TLD.
+6. Deploy the `alice.night` resolver with the AAC as its contract target.
+7. Register the resolver in the `.night` namespace.
+8. Resolve `alice.night` from the external wallet and verify the target.
+9. Mint a local test shielded token to the external wallet.
+10. Resolve the alias again, connect to the resolved AAC, and call
+    `deposit_shielded`.
+11. Read the AAC ledger and assert that it holds the deposited shielded value.
+
+The depositor never receives or uses the raw AAC address as its destination
+input. The adapter resolves the alias first and constructs the AAC connection
+from the returned contract target.
+
+## Code map
+
+- `scripts/prepare-midnames-preview.mjs` fetches and builds the exact Preview
+  revision. The checkout and generated contract files stay git-ignored.
+- `src/integrations/midnames/preview.ts` deploys, claims, resolves, and routes
+  shielded deposits through a resolved alias.
+- `src/tests/lifecycle-midnames.ts` runs the two-wallet localnet lifecycle and
+  verifies the resulting AAC ledger state.
+- `test/midnames.test.ts` covers alias and address normalization plus the
+  Midnames ownership-key derivation.
+
+## Local evidence
+
+Successful runs write `midnames-deployment.json` with the contract addresses,
+transaction IDs, token color, amount, network, Preview revision, and timestamp.
+The file is intentionally ignored because it describes one disposable local
+chain and is not source code.
+
+## Scope
+
+This proves the localnet contract integration and the external shielded-deposit
+use case. Preview/preprod deployment configuration, production namespace
+policy, pricing, renewal, recovery, and anti-squatting rules remain Midnames
+and Passport product decisions outside this local acceptance path.

--- a/experiments/account-custody-prototype/README.md
+++ b/experiments/account-custody-prototype/README.md
@@ -16,6 +16,7 @@ in [DECISIONS.md](./DECISIONS.md).
 | `contracts/account.compact` | The per-account custody contract (11 circuits). |
 | `contracts/identity_registry.compact` | Shared demo registry binding a Night ID handle to the deployed Passport account contract. |
 | `contracts/faucet.compact` | Test scaffolding: shielded-token origin for localnet. |
+| `src/integrations/midnames/` | Adapter for the pinned Midnames Preview contract. |
 | `src/wallet/` | Platform-neutral client core: contract bindings, witnesses (C7), Shamir 2-of-3, `PassportAccount` API. |
 | `src/node/` | Node-side wiring: funding wallet, providers, deploy helpers. |
 | `src/tests/` | Localnet integration scenarios (see below). |
@@ -33,6 +34,7 @@ in [DECISIONS.md](./DECISIONS.md).
 ./run-all.sh            # localnet up + compile + unit tests + all scenarios
 ./run-all.sh --fresh    # reset chain state first
 ./run-all.sh --tests night,grants
+npm run demo:midnames     # clean chain + issue #100 acceptance flow
 ```
 
 ## Step by step
@@ -54,7 +56,27 @@ npm run test:lifecycle           # Night: deposit/withdraw, rogue-device reject,
 npm run test:grants              # grant issue/spend/cap/revoke
 npm run test:shielded            # faucet mint → deposit → partial withdraw (change path)
 npm run test:recovery            # share reconstruction → recover → old device locked out
+npm run test:midnames            # requires running localnet; alias → external shielded deposit
 ```
+
+## Midnames integration
+
+The issue #100 path uses the real Midnames Preview contract rather than the
+prototype `identity_registry.compact` contract. It deploys `.night`, claims
+`alice.night` for a newly deployed Passport AAC, resolves the alias from a
+second wallet, and calls the AAC `deposit_shielded` circuit with a shielded
+token owned by that second wallet.
+
+The complete clean-chain demo is:
+
+```sh
+npm run demo:midnames
+```
+
+The runner prints every landed transaction ID and writes a local,
+git-ignored `midnames-deployment.json` evidence record. See
+[MIDNAMES-INTEGRATION.md](./MIDNAMES-INTEGRATION.md) for the architecture,
+version pin, and validation details.
 
 ## Demo app
 

--- a/experiments/account-custody-prototype/package-lock.json
+++ b/experiments/account-custody-prototype/package-lock.json
@@ -8,6 +8,7 @@
       "name": "account-custody-prototype",
       "version": "0.1.0",
       "dependencies": {
+        "@midnight-ntwrk/compact-js": "2.5.1",
         "@midnight-ntwrk/compact-runtime": "^0.16.0",
         "@midnight-ntwrk/ledger-v8": "^8.0.3",
         "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",

--- a/experiments/account-custody-prototype/package.json
+++ b/experiments/account-custody-prototype/package.json
@@ -8,14 +8,17 @@
     "compile": "compact compile contracts/account.compact contracts/managed/account && compact compile contracts/faucet.compact contracts/managed/faucet && compact compile contracts/identity_registry.compact contracts/managed/identity_registry",
     "build": "tsc",
     "demo": "node scripts/demo-local.mjs",
+    "demo:midnames": "./run-all.sh --fresh --tests=midnames",
     "demo:e2e": "node app/scripts/e2e-devmode.mjs http://127.0.0.1:5173/",
+    "midnames:prepare": "node scripts/prepare-midnames-preview.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "deploy": "tsx src/tests/deploy.ts",
     "test:lifecycle": "tsx src/tests/lifecycle-night.ts",
     "test:shielded": "tsx src/tests/lifecycle-shielded.ts",
     "test:grants": "tsx src/tests/lifecycle-grants.ts",
-    "test:recovery": "tsx src/tests/lifecycle-recovery.ts"
+    "test:recovery": "tsx src/tests/lifecycle-recovery.ts",
+    "test:midnames": "npm run midnames:prepare && tsx src/tests/lifecycle-midnames.ts"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -25,6 +28,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@midnight-ntwrk/compact-js": "2.5.1",
     "@midnight-ntwrk/compact-runtime": "^0.16.0",
     "@midnight-ntwrk/ledger-v8": "^8.0.3",
     "@midnight-ntwrk/midnight-js-contracts": "^4.0.4",

--- a/experiments/account-custody-prototype/run-all.sh
+++ b/experiments/account-custody-prototype/run-all.sh
@@ -24,7 +24,7 @@ for arg in "${@:-}"; do
   esac
 done
 
-ALL_TESTS=(night grants shielded recovery)
+ALL_TESTS=(night grants shielded recovery midnames)
 if [[ -n "$TESTS" ]]; then
   IFS=',' read -r -a SELECTED <<< "$TESTS"
 else
@@ -36,6 +36,13 @@ check_cmd docker
 check_cmd node
 check_cmd openssl
 check_cmd compact
+check_cmd curl
+for t in "${SELECTED[@]}"; do
+  if [[ "$t" == "midnames" ]]; then
+    check_cmd bun
+    break
+  fi
+done
 
 # ── infra/.env ──────────────────────────────────────────────────────────────
 
@@ -59,6 +66,14 @@ npm install --silent
 echo "Compiling Compact contracts..."
 npm run compile
 
+for t in "${SELECTED[@]}"; do
+  if [[ "$t" == "midnames" ]]; then
+    echo "Preparing pinned Midnames Preview contracts..."
+    npm run midnames:prepare
+    break
+  fi
+done
+
 # ── Compose ─────────────────────────────────────────────────────────────────
 
 COMPOSE_FILES="-f $INFRA_DIR/docker-compose.yml"
@@ -72,7 +87,42 @@ if $FRESH; then
 fi
 
 echo "Starting localnet..."
-docker compose $COMPOSE_FILES up -d --wait
+docker compose $COMPOSE_FILES up -d
+
+wait_for_http() {
+  local label="$1"
+  local url="$2"
+  for _ in {1..60}; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      echo "$label is ready."
+      return
+    fi
+    sleep 2
+  done
+  echo "ERROR: $label did not become ready: $url"
+  exit 1
+}
+
+wait_for_http "Midnight node" "http://127.0.0.1:9944/health"
+wait_for_http "Proof server" "http://127.0.0.1:6300"
+sleep 6
+docker compose $COMPOSE_FILES up -d indexer
+INDEXER_READY=false
+for _ in {1..60}; do
+  if curl -fsS \
+    -H "Content-Type: application/json" \
+    -d '{"query":"{__typename}"}' \
+    "http://127.0.0.1:8088/api/v4/graphql" >/dev/null 2>&1; then
+    echo "Indexer is ready."
+    INDEXER_READY=true
+    break
+  fi
+  sleep 2
+done
+if [[ "$INDEXER_READY" != "true" ]]; then
+  echo "ERROR: Indexer did not become ready."
+  exit 1
+fi
 
 # ── Unit tests ──────────────────────────────────────────────────────────────
 

--- a/experiments/account-custody-prototype/scripts/prepare-midnames-preview.mjs
+++ b/experiments/account-custody-prototype/scripts/prepare-midnames-preview.mjs
@@ -1,0 +1,119 @@
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MIDNAMES_REPOSITORY = 'https://github.com/midnames/sdk.git';
+const MIDNAMES_REVISION = '83f8422b0b39113d5c14aa8adc3d42804edaf492';
+const COMPACT_VERSION = '0.31.1';
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cacheRoot = resolve(projectRoot, '.cache');
+const checkout = resolve(cacheRoot, 'midnames-sdk-preview');
+const stampPath = resolve(checkout, '.passport-build.json');
+const contractEntry = resolve(checkout, 'packages/contract/dist/index.js');
+const sdkEntry = resolve(checkout, 'packages/sdk/dist/index.js');
+const builtManagedContract = resolve(
+  checkout,
+  'packages',
+  'contract',
+  'dist',
+  'managed',
+  'leaf',
+);
+const publishedManagedContract = resolve(projectRoot, 'contracts', 'managed', 'midnames');
+const force = process.argv.includes('--force');
+
+function run(command, args, cwd = projectRoot, stdio = 'inherit') {
+  return execFileSync(command, args, { cwd, stdio, encoding: 'utf8' });
+}
+
+function readStamp() {
+  if (!existsSync(stampPath)) return null;
+  try {
+    return JSON.parse(readFileSync(stampPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function ensureCheckout() {
+  mkdirSync(cacheRoot, { recursive: true });
+  if (!existsSync(resolve(checkout, '.git'))) {
+    run('git', ['clone', '--filter=blob:none', '--no-checkout', MIDNAMES_REPOSITORY, checkout]);
+  }
+
+  run('git', ['remote', 'set-url', 'origin', MIDNAMES_REPOSITORY], checkout, 'ignore');
+  try {
+    run('git', ['cat-file', '-e', `${MIDNAMES_REVISION}^{commit}`], checkout, 'ignore');
+  } catch {
+    run('git', ['fetch', '--depth=1', 'origin', MIDNAMES_REVISION], checkout);
+  }
+
+  const current = run('git', ['rev-parse', 'HEAD'], checkout, 'pipe').trim();
+  if (current !== MIDNAMES_REVISION) {
+    run('git', ['checkout', '--detach', MIDNAMES_REVISION], checkout);
+  }
+}
+
+function ensureCompactCompiler() {
+  try {
+    run('compact', ['compile', `+${COMPACT_VERSION}`, '--version'], projectRoot, 'ignore');
+  } catch {
+    run('compact', ['update', COMPACT_VERSION]);
+  }
+}
+
+function publishManagedContract() {
+  if (!existsSync(resolve(builtManagedContract, 'contract', 'index.js'))) {
+    throw new Error('Midnames generated contract is missing after the Preview build.');
+  }
+  rmSync(publishedManagedContract, { recursive: true, force: true });
+  mkdirSync(dirname(publishedManagedContract), { recursive: true });
+  cpSync(builtManagedContract, publishedManagedContract, { recursive: true });
+}
+
+ensureCheckout();
+
+const stamp = readStamp();
+if (
+  !force &&
+  stamp?.revision === MIDNAMES_REVISION &&
+  stamp?.compactVersion === COMPACT_VERSION &&
+  existsSync(contractEntry) &&
+  existsSync(sdkEntry)
+) {
+  publishManagedContract();
+  console.log(`Midnames preview ${MIDNAMES_REVISION.slice(0, 12)} is ready.`);
+  process.exit(0);
+}
+
+ensureCompactCompiler();
+run('bun', ['install', '--frozen-lockfile'], checkout);
+run('bun', ['run', '--filter', '@midnames/ns', 'compact'], checkout);
+run('bun', ['run', '--filter', '@midnames/ns', 'build'], checkout);
+run('bun', ['run', '--filter', '@midnames/sdk', 'build'], checkout);
+publishManagedContract();
+
+writeFileSync(
+  stampPath,
+  `${JSON.stringify(
+    {
+      repository: MIDNAMES_REPOSITORY,
+      revision: MIDNAMES_REVISION,
+      compactVersion: COMPACT_VERSION,
+      builtAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+console.log(`Midnames preview ${MIDNAMES_REVISION.slice(0, 12)} built successfully.`);

--- a/experiments/account-custody-prototype/src/integrations/midnames/preview.ts
+++ b/experiments/account-custody-prototype/src/integrations/midnames/preview.ts
@@ -1,0 +1,417 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { CompiledContract } from '@midnight-ntwrk/compact-js';
+import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import { nativeToken } from '@midnight-ntwrk/ledger-v8';
+
+import {
+  PassportAccount,
+  type ShieldedCoin,
+  type TxResult,
+} from '../../wallet/account.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..', '..', '..');
+const MIDNAMES_CONTRACT_ENTRY = resolve(
+  PROJECT_ROOT,
+  'contracts',
+  'managed',
+  'midnames',
+  'contract',
+  'index.js',
+);
+const MIDNAMES_MANAGED_PATH = resolve(
+  PROJECT_ROOT,
+  'contracts',
+  'managed',
+  'midnames',
+);
+
+const EMPTY_BYTES = new Uint8Array(32);
+const TLD = 'night';
+const DEFAULT_PRIVATE_STATE_ID = 'passport-midnames-owner';
+
+interface MidnamesModules {
+  contract: any;
+}
+
+export interface MidnamesDeployment {
+  address: string;
+  txId: string;
+  handle: any;
+}
+
+export interface PassportAliasClaim {
+  alias: string;
+  domain: string;
+  tldAddress: string;
+  resolverAddress: string;
+  passportAddress: string;
+  resolverDeployTxId: string;
+  registerTxId: string;
+}
+
+export interface ResolvedPassportAlias {
+  alias: string;
+  domain: string;
+  resolverAddress: string;
+  type: 'contract';
+  address: string;
+}
+
+export interface AliasShieldedDeposit {
+  resolved: ResolvedPassportAlias;
+  deposit: TxResult;
+}
+
+let modulesPromise: Promise<MidnamesModules> | undefined;
+
+const midnamesWitnesses = {
+  secretKey: ({ privateState }: { privateState: { secretKey: string } }) => [
+    privateState,
+    new Uint8Array(Buffer.from(privateState.secretKey, 'hex')),
+  ],
+};
+
+function domainToKey(name: string): { key: Uint8Array; len: bigint } {
+  const bytes = new TextEncoder().encode(name);
+  if (bytes.length === 0 || bytes.length > 32) {
+    throw new Error(`Domain name must be 1-32 bytes, got ${bytes.length}.`);
+  }
+  const key = new Uint8Array(32).fill(255);
+  key.set(bytes);
+  return { key, len: BigInt(bytes.length) };
+}
+
+function assertPreviewReady(): void {
+  if (!existsSync(MIDNAMES_CONTRACT_ENTRY)) {
+    throw new Error(
+      'Midnames preview is not built. Run `npm run midnames:prepare` from the prototype directory.',
+    );
+  }
+}
+
+async function loadMidnames(): Promise<MidnamesModules> {
+  assertPreviewReady();
+  modulesPromise ??= import(pathToFileURL(MIDNAMES_CONTRACT_ENTRY).href).then(
+    (contract) => ({ contract }),
+  );
+  return modulesPromise;
+}
+
+export function midnamesZkConfigPath(): string {
+  assertPreviewReady();
+  return MIDNAMES_MANAGED_PATH;
+}
+
+export function normalizePassportAlias(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/\.+$/, '');
+  const alias = normalized.endsWith(`.${TLD}`)
+    ? normalized.slice(0, -(TLD.length + 1))
+    : normalized;
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/.test(alias)) {
+    throw new Error('Alias must be 1-32 lowercase letters, numbers, or interior hyphens.');
+  }
+  return alias;
+}
+
+export function rawContractAddress(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/^0x/, '').replace(/^0200/, '');
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error(`Invalid Midnight contract address: ${value}`);
+  }
+  return normalized;
+}
+
+export function contractAddressBytes(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(rawContractAddress(value), 'hex'));
+}
+
+export function deriveMidnamesOwnerKey(secret: Uint8Array): Uint8Array {
+  if (secret.length !== 32) {
+    throw new Error(`Midnames owner secret must be 32 bytes, received ${secret.length}.`);
+  }
+  const tag = new Uint8Array(32);
+  tag.set(new TextEncoder().encode('midnight.domains'));
+  const payload = new Uint8Array(64);
+  payload.set(tag);
+  payload.set(secret, 32);
+  return new Uint8Array(createHash('sha256').update(payload).digest());
+}
+
+function bytesToHex(value: Uint8Array): string {
+  return Buffer.from(value).toString('hex');
+}
+
+function txId(result: any): string {
+  const value = result?.public?.txId ?? result?.public?.transactionHash;
+  if (!value) throw new Error('Midnames contract call returned without a transaction id.');
+  return String(value);
+}
+
+function maybeBytes(value?: Uint8Array): { is_some: boolean; value: Uint8Array } {
+  return value
+    ? { is_some: true, value }
+    : { is_some: false, value: new Uint8Array(32) };
+}
+
+function maybeString(value?: string): { is_some: boolean; value: string } {
+  return value ? { is_some: true, value } : { is_some: false, value: '' };
+}
+
+function buildKvs(fields: Array<[string, string]> = []) {
+  return Array.from({ length: 10 }, (_, index) => ({
+    is_some: index < fields.length,
+    value: index < fields.length ? fields[index] : ['', ''],
+  }));
+}
+
+function unshieldedAddressBytes(walletCtx: any): Uint8Array {
+  const address: any = walletCtx.unshieldedKeystore.getAddress();
+  const candidate = address?.raw ?? address?.data ?? address?.bytes;
+  if (candidate instanceof Uint8Array || Buffer.isBuffer(candidate)) {
+    const bytes = new Uint8Array(candidate);
+    if (bytes.length < 32) throw new Error('Unshielded address is shorter than 32 bytes.');
+    return bytes.subarray(bytes.length - 32);
+  }
+
+  const text = String(address).replace(/^0x/, '');
+  if (/^[0-9a-fA-F]{64}$/.test(text)) {
+    return new Uint8Array(Buffer.from(text, 'hex'));
+  }
+  throw new Error('Unable to extract the 32-byte unshielded address from the wallet.');
+}
+
+function nativeColor(): Uint8Array {
+  return new Uint8Array(Buffer.from(nativeToken().raw.toString().replace(/^0x/, ''), 'hex'));
+}
+
+async function deployLeaf(
+  providers: any,
+  walletCtx: any,
+  options: {
+    secret: Uint8Array;
+    ownerKey: Uint8Array;
+    parentDomain?: string;
+    parentResolver?: string;
+    domain: string;
+    targetAddress: string;
+    targetType: number;
+    privateStateId?: string;
+  },
+): Promise<MidnamesDeployment> {
+  const { contract } = await loadMidnames();
+  const compiledContract = CompiledContract.make(
+    'passport-midnames-leaf',
+    contract.Contract,
+  ).pipe(
+    CompiledContract.withWitnesses(midnamesWitnesses as any),
+    CompiledContract.withCompiledFileAssets(MIDNAMES_MANAGED_PATH),
+  );
+  const domainKey = domainToKey(options.domain).key;
+  const parentKey = options.parentDomain
+    ? domainToKey(options.parentDomain).key
+    : undefined;
+  const deployed = await deployContract(providers, {
+    compiledContract,
+    privateStateId: options.privateStateId ?? DEFAULT_PRIVATE_STATE_ID,
+    initialPrivateState: { secretKey: bytesToHex(options.secret) },
+    args: [
+      maybeBytes(parentKey),
+      { bytes: options.parentResolver ? contractAddressBytes(options.parentResolver) : EMPTY_BYTES },
+      [contractAddressBytes(options.targetAddress), options.targetType],
+      maybeBytes(domainKey),
+      nativeColor(),
+      0n,
+      0n,
+      0n,
+      maybeString(),
+      false,
+      options.ownerKey,
+      { bytes: unshieldedAddressBytes(walletCtx) },
+      buildKvs(),
+    ],
+  } as any);
+
+  return {
+    address: rawContractAddress(deployed.deployTxData.public.contractAddress),
+    txId: txId(deployed.deployTxData),
+    handle: deployed,
+  };
+}
+
+/**
+ * Resolves a .night name through Midnames and uses its contract target as the
+ * destination of the permissionless AAC shielded-deposit circuit.
+ */
+export async function depositShieldedByAlias(
+  depositorProviders: any,
+  compiledAccountContract: any,
+  tldAddress: string,
+  domain: string,
+  coin: ShieldedCoin,
+): Promise<AliasShieldedDeposit> {
+  const resolved = await resolvePassportAlias(
+    depositorProviders.publicDataProvider,
+    tldAddress,
+    domain,
+  );
+  if (resolved.type !== 'contract') {
+    throw new Error(`Midnames domain ${domain} does not target a contract.`);
+  }
+
+  const account = await PassportAccount.connect(
+    depositorProviders,
+    compiledAccountContract,
+    resolved.address,
+    {},
+    `passport-alias-deposit-${resolved.alias}`,
+  );
+  const deposit = await account.depositShielded(coin);
+  return { resolved, deposit };
+}
+
+export async function deployMidnamesTld(
+  providers: any,
+  walletCtx: any,
+  ownerSecret: Uint8Array,
+): Promise<MidnamesDeployment> {
+  const { contract } = await loadMidnames();
+  const ownerKey = deriveMidnamesOwnerKey(ownerSecret);
+  return deployLeaf(providers, walletCtx, {
+    secret: ownerSecret,
+    ownerKey,
+    domain: TLD,
+    targetAddress: '0'.repeat(64),
+    targetType: contract.AddressType.ContractAddr,
+    privateStateId: 'passport-midnames-tld-owner',
+  });
+}
+
+export async function claimPassportAlias(
+  providers: any,
+  walletCtx: any,
+  tld: MidnamesDeployment,
+  ownerSecret: Uint8Array,
+  aliasValue: string,
+  passportAddressValue: string,
+): Promise<PassportAliasClaim> {
+  const { contract } = await loadMidnames();
+  const alias = normalizePassportAlias(aliasValue);
+  const passportAddress = rawContractAddress(passportAddressValue);
+  const ownerKey = deriveMidnamesOwnerKey(ownerSecret);
+
+  await waitForContract(providers.publicDataProvider, tld.address);
+  const resolver = await deployLeaf(providers, walletCtx, {
+    secret: ownerSecret,
+    ownerKey,
+    parentDomain: TLD,
+    parentResolver: tld.address,
+    domain: alias,
+    targetAddress: passportAddress,
+    targetType: contract.AddressType.ContractAddr,
+    privateStateId: `passport-midnames-${alias}-owner`,
+  });
+
+  await waitForContract(providers.publicDataProvider, resolver.address);
+  const { key, len } = domainToKey(alias);
+  const registration = await tld.handle.callTx.register_domain_for(
+    ownerKey,
+    key,
+    len,
+    { bytes: contractAddressBytes(resolver.address) },
+  );
+
+  await waitForAlias(providers.publicDataProvider, tld.address, `${alias}.${TLD}`);
+  return {
+    alias,
+    domain: `${alias}.${TLD}`,
+    tldAddress: tld.address,
+    resolverAddress: resolver.address,
+    passportAddress,
+    resolverDeployTxId: resolver.txId,
+    registerTxId: txId(registration),
+  };
+}
+
+export async function resolvePassportAlias(
+  publicDataProvider: any,
+  tldAddressValue: string,
+  domainValue: string,
+): Promise<ResolvedPassportAlias> {
+  const { contract } = await loadMidnames();
+  const normalized = domainValue.trim().toLowerCase().replace(/\.+$/, '');
+  if (!normalized.endsWith(`.${TLD}`)) {
+    throw new Error(`Midnames domain must end with .${TLD}.`);
+  }
+
+  const labels = normalized.split('.');
+  if (labels.length < 2 || labels.at(-1) !== TLD) {
+    throw new Error(`Invalid Midnames domain: ${domainValue}`);
+  }
+
+  let resolverAddress = rawContractAddress(tldAddressValue);
+  for (const label of labels.slice(0, -1).reverse()) {
+    const state = await publicDataProvider.queryContractState(resolverAddress);
+    if (!state) throw new Error(`Midnames resolver not found at ${resolverAddress}.`);
+    const namespace = contract.ledger(state.data);
+    const key = domainToKey(label).key;
+    if (!namespace.domains.member(key)) {
+      throw new Error(`Midnames domain not found: ${normalized}.`);
+    }
+    resolverAddress = rawContractAddress(
+      bytesToHex(namespace.domains.lookup(key).resolver.bytes),
+    );
+  }
+
+  const state = await publicDataProvider.queryContractState(resolverAddress);
+  if (!state) throw new Error(`Midnames resolver not found at ${resolverAddress}.`);
+  const namespace = contract.ledger(state.data);
+  if (!namespace.DOMAIN_TARGET.is_left) {
+    throw new Error(`Midnames domain ${normalized} does not target a contract.`);
+  }
+
+  return {
+    alias: labels[0],
+    domain: normalized,
+    resolverAddress,
+    type: 'contract',
+    address: rawContractAddress(bytesToHex(namespace.DOMAIN_TARGET.left.bytes)),
+  };
+}
+
+export async function waitForContract(
+  publicDataProvider: any,
+  addressValue: string,
+  timeoutMs = 120_000,
+): Promise<void> {
+  const address = rawContractAddress(addressValue);
+  const startedAt = Date.now();
+  while (Date.now() - startedAt <= timeoutMs) {
+    if (await publicDataProvider.queryContractState(address)) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+  }
+  throw new Error(`Timed out waiting for Midnames contract ${address}.`);
+}
+
+async function waitForAlias(
+  publicDataProvider: any,
+  tldAddress: string,
+  domain: string,
+  timeoutMs = 120_000,
+): Promise<ResolvedPassportAlias> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt <= timeoutMs) {
+    try {
+      return await resolvePassportAlias(publicDataProvider, tldAddress, domain);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+    }
+  }
+  throw new Error(`Timed out waiting for ${domain} to resolve.`, { cause: lastError });
+}

--- a/experiments/account-custody-prototype/src/node/setup.ts
+++ b/experiments/account-custody-prototype/src/node/setup.ts
@@ -5,7 +5,10 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { CompiledContract } from '@midnight-ntwrk/compact-js';
-import { deployContract } from '@midnight-ntwrk/midnight-js-contracts';
+import {
+  deployContract,
+  withContractScopedTransaction,
+} from '@midnight-ntwrk/midnight-js-contracts';
 
 import * as FaucetModule from '../../contracts/managed/faucet/contract/index.js';
 import { Contract as IdentityRegistryContract, IdentityRegistry } from '../wallet/identity.js';
@@ -105,6 +108,7 @@ export interface FaucetHandle {
     amount: bigint,
     nonce: Uint8Array,
     recipientCoinPublicKey: Uint8Array,
+    recipientEncryptionPublicKey?: string,
   ) => Promise<string>;
 }
 
@@ -119,10 +123,37 @@ export async function deployFaucet(walletCtx: WalletContext): Promise<FaucetHand
   return {
     address,
     providers,
-    mint: async (color, amount, nonce, recipientCoinPublicKey) => {
-      const r = await (deployed as any).callTx.mint_shielded(color, amount, nonce, {
-        bytes: recipientCoinPublicKey,
-      });
+    mint: async (
+      color,
+      amount,
+      nonce,
+      recipientCoinPublicKey,
+      recipientEncryptionPublicKey,
+    ) => {
+      const recipient = { bytes: recipientCoinPublicKey };
+      if (recipientEncryptionPublicKey) {
+        const recipientCoinPublicKeyHex = Buffer.from(recipientCoinPublicKey).toString('hex');
+        const r = await withContractScopedTransaction(
+          providers,
+          async (txContext) => {
+            await (deployed as any).callTx.mint_shielded(
+              txContext,
+              color,
+              amount,
+              nonce,
+              recipient,
+            );
+          },
+          {
+            additionalCoinEncPublicKeyMappings: new Map([
+              [recipientCoinPublicKeyHex, recipientEncryptionPublicKey],
+            ]),
+          },
+        );
+        return r.public.txId;
+      }
+
+      const r = await (deployed as any).callTx.mint_shielded(color, amount, nonce, recipient);
       return r?.public?.txId ?? r?.public?.transactionHash;
     },
   };

--- a/experiments/account-custody-prototype/src/node/transfers.ts
+++ b/experiments/account-custody-prototype/src/node/transfers.ts
@@ -1,0 +1,139 @@
+import * as Rx from 'rxjs';
+
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { nativeToken, type RawTokenType } from '@midnight-ntwrk/ledger-v8';
+import {
+  MidnightBech32m,
+  UnshieldedAddress,
+  type UnshieldedAddress as UnshieldedAddressType,
+} from '@midnight-ntwrk/wallet-sdk-address-format';
+
+import type { WalletContext } from './wallet.js';
+
+export const NIGHT_RAW = nativeToken().raw;
+
+export function unshieldedAddressOf(walletCtx: WalletContext): UnshieldedAddressType {
+  const bech32 = walletCtx.unshieldedKeystore.getBech32Address();
+  return UnshieldedAddress.codec.decode(
+    getNetworkId() as any,
+    bech32 as MidnightBech32m,
+  );
+}
+
+export async function currentWalletState(walletCtx: WalletContext): Promise<any> {
+  return Rx.firstValueFrom(
+    walletCtx.wallet.state().pipe(Rx.filter((state) => state.isSynced)),
+  );
+}
+
+export function nightBalanceOf(state: any): bigint {
+  return state.unshielded?.balances?.[NIGHT_RAW] ?? 0n;
+}
+
+export function shieldedBalanceOf(state: any, tokenType: RawTokenType): bigint {
+  return state.shielded?.balances?.[tokenType] ?? 0n;
+}
+
+export function dustBalanceOf(state: any, at = new Date()): bigint {
+  return state.dust
+    ? state.dust.capabilities.coinsAndBalances.getWalletBalance(state.dust.state, at)
+    : 0n;
+}
+
+export async function waitForWalletState(
+  walletCtx: WalletContext,
+  predicate: (state: any) => boolean,
+  label: string,
+  timeoutMs = 180_000,
+): Promise<any> {
+  try {
+    return await Rx.firstValueFrom(
+      walletCtx.wallet.state().pipe(
+        Rx.throttleTime(2_000),
+        Rx.filter((state) => state.isSynced && predicate(state)),
+        Rx.timeout(timeoutMs),
+      ),
+    );
+  } catch (error) {
+    throw new Error(`Timed out waiting for wallet state: ${label}.`, { cause: error });
+  }
+}
+
+export async function transferNight(
+  sender: WalletContext,
+  recipient: WalletContext,
+  amount: bigint,
+): Promise<string> {
+  const senderBefore = nightBalanceOf(await currentWalletState(sender));
+  const recipientBefore = nightBalanceOf(await currentWalletState(recipient));
+  if (senderBefore < amount) {
+    throw new Error(`Funding wallet has ${senderBefore} NIGHT units; ${amount} required.`);
+  }
+
+  const recipe = await sender.wallet.transferTransaction(
+    [
+      {
+        type: 'unshielded',
+        outputs: [
+          {
+            type: NIGHT_RAW,
+            receiverAddress: unshieldedAddressOf(recipient),
+            amount,
+          },
+        ],
+      },
+    ],
+    {
+      shieldedSecretKeys: sender.shieldedSecretKeys,
+      dustSecretKey: sender.dustSecretKey,
+    },
+    { ttl: new Date(Date.now() + 30 * 60 * 1000) },
+  );
+  const signed = await sender.wallet.signRecipe(recipe, (payload) =>
+    sender.unshieldedKeystore.signData(payload),
+  );
+  const finalized = await sender.wallet.finalizeRecipe(signed);
+  const txId = await sender.wallet.submitTransaction(finalized);
+
+  await waitForWalletState(
+    recipient,
+    (state) => nightBalanceOf(state) >= recipientBefore + amount,
+    `recipient NIGHT balance >= ${recipientBefore + amount}`,
+  );
+  await waitForWalletState(
+    sender,
+    (state) => nightBalanceOf(state) <= senderBefore - amount,
+    'funding transaction applied to sender',
+  );
+  return String(txId);
+}
+
+export async function registerNightForDust(walletCtx: WalletContext): Promise<string | null> {
+  const state = await currentWalletState(walletCtx);
+  const before = dustBalanceOf(state);
+  const available =
+    state.unshielded?.availableCoins?.filter(
+      (coin: any) =>
+        coin.utxo.type === NIGHT_RAW &&
+        coin.meta.registeredForDustGeneration === false,
+    ) ?? [];
+
+  if (available.length === 0) {
+    if (before > 0n) return null;
+    throw new Error('Wallet has neither DUST nor an unregistered NIGHT UTXO.');
+  }
+
+  const recipe = await walletCtx.wallet.registerNightUtxosForDustGeneration(
+    available,
+    walletCtx.unshieldedKeystore.getPublicKey(),
+    (payload) => walletCtx.unshieldedKeystore.signData(payload),
+  );
+  const finalized = await walletCtx.wallet.finalizeTransaction(recipe.transaction);
+  const txId = await walletCtx.wallet.submitTransaction(finalized);
+  await waitForWalletState(
+    walletCtx,
+    (next) => dustBalanceOf(next) > before,
+    'DUST generation after NIGHT registration',
+  );
+  return String(txId);
+}

--- a/experiments/account-custody-prototype/src/node/wallet.ts
+++ b/experiments/account-custody-prototype/src/node/wallet.ts
@@ -100,7 +100,11 @@ export async function createWallet(seed: string) {
   const dustSecretKey = ledger.DustSecretKey.fromSeed(keys[Roles.Dust]);
   const unshieldedKeystore = createKeystore(keys[Roles.NightExternal], networkId);
 
-  const feeBlocksMargin = Number(process.env.FEE_BLOCKS_MARGIN ?? '100');
+  // A large margin can make a fresh localnet wallet construct transactions
+  // whose projected DUST spend exceeds the few blocks of DUST accrued so far.
+  // Shared networks may override this; five blocks matches the upstream
+  // Midnames localnet harness.
+  const feeBlocksMargin = Number(process.env.FEE_BLOCKS_MARGIN ?? '5');
 
   const configuration = {
     networkId,

--- a/experiments/account-custody-prototype/src/tests/lifecycle-midnames.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-midnames.ts
@@ -1,0 +1,182 @@
+// Midnames + Passport localnet lifecycle:
+//   owner deploys AAC -> AAC claims alias.night through Midnames ->
+//   a distinct funded wallet resolves the alias and deposits a shielded token
+//   through the AAC deposit_shielded circuit.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { firstValueFrom } from 'rxjs';
+import { encodeRawTokenType, rawTokenType } from '@midnight-ntwrk/ledger-v8';
+
+import {
+  claimPassportAlias,
+  deployMidnamesTld,
+  depositShieldedByAlias,
+  midnamesZkConfigPath,
+  resolvePassportAlias,
+} from '../integrations/midnames/preview.js';
+import {
+  compiledAccountContract,
+  deployAccount,
+  deployFaucet,
+  setupWallet,
+} from '../node/setup.js';
+import {
+  currentWalletState,
+  dustBalanceOf,
+  nightBalanceOf,
+  registerNightForDust,
+  shieldedBalanceOf,
+  transferNight,
+  waitForWalletState,
+} from '../node/transfers.js';
+import { coinPublicKeyBytes, createProviders } from '../node/wallet.js';
+import { bytesToHex, randomBytes32 } from '../wallet/hex.js';
+import { runScenario, step, waitForLedger } from './runner.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EVIDENCE_FILE = path.resolve(__dirname, '..', '..', 'midnames-deployment.json');
+
+await runScenario('lifecycle-midnames', async () => {
+  const owner = await setupWallet();
+  const externalSeed = process.env.WALLET_SEED_SECONDARY;
+  if (!externalSeed) throw new Error('WALLET_SEED_SECONDARY env var required');
+  const external = await setupWallet(externalSeed);
+
+  try {
+    step('fund the external depositor and register its NIGHT for DUST');
+    const ownerState = await currentWalletState(owner.walletCtx);
+    console.log(`  owner NIGHT = ${nightBalanceOf(ownerState)}`);
+    console.log(`  owner DUST = ${dustBalanceOf(ownerState)}`);
+    const ownerDustTxId = await registerNightForDust(owner.walletCtx);
+    console.log(`  ownerDustRegistrationTx = ${ownerDustTxId ?? 'already registered'}`);
+    const fundingTxId = await transferNight(owner.walletCtx, external.walletCtx, 1_000_000n);
+    console.log(`  fundingTx = ${fundingTxId}`);
+    const dustTxId = await registerNightForDust(external.walletCtx);
+    console.log(`  dustRegistrationTx = ${dustTxId ?? 'already registered'}`);
+
+    step('deploy the Passport account-custody contract');
+    const account = await deployAccount(owner, {
+      deviceSecret: randomBytes32(),
+      recoverySecret: randomBytes32(),
+    });
+    console.log(`  passport AAC @ ${account.address}`);
+
+    step('deploy Midnames locally and claim alice.night for the AAC');
+    const midnamesOwnerSecret = randomBytes32();
+    const midnamesProviders = await createProviders(
+      owner.walletCtx,
+      midnamesZkConfigPath(),
+    );
+    const tld = await deployMidnamesTld(
+      midnamesProviders,
+      owner.walletCtx,
+      midnamesOwnerSecret,
+    );
+    console.log(`  Midnames .night TLD @ ${tld.address}`);
+    const claim = await claimPassportAlias(
+      midnamesProviders,
+      owner.walletCtx,
+      tld,
+      midnamesOwnerSecret,
+      'alice',
+      account.address,
+    );
+    console.log(`  ${claim.domain} -> ${claim.passportAddress}`);
+    console.log(`  resolverDeployTx = ${claim.resolverDeployTxId}`);
+    console.log(`  registerTx = ${claim.registerTxId}`);
+
+    const resolved = await resolvePassportAlias(
+      external.providers.publicDataProvider,
+      tld.address,
+      claim.domain,
+    );
+    if (resolved.address !== account.address.toLowerCase().replace(/^0200/, '')) {
+      throw new Error(
+        `${claim.domain} resolved to ${resolved.address}, expected ${account.address}`,
+      );
+    }
+    console.log(`  external resolution verified: ${claim.domain} -> ${resolved.address}`);
+
+    step('mint a shielded token to the external depositor');
+    const externalState: any = await firstValueFrom(external.walletCtx.wallet.state());
+    const externalCpk = coinPublicKeyBytes(externalState);
+    const externalEncryptionPublicKey =
+      externalState.shielded.encryptionPublicKey.toHexString();
+    const domesticColor = new Uint8Array(32);
+    domesticColor[31] = 6;
+    const amount = 500n;
+    const mintNonce = randomBytes32();
+    const faucet = await deployFaucet(owner.walletCtx);
+    const mintTxId = await faucet.mint(
+      domesticColor,
+      amount,
+      mintNonce,
+      externalCpk,
+      externalEncryptionPublicKey,
+    );
+    const tokenType = rawTokenType(domesticColor, faucet.address);
+    const color = encodeRawTokenType(tokenType);
+    console.log(`  faucet @ ${faucet.address}`);
+    console.log(`  mintTx = ${mintTxId}`);
+    console.log(`  tokenType = ${String(tokenType)}`);
+
+    await waitForWalletState(
+      external.walletCtx,
+      (state) => shieldedBalanceOf(state, tokenType) >= amount,
+      'external depositor shielded balance',
+    );
+
+    step('resolve alice.night and deposit through the AAC shielded circuit');
+    const aliasDeposit = await depositShieldedByAlias(
+      external.providers,
+      compiledAccountContract(),
+      tld.address,
+      claim.domain,
+      { nonce: mintNonce, color, value: amount },
+    );
+    console.log(`  resolved AAC = ${aliasDeposit.resolved.address}`);
+    console.log(`  depositTx = ${aliasDeposit.deposit.txId}`);
+
+    await waitForLedger(
+      account,
+      `AAC holds ${amount} shielded units deposited through ${claim.domain}`,
+      (ledger) => ledger.coins.member(color) && ledger.coins.lookup(color).value === amount,
+      180_000,
+    );
+
+    fs.writeFileSync(
+      EVIDENCE_FILE,
+      `${JSON.stringify(
+        {
+          network: 'local',
+          midnamesRevision: '83f8422b0b39113d5c14aa8adc3d42804edaf492',
+          domain: claim.domain,
+          tldAddress: claim.tldAddress,
+          resolverAddress: claim.resolverAddress,
+          passportAddress: claim.passportAddress,
+          fundingTxId,
+          ownerDustRegistrationTxId: ownerDustTxId,
+          dustRegistrationTxId: dustTxId,
+          resolverDeployTxId: claim.resolverDeployTxId,
+          registrationTxId: claim.registerTxId,
+          mintTxId,
+          depositTxId: aliasDeposit.deposit.txId,
+          tokenColor: bytesToHex(color),
+          amount: amount.toString(),
+          verifiedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`  evidence = ${EVIDENCE_FILE}`);
+  } finally {
+    await Promise.allSettled([
+      owner.walletCtx.wallet.stop(),
+      external.walletCtx.wallet.stop(),
+    ]);
+  }
+});

--- a/experiments/account-custody-prototype/src/tests/runner.ts
+++ b/experiments/account-custody-prototype/src/tests/runner.ts
@@ -14,9 +14,10 @@ export async function runScenario(name: string, fn: () => Promise<void>): Promis
     console.log(`\n◆ ${name}: FAIL — ${e?.message ?? e}`);
     code = 1;
   }
-  // Wallet/indexer subscriptions keep the event loop alive; force exit the
-  // same way contract-custody-feasibility's runner does.
-  setTimeout(() => process.exit(code), 100).unref();
+  process.exitCode = code;
+  // Wallet/indexer subscriptions can keep the event loop alive. Keep this
+  // timer referenced so a failed scenario cannot accidentally exit with 0.
+  setTimeout(() => process.exit(code), 100);
 }
 
 export function step(label: string): void {

--- a/experiments/account-custody-prototype/test/midnames.test.ts
+++ b/experiments/account-custody-prototype/test/midnames.test.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import {
+  contractAddressBytes,
+  deriveMidnamesOwnerKey,
+  normalizePassportAlias,
+  rawContractAddress,
+} from '../src/integrations/midnames/preview.js';
+
+describe('Midnames Passport adapter', () => {
+  it('normalizes a .night alias', () => {
+    expect(normalizePassportAlias('  Alice.NIGHT. ')).toBe('alice');
+  });
+
+  it('rejects invalid and nested aliases', () => {
+    expect(() => normalizePassportAlias('-alice')).toThrow(/Alias must/);
+    expect(() => normalizePassportAlias('alice.wallet.night')).toThrow(/Alias must/);
+  });
+
+  it('normalizes raw and formatted contract addresses', () => {
+    const raw = 'ab'.repeat(32);
+    expect(rawContractAddress(raw)).toBe(raw);
+    expect(rawContractAddress(`0200${raw}`)).toBe(raw);
+    expect(contractAddressBytes(`0x${raw}`)).toEqual(new Uint8Array(Buffer.from(raw, 'hex')));
+  });
+
+  it('derives the Midnames owner key with the contract domain separator', () => {
+    const secret = new Uint8Array(32).fill(7);
+    const tag = Buffer.alloc(32);
+    tag.write('midnight.domains');
+    const expected = createHash('sha256')
+      .update(Buffer.concat([tag, Buffer.from(secret)]))
+      .digest('hex');
+    expect(Buffer.from(deriveMidnamesOwnerKey(secret)).toString('hex')).toBe(expected);
+  });
+});


### PR DESCRIPTION
Refs #100. Based on `demo/mn-passport-dynamic-flow` so the review surface is one commit (`d50c513`, 14 files, +1083) rather than the Dynamic work underneath it.

## What this does

Integrates the Passport account-custody contract with [`midnames/sdk`](https://github.com/midnames/sdk), pinned to `83f8422b0b39113d5c14aa8adc3d42804edaf492` — the current head of the `preview` branch. `scripts/prepare-midnames-preview.mjs` clones and builds that exact revision into `.cache/`, so no manual checkout is needed and a reviewer cannot accidentally test a different version.

## Acceptance criteria

| Criterion | Implementation | What proves it |
|---|---|---|
| Midnames deployed on local network | `src/integrations/midnames/preview.ts` → `deployMidnamesTld` | Scenario deploys the `.night` TLD fresh on every run |
| AAC claims an alias using Midnames | `claimPassportAlias`, `resolvePassportAlias` | `alice.night` registered to the AAC, then resolved **from an unrelated wallet** — a third party can read the binding |
| External account deposits a shielded token by alias, calling the deposit circuit | `depositShieldedByAlias`, driven by `src/tests/lifecycle-midnames.ts` | A second funded wallet mints a shielded token, resolves the alias, calls `deposit_shielded` on the **resolved** address. Passes only once the AAC ledger holds the coins — not on transaction submission |

## Verify it

```sh
cd experiments/account-custody-prototype
npm run test:midnames        # needs the localnet, bun, and compact 0.31.1
```

Every run writes `midnames-deployment.json` with addresses and transaction IDs. Run of 2026/07/27:

| Item | Value |
|---|---|
| `.night` TLD | `0bc43835dd2d8f40…` |
| AAC | `8a41ec09c6353ae3…` |
| Alias registration tx | `00281d1157ba4303…` |
| Shielded mint tx | `00521f1f95261d92…` |
| Deposit-by-alias tx | `00bd1c8436f857a9…` |
| Result | `lifecycle-midnames: PASS` |

Unit coverage in `test/midnames.test.ts`: alias normalisation, nested-alias rejection, address normalisation, owner-key domain separation.

## What this does not do

- **The browser demo does not use Midnames.** This is a contract and client-library integration; the demo UI still resolves through the local `identity_registry` contract. Wiring the UI is separate work — see the scoping question on #100.
- **Localnet only.** Preview needs access we do not have yet.

## Files

`src/integrations/midnames/preview.ts` (adapter) · `src/tests/lifecycle-midnames.ts` (scenario) · `test/midnames.test.ts` · `scripts/prepare-midnames-preview.mjs` (pinning) · `src/node/transfers.ts` (funding a second wallet) · `MIDNAMES-INTEGRATION.md` (run instructions, acceptance flow, code map)
