### PR TITLE
Validate decoded wire payloads instead of trusting the type assertion

### DIFF
--- a/experiments/account-custody-prototype/src/wallet/buss-core.ts
+++ b/experiments/account-custody-prototype/src/wallet/buss-core.ts
@@ -103,24 +103,72 @@ function encode(kind: string, payload: unknown): string {
   return `${kind}.v0.${bytesToB64url(json)}`;
 }
 
-function decode<T>(kind: string, s: string): T {
+// A hand-edited or corrupted paste must fail here, legibly, not deep inside
+// a wasm call: `JSON.parse(...) as T` is a compile-time-only assertion, so
+// each wire format validates its decoded shape. Unknown extra fields are
+// tolerated (forward compatibility); known fields must have the right type.
+
+const isHexString = (v: unknown, bytes: number): boolean =>
+  typeof v === 'string' && v.length === bytes * 2 && /^[0-9a-fA-F]*$/.test(v);
+
+const isIndex = (v: unknown): boolean =>
+  typeof v === 'number' && Number.isInteger(v) && v >= 1;
+
+type ShapeCheck = (v: unknown) => string | null;
+
+const checkGuardianRequest: ShapeCheck = (v) => {
+  const r = v as Partial<GuardianRequest> | null;
+  if (typeof r !== 'object' || r === null) return 'payload is not an object';
+  if (typeof r.address !== 'string' || r.address.length === 0)
+    return 'address must be a non-empty string';
+  if (!isHexString(r.sessionNonce, 32)) return 'sessionNonce must be 32 bytes of hex';
+  if (!isIndex(r.index)) return 'index must be a positive integer';
+  return null;
+};
+
+const checkGuardianReply: ShapeCheck = (v) => {
+  const r = v as Partial<GuardianReply> | null;
+  if (typeof r !== 'object' || r === null) return 'payload is not an object';
+  if (!isIndex(r.index)) return 'index must be a positive integer';
+  if (!isHexString(r.sigma, 32)) return 'sigma must be 32 bytes of hex';
+  return null;
+};
+
+const checkPaperKey: ShapeCheck = (v) => {
+  const p = v as Partial<PaperKey> | null;
+  if (typeof p !== 'object' || p === null) return 'payload is not an object';
+  if (!isIndex(p.index)) return 'index must be a positive integer';
+  if (!isHexString(p.sk, 32)) return 'sk must be 32 bytes of hex';
+  return null;
+};
+
+function decode<T>(kind: string, s: string, check: ShapeCheck): T {
   const parts = s.trim().split('.');
   if (parts.length !== 3 || parts[0] !== kind || parts[1] !== 'v0') {
     throw new Error(`expected a ${kind}.v0.… string`);
   }
-  return JSON.parse(new TextDecoder().decode(b64urlToBytes(parts[2]))) as T;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(b64urlToBytes(parts[2])));
+  } catch {
+    throw new Error(`${kind}.v0 payload is not valid base64url JSON`);
+  }
+  const problem = check(parsed);
+  if (problem !== null) throw new Error(`${kind}.v0 payload: ${problem}`);
+  return parsed as T;
 }
 
 export const encodeGuardianRequest = (r: GuardianRequest): string => encode('buss-req', r);
 export const decodeGuardianRequest = (s: string): GuardianRequest =>
-  decode<GuardianRequest>('buss-req', s);
+  decode<GuardianRequest>('buss-req', s, checkGuardianRequest);
 
 export const encodeGuardianReply = (r: GuardianReply): string => encode('buss-sig', r);
 export const decodeGuardianReply = (s: string): GuardianReply =>
-  decode<GuardianReply>('buss-sig', s);
+  decode<GuardianReply>('buss-sig', s, checkGuardianReply);
 
 export const encodePaperKey = (p: PaperKey): string => encode('buss-paper', p);
