### PR TITLE
Enforce backup freshness on-chain as an inequality backstop

### DIFF
--- a/experiments/account-custody-prototype/contracts/account.compact
+++ b/experiments/account-custody-prototype/contracts/account.compact
@@ -42,9 +42,14 @@ import CompactStandardLibrary;
 // Two client-side rules are load-bearing (see
 // research/anarkey-buss-recovery-assessment.md):
 //   - Every publish_recovery_backup MUST use a fresh session nonce AND a
-//     fresh recovery secret. Correlated φ vectors across sessions degrade
-//     the threshold; stale φ of a superseded secret is harmless only
-//     because the commitment is rotated with it.
+//     fresh recovery secret (ANARKey Remark 6.1). Reusing a session nonce
+//     with the same guardian roster does not merely degrade the threshold:
+//     both ceremonies' polynomials agree at every guardian point, so their
+//     difference is solvable from the public φ vectors alone, and one
+//     (t+1) quorum on either ceremony opens both secrets. The circuit
+//     enforces an inequality backstop against accidental reuse; genuine
+//     freshness remains a client obligation. Stale φ of a superseded
+//     secret is harmless only because the commitment is rotated with it.
 //   - recover() clears φ: after recovery the account has a recovery secret
 //     but no published backup until the owner runs a new guardian ceremony.
 //
