### PR TITLE
Reconcile claimed token effects against the mirror in the simulator

### DIFF
--- a/experiments/account-custody-prototype/test/settlement.test.ts
+++ b/experiments/account-custody-prototype/test/settlement.test.ts
@@ -1,0 +1,116 @@
+// The deposit-accounting invariant (the night_balances mirror never
+// overstating actual custodied value) used to be checkable only on a real
+// node: the simulator executed circuits without settling token effects, so
+// a change that credited the mirror without receiving the coin passed the
+// whole unit suite. The simulator now reconciles the mirror delta against
+// the claimed token effects after every call; these tests pin the checker
+// itself, and every other simulator test exercises the wiring.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { AccountSimulator, reconcileNightSettlement } from './simulator.js';
+import { randomBytes32, hexToBytes32 } from '../src/wallet/hex.js';
+import { deviceCommitment } from '../src/wallet/contract.js';
+
+const NIGHT = hexToBytes32('01');
+const OTHER = hexToBytes32('02');
+const RECIPIENT = { bytes: hexToBytes32('aabbcc') };
+
+const totals = (entries: Array<[string, bigint]>) => new Map(entries);
+
+describe('reconcileNightSettlement', () => {
+  it('accepts a mirror credit matched by a claimed input', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'deposit_night',
+        claimedIn: totals([['01', 1000n]]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([['01', 1000n]]),
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a mirror credit with no claimed coin behind it (overstatement)', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'deposit_night',
+        claimedIn: totals([]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([['01', 1000n]]),
+      }),
+    ).toThrow(/night settlement mismatch in deposit_night for color 01/);
+  });
+
+  it('rejects a claimed coin the mirror never credited (understatement)', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'deposit_night',
+        claimedIn: totals([['01', 1000n]]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([]),
+      }),
+    ).toThrow(/night settlement mismatch/);
+  });
+
+  it('rejects a partial credit (deposited amount != credited amount)', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'deposit_night',
+        claimedIn: totals([['01', 1000n]]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([['01', 999n]]),
+      }),
+    ).toThrow(/mirror moved by 999, claimed token effects total 1000/);
+  });
+
+  it('rejects a withdrawal that debits the mirror without sending', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'withdraw_night',
+        claimedIn: totals([]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([['01', -400n]]),
+      }),
+    ).toThrow(/night settlement mismatch in withdraw_night/);
+  });
+
+  it('reconciles colors independently', () => {
+    expect(() =>
+      reconcileNightSettlement({
+        circuit: 'deposit_night',
+        claimedIn: totals([
+          ['01', 100n],
+          ['02', 200n],
+        ]),
+        claimedOut: totals([]),
+        mirrorDelta: totals([
+          ['01', 100n],
+          ['02', 150n],
+        ]),
+      }),
+    ).toThrow(/for color 02/);
+  });
+});
+
+describe('settlement reconciliation through the simulator', () => {
+  let sim: AccountSimulator;
+
+  beforeEach(() => {
+    sim = new AccountSimulator({
+      deviceSecret: randomBytes32(),
+      recoverySecret: randomBytes32(),
+    });
+  });
+
+  it('passes conforming deposit and withdrawal flows', () => {
+    sim.call('deposit_night', NIGHT, 1000n);
+    sim.call('deposit_night', OTHER, 50n);
+    sim.call('withdraw_night', NIGHT, 400n, RECIPIENT);
+    expect(sim.ledger().night_balances.lookup(NIGHT)).toBe(600n);
+    expect(sim.ledger().night_balances.lookup(OTHER)).toBe(50n);
+  });
+
+  it('passes circuits that move no tokens at all', () => {
+    expect(() => sim.call('add_device', deviceCommitment(randomBytes32()))).not.toThrow();
+  });
+});

--- a/experiments/account-custody-prototype/test/simulator.ts
+++ b/experiments/account-custody-prototype/test/simulator.ts
@@ -1,8 +1,12 @@
 // In-process contract simulator over @midnight-ntwrk/compact-runtime.
 // Executes circuits (including witness evaluation) against a local
 // QueryContext — no node, indexer, or proof server required. Token