-export const decodePaperKey = (s: string): PaperKey => decode<PaperKey>('buss-paper', s);
+export const decodePaperKey = (s: string): PaperKey =>
+  decode<PaperKey>('buss-paper', s, checkPaperKey);
 
 /** Which wire format a pasted string is, if any. */
 export function classifyPaste(s: string): 'request' | 'reply' | 'paper' | null {

--- a/experiments/account-custody-prototype/test/wire-schema.test.ts
+++ b/experiments/account-custody-prototype/test/wire-schema.test.ts
@@ -1,0 +1,90 @@
+// The copy-paste wire formats must reject a tampered or corrupted payload
+// at decode time with a legible error, instead of letting a mistyped object
+// (sigma as a number, a missing index) propagate into wasm.guardian_sigma
+// or buss_reconstruct.
+
+import { describe, it, expect } from 'vitest';
+import {
+  encodeGuardianRequest,
+  decodeGuardianRequest,
+  encodeGuardianReply,
+  decodeGuardianReply,
+  encodePaperKey,
+  decodePaperKey,
+} from '../src/wallet/buss-core.js';
+
+const b64url = (v: unknown): string =>
+  Buffer.from(JSON.stringify(v)).toString('base64url');
+
+const HEX32 = 'ab'.repeat(32);
+
+describe('wire format schema validation', () => {
+  it('round-trips well-formed payloads', () => {
+    const req = { address: '0200aabb', sessionNonce: HEX32, index: 3 };
+    expect(decodeGuardianRequest(encodeGuardianRequest(req))).toEqual(req);
+
+    const reply = { index: 2, sigma: HEX32 };
+    expect(decodeGuardianReply(encodeGuardianReply(reply))).toEqual(reply);
+
+    const paper = { index: 1, sk: HEX32 };
+    expect(decodePaperKey(encodePaperKey(paper))).toEqual(paper);
+  });
+
+  it('rejects sigma present as a number instead of a hex string', () => {
+    const s = `buss-sig.v0.${b64url({ index: 2, sigma: 12345 })}`;
+    expect(() => decodeGuardianReply(s)).toThrow(/sigma must be 32 bytes of hex/);
+  });
+
+  it('rejects a sigma of the wrong length', () => {
+    const s = `buss-sig.v0.${b64url({ index: 2, sigma: 'ab'.repeat(16) })}`;
+    expect(() => decodeGuardianReply(s)).toThrow(/sigma must be 32 bytes of hex/);
+  });
+
+  it('rejects a missing or non-positive index', () => {
+    expect(() => decodeGuardianReply(`buss-sig.v0.${b64url({ sigma: HEX32 })}`)).toThrow(
+      /index must be a positive integer/,
+    );
+    expect(() =>
+      decodeGuardianReply(`buss-sig.v0.${b64url({ index: 0, sigma: HEX32 })}`),
+    ).toThrow(/index must be a positive integer/);
+    expect(() =>
+      decodeGuardianReply(`buss-sig.v0.${b64url({ index: 1.5, sigma: HEX32 })}`),
+    ).toThrow(/index must be a positive integer/);
+  });
+
+  it('rejects a request with a malformed session nonce or empty address', () => {
+    expect(() =>
+      decodeGuardianRequest(
+        `buss-req.v0.${b64url({ address: '0200aabb', sessionNonce: 'xyz', index: 1 })}`,
+      ),
+    ).toThrow(/sessionNonce must be 32 bytes of hex/);
+    expect(() =>
+      decodeGuardianRequest(
+        `buss-req.v0.${b64url({ address: '', sessionNonce: HEX32, index: 1 })}`,
+      ),
+    ).toThrow(/address must be a non-empty string/);
+  });
+
+  it('rejects a paper key whose sk is not a 32-byte hex string', () => {
+    expect(() => decodePaperKey(`buss-paper.v0.${b64url({ index: 1, sk: 42 })}`)).toThrow(
+      /sk must be 32 bytes of hex/,
+    );
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(() => decodeGuardianReply(`buss-sig.v0.${b64url(42)}`)).toThrow(
+      /payload is not an object/,
+    );
+  });
+
+  it('rejects corrupted base64url with a legible error', () => {
+    expect(() => decodeGuardianReply('buss-sig.v0.%%%%')).toThrow(
+      /not valid base64url JSON/,
+    );
+  });
+
+  it('tolerates unknown extra fields (forward compatibility)', () => {
+    const s = `buss-sig.v0.${b64url({ index: 2, sigma: HEX32, note: 'later-version field' })}`;
+    expect(decodeGuardianReply(s).sigma).toBe(HEX32);
+  });
+});


### PR DESCRIPTION
The copy-paste wire formats decoded with JSON.parse(...) as T, a compile-time-only assertion. A hand-edited or corrupted paste (sigma as a number, a missing index) decoded without error and propagated into wasm.guardian_sigma or buss_reconstruct with no early rejection. Each wire format now validates its decoded shape and rejects with an error naming the offending field; corrupted base64url gets a legible error, and unknown extra fields stay tolerated for forward compatibility.

Unit suite green (32 tests): round trips, per-field tamper cases, non-object payloads, corrupted base64url.

🤖 Generated with [Claude Code](https://claude.com/claude-code)