### PR TITLE
Reject malformed hex instead of silently miscoding it

### DIFF
--- a/experiments/account-custody-prototype/src/wallet/hex.ts
+++ b/experiments/account-custody-prototype/src/wallet/hex.ts
@@ -4,6 +4,9 @@
 export function hexToBytes(hex: string): Uint8Array {
   const clean = hex.replace(/^0x/, '');
   if (clean.length % 2 !== 0) throw new Error(`odd-length hex: ${hex}`);
+  // parseInt would coerce a non-hex pair to NaN, which a Uint8Array then
+  // silently stores as 0 — a typo in a pasted secret must throw instead.
+  if (!/^[0-9a-fA-F]*$/.test(clean)) throw new Error(`invalid hex character in: ${hex}`);
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
     out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);

--- a/experiments/account-custody-prototype/test/hex-strict.test.ts
+++ b/experiments/account-custody-prototype/test/hex-strict.test.ts
@@ -1,0 +1,38 @@
+// hexToBytes must reject malformed hex rather than miscode it: parseInt
+// coerces a non-hex pair to NaN, which a Uint8Array stores as 0, so a typo
+// in a pasted secret (guardian σ, grant secret, device secret) used to
+// substitute a valid-looking byte instead of erroring.
+
+import { describe, it, expect } from 'vitest';
+import { hexToBytes, bytesToHex } from '../src/wallet/hex.js';
+
+describe('hexToBytes strict digit validation', () => {
+  it('rejects non-hex characters instead of coercing them to zero', () => {
+    expect(() => hexToBytes('zz11')).toThrow(/invalid hex character/);
+  });
+
+  it('rejects a single mistyped character anywhere in the string', () => {
+    expect(() => hexToBytes('aabbccdg')).toThrow(/invalid hex character/);
+    expect(() => hexToBytes('g0aabbcc')).toThrow(/invalid hex character/);
+  });
+
+  it('rejects whitespace and separators', () => {
+    expect(() => hexToBytes('aa  bb')).toThrow(/invalid hex character/);
+    expect(() => hexToBytes('aa:bb1')).toThrow(/invalid hex character/);
+  });
+
+  it('still rejects odd-length input', () => {
+    expect(() => hexToBytes('abc')).toThrow(/odd-length hex/);
+  });
+
+  it('accepts mixed case, a 0x prefix, and the empty string', () => {
+    expect(hexToBytes('AaBbCc')).toEqual(new Uint8Array([0xaa, 0xbb, 0xcc]));
+    expect(hexToBytes('0xff00')).toEqual(new Uint8Array([0xff, 0x00]));
+    expect(hexToBytes('')).toEqual(new Uint8Array(0));
+  });
+
+  it('round-trips through bytesToHex', () => {
+    const bytes = new Uint8Array([0, 1, 0x7f, 0x80, 0xff]);
+    expect(hexToBytes(bytesToHex(bytes))).toEqual(bytes);
+  });
+});


### PR DESCRIPTION
parseInt coerces a non-hex pair to NaN, which a Uint8Array stores as 0, so hexToBytes('zz11') returned [0, 17] instead of throwing. Every human-pasted hex value (guardian sigma, grant secret, device secret) goes through this helper, and buss-wasm's canonicity check does not catch a single zeroed byte, so a typo produced a silently wrong secret at every layer. The helper now validates the digits and throws.

Unit suite green (29 tests). No behavioural change for well-formed input. Touches functions adjacent to the hex-bounds PR; hunks do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)