-// operations record their effects but are not settled; balance-mirror
-// ledger fields make the outcomes observable anyway.
+// operations are not settled against a real ledger, but the QueryContext
+// records what the ledger WOULD enforce (claimed token effects), and
+// every call reconciles the night_balances mirror against those claims —
+// see reconcileNightSettlement below. Shielded effects carry commitments,
+// not amounts, so shielded settlement remains observable only through the
+// mirror fields plus the devnet e2e scripts.
 
 import {
   createConstructorContext,
@@ -23,6 +27,7 @@ import {
   privateStateFromSecrets,
   type AccountPrivateState,
 } from '../src/wallet/witnesses.js';
+import { bytesToHex } from '../src/wallet/hex.js';
 
 const COIN_PUBLIC_KEY = '00'.repeat(32);
 
@@ -30,6 +35,82 @@ export interface SimulatorSecrets {
   deviceSecret?: Uint8Array;
   grantSecret?: Uint8Array;
   recoverySecret?: Uint8Array;
+}
+
+// ── Unshielded settlement reconciliation ────────────────────────────────────
+//
+// On a real node the ledger matches a call's claimed token effects against
+// the transaction's actual inputs and outputs; the simulator has no
+// transaction, so without this check a change that credits the mirror
+// without receiving the coin (or debits without sending) would pass every
+// unit test and only surface on devnet. The QueryContext accumulates the
+// claims (effects.unshieldedInputs / unshieldedOutputs), so after every
+// call the mirror delta must equal claimed inputs minus claimed outputs,
+// per color.
+
+/** color hex → total amount. */
+export type UnshieldedTotals = Map<string, bigint>;
+
+interface UnshieldedTokenType {
+  tag: string;
+  raw: string;
+}
+
+function claimedTotals(
+  effects: { unshieldedInputs: Map<UnshieldedTokenType, bigint>; unshieldedOutputs: Map<UnshieldedTokenType, bigint> },
+  side: 'unshieldedInputs' | 'unshieldedOutputs',
+): UnshieldedTotals {
+  const out: UnshieldedTotals = new Map();
+  for (const [tokenType, amount] of effects[side]) {
+    if (tokenType.tag !== 'unshielded') continue;
+    out.set(tokenType.raw, (out.get(tokenType.raw) ?? 0n) + amount);
+  }
+  return out;
+}
+
+function mirrorTotals(l: Ledger): UnshieldedTotals {
+  const out: UnshieldedTotals = new Map();
+  for (const [color, amount] of l.night_balances) {
+    out.set(bytesToHex(color), amount);
+  }
+  return out;
+}
+
+function totalsDelta(before: UnshieldedTotals, after: UnshieldedTotals): UnshieldedTotals {
+  const out: UnshieldedTotals = new Map();
+  for (const color of new Set([...before.keys(), ...after.keys()])) {
+    const d = (after.get(color) ?? 0n) - (before.get(color) ?? 0n);
+    if (d !== 0n) out.set(color, d);
+  }
+  return out;
+}
+
+/**
+ * Throws unless, for every color touched, the night_balances mirror moved
+ * by exactly (claimed unshielded inputs − claimed unshielded outputs).
+ * Exported so the check itself is unit-testable.
+ */
+export function reconcileNightSettlement(opts: {
+  circuit: string;
+  claimedIn: UnshieldedTotals;
+  claimedOut: UnshieldedTotals;
+  mirrorDelta: UnshieldedTotals;
+}): void {
+  const colors = new Set([
+    ...opts.claimedIn.keys(),
+    ...opts.claimedOut.keys(),
+    ...opts.mirrorDelta.keys(),
+  ]);
+  for (const color of colors) {
+    const claimed = (opts.claimedIn.get(color) ?? 0n) - (opts.claimedOut.get(color) ?? 0n);
+    const mirrored = opts.mirrorDelta.get(color) ?? 0n;
+    if (claimed !== mirrored) {
+      throw new Error(
+        `night settlement mismatch in ${opts.circuit} for color ${color}: ` +
+          `mirror moved by ${mirrored}, claimed token effects total ${claimed}`,
+      );
+    }
+  }
 }
 
 export class AccountSimulator {
@@ -66,10 +147,27 @@ export class AccountSimulator {
     return this;
   }
 
-  /** Call an impure circuit; commits the resulting context on success. */
+  /**
+   * Call an impure circuit; commits the resulting context on success and
+   * reconciles the night_balances mirror against the call's claimed
+   * unshielded token effects.
+   */
   call(circuit: string, ...args: unknown[]): unknown {
+    const effectsBefore = this.ctx.currentQueryContext.effects as any;
+    const inBefore = claimedTotals(effectsBefore, 'unshieldedInputs');
+    const outBefore = claimedTotals(effectsBefore, 'unshieldedOutputs');
+    const mirrorBefore = mirrorTotals(this.ledger());
+
     const r = this.contract.impureCircuits[circuit](this.ctx, ...args);
     this.ctx = r.context;
+
+    const effectsAfter = this.ctx.currentQueryContext.effects as any;
+    reconcileNightSettlement({
+      circuit,
+      claimedIn: totalsDelta(inBefore, claimedTotals(effectsAfter, 'unshieldedInputs')),
+      claimedOut: totalsDelta(outBefore, claimedTotals(effectsAfter, 'unshieldedOutputs')),
+      mirrorDelta: totalsDelta(mirrorBefore, mirrorTotals(this.ledger())),
+    });
     return r.result;
   }
 


### PR DESCRIPTION
The simulator executed circuits without settling token effects, so the deposit-accounting invariant (night_balances never overstating custodied value) was only checkable on a real node: a change crediting the mirror without receiving the coin passed the whole unit suite. The QueryContext does record what the ledger would enforce (claimed unshielded inputs and outputs), so call() now reconciles the mirror delta against those claims per color and throws on any mismatch. Shielded effects carry commitments rather than amounts; shielded settlement remains a devnet-only check and the simulator header now says so explicitly.

Unit suite green (31 tests): all 23 pre-existing tests run through the reconciliation, 8 new tests pin the checker (overstatement, understatement, partial credit, unbacked debit, per-color independence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)