### PR TITLE
Throw on oversized input instead of silently truncating to 32 bytes

### DIFF
--- a/experiments/account-custody-prototype/app/src/lib/providers.ts
+++ b/experiments/account-custody-prototype/app/src/lib/providers.ts
@@ -258,15 +258,19 @@ export function compiledFaucetContract() {
 export function userAddressBytes(walletCtx: WalletContext): Uint8Array {
   const pk: any = walletCtx.unshieldedKeystore.getPublicKey();
   const hex: string = typeof pk?.toHexString === 'function' ? pk.toHexString() : String(pk?.bytes ?? pk);
-  const out = new Uint8Array(32);
-  out.set(hexToBytes(hex.replace(/^0x/, '')).subarray(0, 32));
-  return out;
+  const bytes = hexToBytes(hex.replace(/^0x/, ''));
+  if (bytes.length !== 32) {
+    throw new Error(`unshielded public key: expected 32 bytes, got ${bytes.length}`);
+  }
+  return bytes;
 }
 
 export function coinPublicKeyBytes(state: any): Uint8Array {
   const cpk = state.shielded.coinPublicKey;
   const hex: string = typeof cpk?.toHexString === 'function' ? cpk.toHexString() : String(cpk?.bytes ?? cpk);
-  const out = new Uint8Array(32);
-  out.set(hexToBytes(hex.replace(/^0x/, '')).subarray(0, 32));
-  return out;
+  const bytes = hexToBytes(hex.replace(/^0x/, ''));
+  if (bytes.length !== 32) {
+    throw new Error(`coin public key: expected 32 bytes, got ${bytes.length}`);
+  }
+  return bytes;
 }

--- a/experiments/account-custody-prototype/src/node/wallet.ts
+++ b/experiments/account-custody-prototype/src/node/wallet.ts
@@ -202,9 +202,11 @@ export function userAddressBytes(walletCtx: WalletContext): Uint8Array {
           ? Buffer.from(pk.bytes).toString('hex')
           : String(pk);
   const clean = hex.replace(/^0x/, '');
-  const out = new Uint8Array(32);
-  out.set(Buffer.from(clean, 'hex').subarray(0, 32));
-  return out;
+  const bytes = Buffer.from(clean, 'hex');
+  if (bytes.length !== 32) {
+    throw new Error(`unshielded public key: expected 32 bytes, got ${bytes.length}`);
+  }
+  return new Uint8Array(bytes);
 }
 
 // The user's Zswap coin public key bytes, as ZswapCoinPublicKey expects.
@@ -213,7 +215,9 @@ export function coinPublicKeyBytes(state: any): Uint8Array {
   const hex: string =
     typeof cpk?.toHexString === 'function' ? cpk.toHexString() : String(cpk?.bytes ?? cpk);
   const clean = hex.replace(/^0x/, '');
-  const out = new Uint8Array(32);
-  out.set(Buffer.from(clean, 'hex').subarray(0, 32));
-  return out;
+  const bytes = Buffer.from(clean, 'hex');
+  if (bytes.length !== 32) {
+    throw new Error(`coin public key: expected 32 bytes, got ${bytes.length}`);
+  }
+  return new Uint8Array(bytes);
 }

--- a/experiments/account-custody-prototype/src/wallet/hex.ts
+++ b/experiments/account-custody-prototype/src/wallet/hex.ts
@@ -16,11 +16,16 @@ export function hexToBytes(hex: string): Uint8Array {
 
 // Left-aligned 32-byte buffer, zero-padded on the right — matches the
 // hexToBytes32 recipe the contract-custody-feasibility tests used for
-// token colours and user addresses.
+// token colours and user addresses. Zero-padding short values is the
+// documented contract; anything longer than 32 bytes is a caller bug and
+// must throw rather than be silently truncated.
 export function hexToBytes32(hex: string): Uint8Array {
   const bytes = hexToBytes(hex);
+  if (bytes.length > 32) {
+    throw new Error(`hex value longer than 32 bytes: got ${bytes.length}`);
+  }
   const out = new Uint8Array(32);
-  out.set(bytes.subarray(0, Math.min(32, bytes.length)));
+  out.set(bytes);
   return out;
 }
 

--- a/experiments/account-custody-prototype/test/hex-bounds.test.ts
+++ b/experiments/account-custody-prototype/test/hex-bounds.test.ts
@@ -1,0 +1,32 @@
+// hexToBytes32 must be fail-closed on oversized input: silently dropping
+// everything past 32 bytes has no defence if a caller's length assumption
+// changes later (for example an SDK output growing a prefix). Zero-padding
+// short values stays — that is the helper's documented contract, used for
+// token colours like '01'.
+
+import { describe, it, expect } from 'vitest';
+import { hexToBytes32 } from '../src/wallet/hex.js';
+
+describe('hexToBytes32 length bounds', () => {
+  it('rejects input longer than 32 bytes instead of truncating', () => {
+    expect(() => hexToBytes32('ab'.repeat(33))).toThrow(/longer than 32 bytes/);
+  });
+
+  it('rejects a 33-byte value that shares a 32-byte prefix with a valid one', () => {
+    const valid = 'cd'.repeat(32);
+    expect(hexToBytes32(valid)).toHaveLength(32);
+    expect(() => hexToBytes32(valid + 'ee')).toThrow(/longer than 32 bytes/);
+  });
+
+  it('still zero-pads short values on the right', () => {
+    const out = hexToBytes32('01');
+    expect(out).toHaveLength(32);
+    expect(out[0]).toBe(1);
+    expect(out.slice(1).every((b) => b === 0)).toBe(true);
+  });
+
+  it('accepts exactly 32 bytes unchanged', () => {
+    const out = hexToBytes32('ff'.repeat(32));
+    expect(out.every((b) => b === 0xff)).toBe(true);
+  });
+});


### PR DESCRIPTION
hexToBytes32 dropped everything past 32 bytes with no warning, and the wallet public-key helpers (src/node/wallet.ts plus the app mirror) carried the same subarray(0, 32) pattern inline. Nothing exploits it today, but the helpers were not fail-closed against a longer-than-expected value arriving later. hexToBytes32 keeps its documented zero-padding for short values and now throws past 32 bytes; the public-key helpers expect exactly 32 bytes and throw otherwise.

Unit suite green (27 tests). The exact-32 assertion is only exercised on localnet; worth a lifecycle run if in doubt. Touches functions adjacent to the strict-hex PR; hunks do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)