@@ -406,8 +411,9 @@ export circuit revoke_grant(grant: Field): [] {
 // (covers e.g. three guardians at threshold two, φ = 2, or five guardians
 // at threshold three, φ = 3); unused slots must be zero and are gated by
 // recovery_phi_len. The client MUST rotate the recovery secret and use a
-// fresh session nonce on every call — re-publishing φ for the same secret
-// with correlated guardian shares degrades the threshold (see header).
+// fresh session nonce on every call — nonce reuse under the same roster
+// collapses the independence of the two ceremonies (see header). The
+// circuit rejects the previous nonce and commitment as a backstop.
 
 export circuit publish_recovery_backup(
   new_recovery_commitment: Field,
@@ -421,6 +427,14 @@ export circuit publish_recovery_backup(
   require_device();
   assert(phi_len >= (1 as Uint<8>), "phi must not be empty");
   assert(phi_len <= (4 as Uint<8>), "phi length out of range");
+  // On-chain backstop for the freshness MUST above: reject reuse of the
+  // stored session nonce or recovery commitment. Equality with the stored
+  // value is the only reuse the contract can see — genuine freshness
+  // (independent randomness in the client) stays a client obligation.
+  // The constructor's all-zero recovery_session sentinel also makes an
+  // all-zero nonce (broken client RNG) unacceptable on the first backup.
+  assert(session_nonce != recovery_session, "session nonce reused");
+  assert(new_recovery_commitment != recovery, "recovery commitment reused");
   recovery         = disclose(new_recovery_commitment);
   recovery_session = disclose(session_nonce);
   recovery_phi.insert(1 as Uint<8>, disclose(phi_1));

--- a/experiments/account-custody-prototype/src/wallet/account.ts
+++ b/experiments/account-custody-prototype/src/wallet/account.ts
@@ -158,10 +158,11 @@ export class PassportAccount {
   /**
    * Publish a BUSS recovery backup: rotates the recovery commitment to a
    * FRESH secret and stores φ under a FRESH session nonce (both rules are
-   * load-bearing — see contracts/account.compact header). Device-authorised.
-   * `phi` holds 1..4 entries of 32 bytes each, straight from buildPhi();
-   * each is converted to the on-chain Field value here, so a non-canonical
-   * entry is rejected before it can land on-chain.
+   * load-bearing — see contracts/account.compact header; the circuit
+   * rejects reuse of the stored nonce or commitment as a backstop).
+   * Device-authorised. `phi` holds 1..4 entries of 32 bytes each, straight
+   * from buildPhi(); each is converted to the on-chain Field value here, so
+   * a non-canonical entry is rejected before it can land on-chain.
    */
   publishRecoveryBackup(
     newRecoverySecret: Uint8Array,

--- a/experiments/account-custody-prototype/test/backup-freshness.test.ts
+++ b/experiments/account-custody-prototype/test/backup-freshness.test.ts
@@ -1,0 +1,75 @@
+// publish_recovery_backup must reject accidental reuse of the previous
+// session nonce or recovery commitment. ANARKey (Remark 6.1) requires a
+// unique session id per ceremony: with the same roster, a reused nonce
+// makes both ceremonies' polynomials agree at every guardian point, so
+// their difference is computable from the public φ vectors alone and one
+// (t+1) quorum opens both secrets. The on-chain check only catches
+// equality with the stored values — genuine freshness stays a client
+// obligation — but it turns the documented MUST into a hard failure
+// instead of a silent one.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { AccountSimulator } from './simulator.js';
+import { randomBytes32 } from '../src/wallet/hex.js';
+import { recoveryCommitment } from '../src/wallet/contract.js';
+import { newRecoverySecret, newSessionNonce } from '../src/wallet/buss.js';
+
+const ZERO = new Uint8Array(32);
+
+const publish = (
+  sim: AccountSimulator,
+  secret: Uint8Array,
+  nonce: Uint8Array,
+): unknown =>
+  sim.call(
+    'publish_recovery_backup',
+    recoveryCommitment(secret),
+    nonce,
+    randomBytes32(),
+    randomBytes32(),
+    ZERO,
+    ZERO,
+    2n,
+  );
+
+describe('backup freshness backstop', () => {
+  let sim: AccountSimulator;
+  let deviceSecret: Uint8Array;
+
+  beforeEach(() => {
+    deviceSecret = randomBytes32();
+    sim = new AccountSimulator({
+      deviceSecret,
+      recoverySecret: newRecoverySecret(),
+    });
+  });
+
+  it('accepts a backup with a fresh nonce and a rotated commitment', () => {
+    expect(() => publish(sim, newRecoverySecret(), newSessionNonce())).not.toThrow();
+  });
+
+  it('rejects reuse of the stored session nonce even with a rotated secret', () => {
+    const nonce = newSessionNonce();
+    publish(sim, newRecoverySecret(), nonce);
+    expect(() => publish(sim, newRecoverySecret(), nonce)).toThrow(/session nonce reused/);
+  });
+
+  it('rejects re-publishing φ for the current recovery secret', () => {
+    const secret = newRecoverySecret();
+    publish(sim, secret, newSessionNonce());
+    expect(() => publish(sim, secret, newSessionNonce())).toThrow(
+      /recovery commitment reused/,
+    );
+  });
+
+  it('rejects an all-zero nonce on the first backup (constructor sentinel)', () => {
+    expect(() => publish(sim, newRecoverySecret(), ZERO)).toThrow(/session nonce reused/);
+  });
+
+  it('accepts consecutive backups when both values are rotated', () => {
+    publish(sim, newRecoverySecret(), newSessionNonce());
+    expect(() => publish(sim, newRecoverySecret(), newSessionNonce())).not.toThrow();
+    expect(sim.ledger().recovery_phi_len).toBe(2n);
+  });
+});


### PR DESCRIPTION
ANARKey (EPRINT 2025/551, Remark 6.1) requires a unique session id per backup ceremony and the contract header states the same rule as a MUST, but publish_recovery_backup wrote session_nonce and the rotated commitment with no check against the stored values. With the same guardian roster, a reused nonce makes both ceremonies' polynomials agree at every guardian point; their difference is solvable from the public (permanently readable) phi vectors alone, and one (t+1) quorum on either ceremony then opens both secrets. The circuit now rejects the stored session nonce and the stored recovery commitment, and the constructor's all-zero sentinel makes a zero nonce unacceptable on the first backup. This catches accidental reuse only; genuine freshness remains a client obligation, as the comments now spell out. No legitimate flow changes: the client always rotates both values.

Contract recompiled (compact 0.31.1), unit suite green (28 tests). Localnet recovery lifecycle not re-run here.

Note: touches the same circuit as the phi-canonical PR. Hunks do not overlap, but whichever lands second needs a recompile, and once both are in, test/backup-freshness.test.ts must pass Field values in the phi slots (three-line change, happy to rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)