### PR TITLE
ci: add org-standard scan workflow

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,0 +1,37 @@
+name: Scan
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+concurrency:
+  group:
+    ${{ github.event_name != 'merge_group' && format('{0}-{1}', github.workflow, github.head_ref) || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  # needed to stop rate limiting of downloads during scan
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
+      statuses: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  #v7.0.1
+
+      - name: Scan code
+        uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -14,10 +14,6 @@ concurrency:
     ${{ github.event_name != 'merge_group' && format('{0}-{1}', github.workflow, github.head_ref) || github.run_id }}
   cancel-in-progress: true
 
-env:
-  # needed to stop rate limiting of downloads during scan
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   scan:
     runs-on: ubuntu-24.04
@@ -33,5 +29,9 @@ jobs:
 
       - name: Scan code
         uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167
+        env:
+          # step-scoped: avoids exposing the token to every step (rate-limit
+          # relief for scanner downloads only)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #118

Adds the standard org `scan.yaml` (Scorecard + Opengrep + Checkov via `midnightntwrk/upload-sarif-github-action`, same pinned SHA as sibling repos; runner pinned to `ubuntu-24.04`). This produces the `scan` status that `main`'s branch protection already requires, unblocking #98 and every future PR.

After merge: existing PRs (e.g. #98) need a branch push or close/reopen to trigger the workflow; the first run also seeds the repo's Code Scanning tab.

_AI-assisted (bot:ai-assisted label unavailable in this repo)._