### PR TITLE
Store the recovery backup as Field values so canonicity is typed in

### DIFF
--- a/experiments/account-custody-prototype/app/src/lib/buss.ts
+++ b/experiments/account-custody-prototype/app/src/lib/buss.ts
@@ -12,6 +12,8 @@ export const buss = makeBussApi(wasm);
 export {
   sessionIdBytes,
   paramsFromPhi,
+  phiFieldFromBytes,
+  phiBytesFromField,
   newSessionNonce,
   encodeGuardianRequest,
   decodeGuardianRequest,

--- a/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
+++ b/experiments/account-custody-prototype/app/src/views/RecoveryPanel.tsx
@@ -8,6 +8,7 @@ import {
   buss,
   newSessionNonce,
   paramsFromPhi,
+  phiBytesFromField,
   encodeGuardianRequest,
   decodeGuardianRequest,
   encodeGuardianReply,
@@ -576,7 +577,7 @@ function RecoverPanel(props: {
 
               log(`TOTAL LOSS — reconstructing from ${quorum.length} shares + ${phiLen} public points…`);
               const phi = Array.from({ length: phiLen }, (_, i) =>
-                ledger.recovery_phi.lookup(BigInt(i + 1)),
+                phiBytesFromField(ledger.recovery_phi.lookup(BigInt(i + 1))),
               );
               const secret = buss.reconstructRecoverySecret(
                 phi,

--- a/experiments/account-custody-prototype/contracts/account.compact
+++ b/experiments/account-custody-prototype/contracts/account.compact
@@ -117,10 +117,14 @@ export ledger device_count: Uint<8>;
 export ledger recovery: Field;
 // Commitment to the recovery secret (derive_recovery_commitment).
 
-export ledger recovery_phi: Map<Uint<8>, Bytes<32>>;
-// BUSS public vector φ, keyed 1..recovery_phi_len. Each entry is the
-// canonical 32-byte encoding of a BLS12-381 scalar field element. Opaque to
-// the contract; interpreted only by the client (buss-wasm).
+export ledger recovery_phi: Map<Uint<8>, Field>;
+// BUSS public vector φ, keyed 1..recovery_phi_len. Each entry is a BLS12-381
+// scalar field element, canonical by construction: the Field type makes a
+// non-canonical encoding unrepresentable on-chain, so a malformed backup is
+// rejected when the publishing transaction is built instead of blocking
+// every guardian's decode at recovery time. Interpreted only by the client
+// (buss-wasm); the client boundary encoding is the canonical little-endian
+// 32-byte repr (buss-core phiFieldFromBytes / phiBytesFromField).
 
 export ledger recovery_phi_len: Uint<8>;
 // Number of live φ entries. 0 = no backup published (recovery possible only
@@ -408,10 +412,10 @@ export circuit revoke_grant(grant: Field): [] {
 export circuit publish_recovery_backup(
   new_recovery_commitment: Field,
   session_nonce: Bytes<32>,
-  phi_1: Bytes<32>,
-  phi_2: Bytes<32>,
-  phi_3: Bytes<32>,
-  phi_4: Bytes<32>,
+  phi_1: Field,
+  phi_2: Field,
+  phi_3: Field,
+  phi_4: Field,
   phi_len: Uint<8>,
 ): [] {
   require_device();

--- a/experiments/account-custody-prototype/src/demo/recover.ts
+++ b/experiments/account-custody-prototype/src/demo/recover.ts
@@ -21,6 +21,7 @@ import {
   paperSigma,
   reconstructRecoverySecret,
   paramsFromPhi,
+  phiBytesFromField,
   encodeGuardianRequest,
   decodeGuardianReply,
   decodePaperKey,
@@ -55,7 +56,9 @@ const reader = await connectAccount(ctx, address, {});
 const l = await reader.ledgerState();
 const phiLen = Number(l.recovery_phi_len);
 if (phiLen === 0) throw new Error('no recovery backup published on this account');
-const phi = Array.from({ length: phiLen }, (_, i) => l.recovery_phi.lookup(BigInt(i + 1)));
+const phi = Array.from({ length: phiLen }, (_, i) =>
+  phiBytesFromField(l.recovery_phi.lookup(BigInt(i + 1))),
+);
 const sessionHex = bytesToHex(l.recovery_session);
 const params = paramsFromPhi(phiLen, guardians);
 const threshold = params.t + 1;

--- a/experiments/account-custody-prototype/src/tests/lifecycle-recovery.ts
+++ b/experiments/account-custody-prototype/src/tests/lifecycle-recovery.ts
@@ -28,6 +28,7 @@ import {
   buildPhi,
   reconstructRecoverySecret,
   paramsFromPhi,
+  phiBytesFromField,
   encodeGuardianRequest,
   decodeGuardianRequest,
   encodeGuardianReply,
@@ -107,7 +108,10 @@ await runScenario('lifecycle-recovery', async () => {
 
   step('TOTAL LOSS — rebuild everything from public state + a t+1 quorum');
   const l = await account.ledgerState();
-  const phiFromChain = [l.recovery_phi.lookup(1n), l.recovery_phi.lookup(2n)];
+  const phiFromChain = [
+    phiBytesFromField(l.recovery_phi.lookup(1n)),
+    phiBytesFromField(l.recovery_phi.lookup(2n)),
+  ];
   const sessionFromChain = bytesToHex(l.recovery_session);
 
   // Quorum member 1: the guardian passport, asked again with a request

--- a/experiments/account-custody-prototype/src/wallet/account.ts
+++ b/experiments/account-custody-prototype/src/wallet/account.ts
@@ -8,9 +8,9 @@ import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-j
 import { deviceCommitment, grantCommitment, recoveryCommitment, ledger, type Ledger } from './contract.js';
 import { privateStateFromSecrets, type AccountPrivateState } from './witnesses.js';
 import { bytesToHex } from './hex.js';
+import { phiFieldFromBytes } from './buss-core.js';
 
 const MAX_PHI = 4;
-const ZERO_32 = new Uint8Array(32);
 
 export interface AccountSecrets {
   deviceSecret?: Uint8Array;
@@ -159,7 +159,9 @@ export class PassportAccount {
    * Publish a BUSS recovery backup: rotates the recovery commitment to a
    * FRESH secret and stores φ under a FRESH session nonce (both rules are
    * load-bearing — see contracts/account.compact header). Device-authorised.
-   * `phi` holds 1..4 entries of 32 bytes each, straight from buildPhi().
+   * `phi` holds 1..4 entries of 32 bytes each, straight from buildPhi();
+   * each is converted to the on-chain Field value here, so a non-canonical
+   * entry is rejected before it can land on-chain.
    */
   publishRecoveryBackup(
     newRecoverySecret: Uint8Array,
@@ -169,7 +171,9 @@ export class PassportAccount {
     if (phi.length < 1 || phi.length > MAX_PHI) {
       throw new Error(`phi must have 1..${MAX_PHI} entries, got ${phi.length}`);
     }
-    const slots = Array.from({ length: MAX_PHI }, (_, i) => phi[i] ?? ZERO_32);
+    const slots = Array.from({ length: MAX_PHI }, (_, i) =>
+      phi[i] ? phiFieldFromBytes(phi[i]) : 0n,
+    );
     return this.call(
       'publish_recovery_backup',
       recoveryCommitment(newRecoverySecret),

--- a/experiments/account-custody-prototype/src/wallet/buss-core.ts
+++ b/experiments/account-custody-prototype/src/wallet/buss-core.ts
@@ -74,6 +74,34 @@ export function paramsFromPhi(phiLen: number, guardianCount: number): BussParams
   return { t: n - phiLen - 1, n };
 }
 
+// φ entries cross the BussApi boundary as the canonical little-endian
+// 32-byte repr of a BLS12-381 scalar; on-chain they are Field values
+// (bigint on the TS side), which makes a non-canonical encoding
+// unrepresentable. These two convert between the encodings.
+
+/** Canonical little-endian 32-byte repr → on-chain Field value. */
+export function phiFieldFromBytes(bytes: Uint8Array): bigint {
+  if (bytes.length !== 32) {
+    throw new Error(`phi entry must be 32 bytes, got ${bytes.length}`);
+  }
+  let f = 0n;
+  for (let i = 31; i >= 0; i--) f = (f << 8n) | BigInt(bytes[i]);
+  return f;
+}
+
+/** On-chain Field value → canonical little-endian 32-byte repr. */
+export function phiBytesFromField(field: bigint): Uint8Array {
+  if (field < 0n) throw new Error('phi entry must be non-negative');
+  const out = new Uint8Array(32);
+  let v = field;
+  for (let i = 0; i < 32; i++) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  if (v !== 0n) throw new Error('phi entry does not fit in 32 bytes');
+  return out;
+}
+
 /** Fresh 32-byte session nonce for a backup publication. */
 export function newSessionNonce(): Uint8Array {
   const nonce = new Uint8Array(32);

--- a/experiments/account-custody-prototype/src/wallet/buss.ts
+++ b/experiments/account-custody-prototype/src/wallet/buss.ts
@@ -25,6 +25,8 @@ export const {
 export {
   sessionIdBytes,
   paramsFromPhi,
+  phiFieldFromBytes,
+  phiBytesFromField,
   newSessionNonce,
   encodeGuardianRequest,
   decodeGuardianRequest,

--- a/experiments/account-custody-prototype/test/account.test.ts
+++ b/experiments/account-custody-prototype/test/account.test.ts
@@ -16,6 +16,8 @@ import {
   buildPhi,
   reconstructRecoverySecret,
   paramsFromPhi,
+  phiFieldFromBytes,
+  phiBytesFromField,
   type GuardianReply,
 } from '../src/wallet/buss.js';
 import { randomBytes32, hexToBytes32, bytesToHex } from '../src/wallet/hex.js';
@@ -177,8 +179,6 @@ describe('scoped grants', () => {
 });
 
 describe('recovery backup publication (BUSS)', () => {
-  const ZERO = new Uint8Array(32);
-
   it('publishes φ, session nonce, and rotated commitment', () => {
     const rotated = newRecoverySecret();
     const nonce = newSessionNonce();
@@ -186,10 +186,10 @@ describe('recovery backup publication (BUSS)', () => {
       'publish_recovery_backup',
       recoveryCommitment(rotated),
       nonce,
-      randomBytes32(),
-      randomBytes32(),
-      ZERO,
-      ZERO,
+      phiFieldFromBytes(newRecoverySecret()),
+      phiFieldFromBytes(newRecoverySecret()),
+      0n,
+      0n,
       2n,
     );
     const l = sim.ledger();
@@ -206,10 +206,10 @@ describe('recovery backup publication (BUSS)', () => {
         'publish_recovery_backup',
         recoveryCommitment(newRecoverySecret()),
         newSessionNonce(),
-        ZERO,
-        ZERO,
-        ZERO,
-        ZERO,
+        0n,
+        0n,
+        0n,
+        0n,
         0n,
       ),
     ).toThrow(/phi must not be empty/);
@@ -222,10 +222,10 @@ describe('recovery backup publication (BUSS)', () => {
         'publish_recovery_backup',
         recoveryCommitment(newRecoverySecret()),
         newSessionNonce(),
-        randomBytes32(),
-        ZERO,
-        ZERO,
-        ZERO,
+        phiFieldFromBytes(newRecoverySecret()),
+        0n,
+        0n,
+        0n,
         1n,
       ),
     ).toThrow(/device_secret requested/);
@@ -270,21 +270,23 @@ describe('total-loss recovery (BUSS)', () => {
     const phi = buildPhi(rotated, replies, params);
     expect(phi.length).toBe(2);
 
-    const ZERO = new Uint8Array(32);
     sim.call(
       'publish_recovery_backup',
       recoveryCommitment(rotated),
       nonce,
-      phi[0],
-      phi[1],
-      ZERO,
-      ZERO,
+      phiFieldFromBytes(phi[0]),
+      phiFieldFromBytes(phi[1]),
+      0n,
+      0n,
       2n,
     );
 
     // ── Total loss: reconstruct from guardian σ + ONE paper key + chain ──
     const l = sim.ledger();
-    const phiFromChain = [l.recovery_phi.lookup(1n), l.recovery_phi.lookup(2n)];
+    const phiFromChain = [
+      phiBytesFromField(l.recovery_phi.lookup(1n)),
+      phiBytesFromField(l.recovery_phi.lookup(2n)),
+    ];
     const sessionFromChain = bytesToHex(l.recovery_session);
     const quorum: GuardianReply[] = [
       computeSigma({ address: sim.address, sessionNonce: sessionFromChain, index: 1 }, guardianSk),
@@ -334,15 +336,14 @@ describe('total-loss recovery (BUSS)', () => {
     const papers = [1, 2, 3].map(newPaperKey);
     const replies = papers.map((p) => paperSigma(p, sim.address, nonceHex));
     const phi = buildPhi(rotated, replies, { t: 1, n: 4 });
-    const ZERO = new Uint8Array(32);
     sim.call(
       'publish_recovery_backup',
       recoveryCommitment(rotated),
       nonce,
-      phi[0],
-      phi[1],
-      ZERO,
-      ZERO,
+      phiFieldFromBytes(phi[0]),
+      phiFieldFromBytes(phi[1]),
+      0n,
+      0n,
       2n,
     );
 

--- a/experiments/account-custody-prototype/test/phi-canonical.test.ts
+++ b/experiments/account-custody-prototype/test/phi-canonical.test.ts
@@ -1,0 +1,109 @@
+// φ entries are stored on-chain as Field values, so a non-canonical or
+// out-of-range encoding is rejected when the publishing call is built,
+// instead of landing on-chain as opaque bytes and blocking every future
+// recovery attempt until the owner republishes. These tests pin the
+// boundary conversion and the rejection itself.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { AccountSimulator } from './simulator.js';
+import { randomBytes32, bytesToHex } from '../src/wallet/hex.js';
+import { recoveryCommitment } from '../src/wallet/contract.js';
+import {
+  newRecoverySecret,
+  newSessionNonce,
+  newPaperKey,
+  paperSigma,
+  buildPhi,
+  phiFieldFromBytes,
+  phiBytesFromField,
+} from '../src/wallet/buss.js';
+
+// BLS12-381 scalar field modulus (the Compact Field modulus).
+const FR_MODULUS =
+  0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001n;
+
+describe('phi field/bytes boundary conversion', () => {
+  it('round-trips canonical field encodings from the wasm side', () => {
+    const bytes = newRecoverySecret(); // random field element, canonical repr
+    expect(phiBytesFromField(phiFieldFromBytes(bytes))).toEqual(bytes);
+  });
+
+  it('rejects a repr of the wrong length', () => {
+    expect(() => phiFieldFromBytes(new Uint8Array(31))).toThrow(/must be 32 bytes/);
+    expect(() => phiFieldFromBytes(new Uint8Array(33))).toThrow(/must be 32 bytes/);
+  });
+
+  it('rejects a field value that does not fit in 32 bytes', () => {
+    expect(() => phiBytesFromField(1n << 256n)).toThrow(/does not fit in 32 bytes/);
+    expect(() => phiBytesFromField(-1n)).toThrow(/non-negative/);
+  });
+
+  it('uses little-endian byte order (matches the wasm repr)', () => {
+    const bytes = new Uint8Array(32);
+    bytes[0] = 0x02; // least significant byte
+    expect(phiFieldFromBytes(bytes)).toBe(2n);
+  });
+});
+
+describe('on-chain canonicity guard', () => {
+  let sim: AccountSimulator;
+
+  beforeEach(() => {
+    sim = new AccountSimulator({
+      deviceSecret: randomBytes32(),
+      recoverySecret: newRecoverySecret(),
+    });
+  });
+
+  const publishWithSlot = (slot: bigint): unknown =>
+    sim.call(
+      'publish_recovery_backup',
+      recoveryCommitment(newRecoverySecret()),
+      newSessionNonce(),
+      slot,
+      0n,
+      0n,
+      0n,
+      1n,
+    );
+
+  it('rejects an out-of-range φ value at the call boundary', () => {
+    expect(() => publishWithSlot(FR_MODULUS)).toThrow();
+    expect(() => publishWithSlot((1n << 256n) - 1n)).toThrow();
+  });
+
+  it('accepts the full canonical range and round-trips through the ledger', () => {
+    const phiBytes = newRecoverySecret();
+    publishWithSlot(phiFieldFromBytes(phiBytes));
+    const fromChain = sim.ledger().recovery_phi.lookup(1n);
+    expect(phiBytesFromField(fromChain)).toEqual(phiBytes);
+  });
+
+  it('preserves the full BUSS round trip through the typed ledger', () => {
+    const rotated = newRecoverySecret();
+    const nonce = newSessionNonce();
+    const nonceHex = bytesToHex(nonce);
+    const papers = [1, 2, 3].map(newPaperKey);
+    const replies = papers.map((p) => paperSigma(p, sim.address, nonceHex));
+    const phi = buildPhi(rotated, replies, { t: 1, n: 4 });
+
+    sim.call(
+      'publish_recovery_backup',
+      recoveryCommitment(rotated),
+      nonce,
+      phiFieldFromBytes(phi[0]),
+      phiFieldFromBytes(phi[1]),
+      0n,
+      0n,
+      2n,
+    );
+
+    const l = sim.ledger();
+    const phiFromChain = [
+      phiBytesFromField(l.recovery_phi.lookup(1n)),
+      phiBytesFromField(l.recovery_phi.lookup(2n)),
+    ];
+    expect(phiFromChain).toEqual([phi[0], phi[1]]);
+  });
+});


### PR DESCRIPTION
The four phi slots were raw Bytes<32> with no validation at publish time: a malformed entry landed on-chain unchecked, every guardian's decode then failed at recovery time, and recovery stayed blocked until the owner republished. Compact 0.31 cannot range-check 32 bytes against the field modulus in-circuit, but the entries ARE BLS12-381 scalar field elements, so the honest guard is the type system: recovery_phi and the publish arguments are now Field, which makes a non-canonical encoding unrepresentable on-chain and rejects out-of-range values when the call is built. The client boundary keeps the canonical little-endian 32-byte repr from buss-wasm (phiFieldFromBytes / phiBytesFromField convert at the seam); publishRecoveryBackup keeps its Uint8Array API and the guardian read sites wrap their lookups.

Ledger-schema change: fresh deployments only (routine for the prototype). Contract recompiled (compact 0.31.1), unit suite green (30 tests) including the full BUSS ceremony reconstructing from the typed ledger and rejection of the modulus at the call boundary. Localnet recovery lifecycle not re-run here.

Note: touches the same circuit as the backup-freshness PR. Hunks do not overlap, but whichever lands second needs a recompile, and once both are in, test/backup-freshness.test.ts must switch its phi slots to Field values (three-line change, happy to rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)