### PR TITLE
Admit dApp-connector ECDSA signers: a per-device envelope on the k256 arm

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -41,10 +41,36 @@ once, below every arm.
   (the verify reduces the digest mod n natively); keys bind as
   little-endian affine coordinate bytes; both S forms are accepted (real
   P-256 authenticators emit high-S; single-use entries make a malleated
-  twin non-replayable). Gated ABIs are `(…args, pk, use_counter, sig)`.
+  twin non-replayable). Gated ABIs are
+  `(…args, pk, use_counter, sig, envelope)`.
   Its signer is software only (`@noble/curves` in TypeScript, `k256` in
   Rust): WebAuthn passkeys are hardware-locked to P-256, which is
   precisely what the r1 landing enables.
+
+  ECDSA signs a 32-byte digest, and signers wrap the challenge
+  differently before hashing it, so the arm carries a per-device
+  **envelope**: an enumerated id fixed at enrolment, with the signature
+  always covering `SHA-256(prefix(envelope) || challenge)` (exported as
+  `envelope_digest`, recomputable in-circuit because `persistentHash` IS
+  SHA-256 and a tuple of `Bytes` hashes as the raw concatenation).
+
+  | id | envelope | prefix | who signs it |
+  |---|---|---|---|
+  | 0 | none | (empty) | software, HSM, and MPC signers driven directly: ordinary ECDSA-SHA256 over the challenge bytes as the message |
+  | 1 | connector | `midnight_signed_message:32:` | keys behind the dApp-connector `signData` surface (the `ecdsa_secp256k1_sha256` scheme), which never signs caller bytes as-is |
+
+  No envelope signs the challenge itself as a prehash: one rule, one hash
+  per id. The id is an enumeration rather than the prefix bytes because
+  Compact has no variable-length `Bytes`: a `Bytes<N>` parameter hashes
+  at its full width, padding included, so an empty prefix cannot be a
+  shorter value of the same field, and a prefix of another length would
+  be another type and so another ABI. The id selects among fixed hash
+  shapes instead. The id is bound into the device's entry
+  and boot derivations (DST families `midnight:account:device:k1:v2`,
+  `midnight:account:boot:k1:v2`; v2 appends the one-byte id after the
+  key coordinates), so the caller can present only the envelope the
+  device was enrolled with. Unknown ids abort. The challenge preimages
+  (`midnight:account:auth:k1:v1:*`) are unchanged.
 
 Per-arm circuits instead of one circuit with an in-circuit scheme
 conditional: Compact compiles every exported circuit to its own proof, so

--- a/contract/contracts/account.compact
+++ b/contract/contracts/account.compact
@@ -78,8 +78,37 @@ import CompactStandardLibrary;
 //     cannot replay, and signatures are never used as identifiers. No low-S
 //     constraint is imposed — deliberately, because real P-256
 //     authenticators emit high-S signatures and the r1 arm must accept
-//     them. DST families: "midnight:account:device:k1:v1",
-//     "midnight:account:auth:k1:v1:*", "midnight:account:boot:k1:v1".
+//     them. DST families: "midnight:account:device:k1:v2",
+//     "midnight:account:auth:k1:v1:*", "midnight:account:boot:k1:v2".
+//
+//     ECDSA signs a 32-byte digest, and different signers wrap the
+//     challenge differently before hashing it. The arm therefore carries a
+//     per-device ENVELOPE, an enumerated id fixed at enrolment, and the
+//     signature always covers SHA-256(prefix(envelope) || challenge):
+//       0  none       prefix = ""; the digest is plain SHA-256 of the
+//                     challenge, i.e. ordinary ECDSA-SHA256 over the
+//                     challenge bytes as the message (software signers,
+//                     HSMs, MPC signers driven directly).
+//       1  connector  prefix = "midnight_signed_message:32:"; the mandatory
+//                     envelope of the dApp-connector `signData` surface
+//                     (the `ecdsa_secp256k1_sha256` scheme of the connector
+//                     specification), which never signs caller-supplied
+//                     bytes as-is.
+//     There is no mode that signs the challenge itself as a prehash: one
+//     rule, one hash, per envelope. The digest is recomputable in-circuit
+//     because persistentHash IS SHA-256 and a tuple of Bytes hashes as the
+//     raw concatenation. The envelope is an id rather than the prefix
+//     bytes because Compact has no variable-length Bytes: a Bytes<N>
+//     parameter hashes at its full width, padding included, so an empty
+//     prefix cannot be a shorter value of the same field, and a prefix of
+//     another length would be another type and so another ABI. The id
+//     selects among fixed hash shapes instead. It is bound into the
+//     device's entry and boot derivations (the v2 preimages carry it), so
+//     the caller can present only the envelope the device was enrolled
+//     with: a wrong id fails the membership assert before any signature
+//     is examined. The gated ABI is the same for every envelope: (…args,
+//     pk, use_counter, sig, envelope). Cost: one extra persistentHash per
+//     k256 authorisation.
 //
 // Per-arm circuits instead of one circuit with an in-circuit scheme choice:
 // Compact compiles every exported circuit to its own proof, so a proof
@@ -253,12 +282,17 @@ export circuit activate_initial_device_with_jubjub(pk: JubjubPoint, salt: Bytes<
   ));
 }
 
-export circuit activate_initial_device_with_k256(pk: Secp256k1Point, salt: Bytes<32>): [] {
+export circuit activate_initial_device_with_k256(
+  pk:       Secp256k1Point,
+  salt:     Bytes<32>,
+  envelope: Uint<8>,
+): [] {
   assert(!booted, "already activated");
   require_live_k256_key(pk);
-  assert(derive_boot_commitment_with_k256(salt, pk) == boot, "boot commitment mismatch");
+  assert(derive_boot_commitment_with_k256(salt, pk, envelope) == boot,
+         "boot commitment mismatch");
   do_activate_initial_device(derive_device_entry_with_k256(
-    kernel.self(), pk, device_epoch, 0 as Uint<64>
+    kernel.self(), pk, envelope, device_epoch, 0 as Uint<64>
   ));
 }
 
@@ -272,13 +306,20 @@ export pure circuit derive_boot_commitment_with_jubjub(salt: Bytes<32>, pk: Jubj
   );
 }
 
-// Arm k256: DST_BOOT = "midnight:account:boot:k1:v1". The key is bound as
+// Arm k256: DST_BOOT = "midnight:account:boot:k1:v2". The key is bound as
 // its little-endian affine coordinate bytes, the same encoding the arm's
-// device entries use.
-export pure circuit derive_boot_commitment_with_k256(salt: Bytes<32>, pk: Secp256k1Point): Bytes<32> {
-  return persistentHash<[Bytes<32>, Bytes<32>, Bytes<32>, Bytes<32>]>(
-    [pad(32, "midnight:account:boot:k1:v1"), salt,
-     secp256k1PointX(pk) as Bytes<32>, secp256k1PointY(pk) as Bytes<32>]
+// device entries use, followed by the device's envelope id (v2 adds it: the
+// envelope is part of the committed identity, so it cannot be equivocated
+// at activation).
+export pure circuit derive_boot_commitment_with_k256(
+  salt:     Bytes<32>,
+  pk:       Secp256k1Point,
+  envelope: Uint<8>,
+): Bytes<32> {
+  return persistentHash<[Bytes<32>, Bytes<32>, Bytes<32>, Bytes<32>, Uint<8>]>(
+    [pad(32, "midnight:account:boot:k1:v2"), salt,
+     secp256k1PointX(pk) as Bytes<32>, secp256k1PointY(pk) as Bytes<32>,
+     envelope]
   );
 }
 
@@ -304,10 +345,14 @@ export pure circuit derive_device_entry_with_jubjub(
   );
 }
 
-// Arm k256: DST_DEVICE = "midnight:account:device:k1:v1" zero-padded to
+// Arm k256: DST_DEVICE = "midnight:account:device:k1:v2" zero-padded to
 // 32 bytes. The key is bound as the little-endian 32-byte encodings of its
 // affine coordinates — an explicit byte encoding independent signers
-// reproduce without the compiler's field-aligned point layout.
+// reproduce without the compiler's field-aligned point layout — followed by
+// the device's envelope id (the v2 addition, one byte), then epoch and
+// counter. Binding the envelope here is what makes it a property of the
+// enrolled device rather than of one call: the same key enrolled under two
+// envelopes owns two disjoint entry sets.
 //
 // The identity flag of Secp256k1Point is deliberately NOT bound: both entry
 // points that admit a k256 key (the seam and the bootstrap) reject the point
@@ -317,13 +362,14 @@ export pure circuit derive_device_entry_with_jubjub(
 export pure circuit derive_device_entry_with_k256(
   self_addr: ContractAddress,
   pk:        Secp256k1Point,
+  envelope:  Uint<8>,
   epoch:     Uint<32>,
   counter:   Uint<64>,
 ): Bytes<32> {
-  return persistentHash<[Bytes<32>, ContractAddress, Bytes<32>, Bytes<32>, Uint<32>, Uint<64>]>(
-    [pad(32, "midnight:account:device:k1:v1"), self_addr,
+  return persistentHash<[Bytes<32>, ContractAddress, Bytes<32>, Bytes<32>, Uint<8>, Uint<32>, Uint<64>]>(
+    [pad(32, "midnight:account:device:k1:v2"), self_addr,
      secp256k1PointX(pk) as Bytes<32>, secp256k1PointY(pk) as Bytes<32>,
-     epoch, counter]
+     envelope, epoch, counter]
   );
 }
 
@@ -349,6 +395,26 @@ circuit require_live_k256_key(pk: Secp256k1Point): [] {
       && (secp256k1PointY(pk) as Bytes<32>) == pad(32, "")),
     "device key is the point at infinity"
   );
+}
+
+// The digest a k256 device signs for a challenge, by envelope id:
+//   0  SHA-256(challenge)
+//   1  SHA-256("midnight_signed_message:32:" || challenge), the mandatory
+//      envelope of the dApp-connector `signData` surface (connector
+//      specification, section "Signing").
+// persistentHash over Bytes is exactly SHA-256 of the raw concatenation
+// (the field-aligned encoding of a Bytes atom is the bytes themselves), so
+// both digests are recomputable in-circuit from the challenge. Unknown ids
+// abort. Both candidates are hashed on every call (a circuit conditional
+// is a select, not a branch). Exported, like the challenge constructions,
+// so independent signers reproduce the digest bit-exactly.
+export pure circuit envelope_digest(envelope: Uint<8>, challenge: Bytes<32>): Bytes<32> {
+  assert(envelope <= 1, "unknown envelope");
+  const none = persistentHash<Bytes<32>>(challenge);
+  const connector = persistentHash<[Bytes<27>, Bytes<32>]>(
+    [pad(27, "midnight_signed_message:32:"), challenge]
+  );
+  return (envelope == 1 ? connector : none);
 }
 
 // Scalar-to-point helpers: R = r·G, pk = sk·G. Exposed so signers use the
@@ -687,19 +753,28 @@ circuit require_authorised_with_k256(
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
   challenge:   Bytes<32>,
+  envelope:    Uint<8>,
 ): [] {
   require_live_k256_key(pk);
-  const entry = disclose(derive_device_entry_with_k256(kernel.self(), pk, device_epoch, use_counter));
+  const entry = disclose(derive_device_entry_with_k256(
+    kernel.self(), pk, envelope, device_epoch, use_counter
+  ));
   assert(devices.member(entry), "unknown device entry");
   devices.remove(entry);
   devices.insert(disclose(derive_device_entry_with_k256(
-    kernel.self(), pk, device_epoch, ((use_counter + (1 as Uint<64>)) as Uint<64>)
+    kernel.self(), pk, envelope, device_epoch,
+    ((use_counter + (1 as Uint<64>)) as Uint<64>)
   )));
-  // The verify interprets the challenge as a big-endian integer and reduces
-  // it mod the curve order internally; both low-S and high-S signature
-  // forms are accepted (see the malleability note in the header).
+  // The signature covers the envelope digest of the challenge, never the
+  // challenge itself. The envelope cannot be equivocated per call: the
+  // entry derivation above binds it, so a wrong id fails the membership
+  // assert before any signature is examined. The verify interprets its
+  // digest as a big-endian integer and reduces it mod the curve order
+  // internally; both low-S and high-S signature forms are accepted (see
+  // the malleability note in the header).
+  const digest = envelope_digest(envelope, challenge);
   assert(
-    secp256k1EcdsaVerify(challenge, sig, pk),
+    secp256k1EcdsaVerify(digest, sig, pk),
     "invalid signature"
   );
   auth_nonce = ((auth_nonce + (1 as Uint<64>)) as Uint<64>);
@@ -870,11 +945,12 @@ export circuit withdraw_unshielded_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [] {
   const challenge = challenge_withdraw_unshielded_with_k256(
     kernel.self(), pk, color, amount, recipient, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   do_withdraw_unshielded(color, amount, recipient);
 }
 
@@ -915,11 +991,12 @@ export circuit append_inbox_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [] {
   const challenge = challenge_append_inbox_with_k256(
     kernel.self(), pk, entry, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   do_append_inbox(entry);
 }
 
@@ -954,12 +1031,13 @@ export circuit withdraw_shielded_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): Maybe<ShieldedCoinInfo> {
   const coin = held_coin(color);
   const challenge = challenge_withdraw_shielded_with_k256(
     kernel.self(), pk, recipient, color, amount, coin, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   return do_withdraw_shielded(recipient, amount, coin);
 }
 
@@ -1002,12 +1080,13 @@ export circuit withdraw_shielded_to_contract_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [ShieldedCoinInfo, Maybe<ShieldedCoinInfo>] {
   const coin = held_coin(color);
   const challenge = challenge_withdraw_shielded_to_contract_with_k256(
     kernel.self(), pk, recipient, color, amount, coin, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   return do_withdraw_shielded_to_contract(recipient, amount, coin);
 }
 
@@ -1037,11 +1116,12 @@ export circuit rotate_enc_key_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [] {
   const challenge = challenge_rotate_enc_key_with_k256(
     kernel.self(), pk, new_key, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   do_rotate_enc_key(new_key);
 }
 
@@ -1131,11 +1211,12 @@ export circuit add_device_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [] {
   const challenge = challenge_add_device_with_k256(
     kernel.self(), pk, new_entry, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   do_add_device(new_entry);
 }
 
@@ -1169,13 +1250,15 @@ export circuit remove_device_with_k256(
   pk:          Secp256k1Point,
   use_counter: Uint<64>,
   sig:         Secp256k1EcdsaSignature,
+  envelope:    Uint<8>,
 ): [] {
   const challenge = challenge_remove_device_with_k256(
     kernel.self(), pk, entry, auth_nonce
   );
-  require_authorised_with_k256(pk, use_counter, sig, challenge);
+  require_authorised_with_k256(pk, use_counter, sig, challenge, envelope);
   // As above: the caller's post-roll entry is off limits.
   do_remove_device(entry, derive_device_entry_with_k256(
-    kernel.self(), pk, device_epoch, ((use_counter + (1 as Uint<64>)) as Uint<64>)
+    kernel.self(), pk, envelope, device_epoch,
+    ((use_counter + (1 as Uint<64>)) as Uint<64>)
   ));
 }

--- a/contract/signer-rs/src/main.rs
+++ b/contract/signer-rs/src/main.rs
@@ -26,8 +26,11 @@
 //! "midnight:account:auth:k1:v1:<circuit>". There is no signature term (an
 //! ECDSA message must not depend on its own signature) and no grinding
 //! nonce (secp256k1EcdsaVerify reduces the 32-byte challenge mod the curve
-//! order natively). The signature is ECDSA over the challenge as a prehash;
-//! k256 emits the low-S normalised form by default and the contract accepts
+//! order natively). The signature is ECDSA over the ENVELOPE digest
+//! SHA-256(prefix(envelope) || challenge), never the challenge itself
+//! (`envelope_digest` below: envelope 0 has an empty prefix, envelope 1 the
+//! dApp-connector `signData` prefix), passed to k256 as a prehash; k256
+//! emits the low-S normalised form by default and the contract accepts
 //! both S forms (see the malleability note in account.compact).
 //!
 //! persistentHash is SHA-256 over the compiler's field-aligned binary
@@ -265,6 +268,33 @@ struct SignRequest {
     amount: String,
     recipient: String,
     auth_nonce: String,
+    /// k256 envelope id (see `envelope_digest`): 0 = no prefix (default),
+    /// 1 = the dApp-connector `signData` envelope (the
+    /// `ecdsa_secp256k1_sha256` scheme of the connector specification).
+    /// Ignored by the jubjub arm.
+    #[serde(default)]
+    envelope: u8,
+}
+
+/// The connector's mandatory signing prefix for a 32-byte payload
+/// (connector specification, section "Signing").
+const CONNECTOR_ENVELOPE_PREFIX: &[u8; 27] = b"midnight_signed_message:32:";
+
+/// The digest a k256 device signs for a challenge, by envelope id. Mirrors
+/// the contract's exported `envelope_digest` pure circuit:
+///   0  SHA-256(challenge)
+///   1  SHA-256("midnight_signed_message:32:" || challenge)
+/// persistentHash over Bytes is SHA-256 of the raw concatenation, so both
+/// are plain SHA-256 and bit-equal to the circuit's output.
+fn envelope_digest(envelope: u8, challenge: &[u8; 32]) -> Result<[u8; 32]> {
+    match envelope {
+        0 => persistent_hash(&[el_bytes(32, challenge)]),
+        1 => persistent_hash(&[
+            el_bytes(27, CONNECTOR_ENVELOPE_PREFIX),
+            el_bytes(32, challenge),
+        ]),
+        other => bail!("unknown k256 envelope id {other}"),
+    }
 }
 
 fn main() -> Result<()> {
@@ -386,14 +416,19 @@ fn sign_k256(req: &SignRequest) -> Result<serde_json::Value> {
         el_uint(8, u128::from(p.auth_nonce)),
     ])?;
 
-    // ECDSA over the challenge as a prehash (RFC 6979 deterministic nonce).
+    // The signature covers the envelope digest, never the challenge itself.
+    let digest = envelope_digest(req.envelope, &challenge)?;
+
+    // ECDSA over the digest as a prehash (RFC 6979 deterministic nonce).
     // k256 emits the low-S normalised form; the contract's verifier accepts
     // either form, so the signature travels as produced.
-    let sig: Signature = sk.sign_prehash(&challenge).map_err(|_| anyhow!("signing failed"))?;
+    let sig: Signature = sk
+        .sign_prehash(&digest)
+        .map_err(|_| anyhow!("signing failed"))?;
 
     // Local verification before emitting (k256's verifier, which insists on
     // the low-S form its signer produces).
-    vk.verify_prehash(&challenge, &sig)
+    vk.verify_prehash(&digest, &sig)
         .map_err(|_| anyhow!("self-verification failed"))?;
 
     let (sig_r, sig_s) = sig.split_bytes();
@@ -404,6 +439,8 @@ fn sign_k256(req: &SignRequest) -> Result<serde_json::Value> {
             "s": format!("0x{}", hex::encode(sig_s)),
         },
         "challenge": hex::encode(challenge),
+        "digest": hex::encode(digest),
+        "envelope": req.envelope,
     }))
 }
 
@@ -467,10 +504,8 @@ mod tests {
             circuit_dst(&Arm::K256, "withdraw_unshielded").unwrap(),
             k256_by_hand
         );
-        let jubjub_by_hand = sha256_concat(&[pad_to(
-            64,
-            b"midnight:account:auth:v1:withdraw_unshielded",
-        )]);
+        let jubjub_by_hand =
+            sha256_concat(&[pad_to(64, b"midnight:account:auth:v1:withdraw_unshielded")]);
         assert_eq!(
             circuit_dst(&Arm::Jubjub, "withdraw_unshielded").unwrap(),
             jubjub_by_hand
@@ -478,36 +513,96 @@ mod tests {
     }
 
     #[test]
-    fn k256_device_entry_matches_the_by_hand_derivation() {
-        // derive_device_entry_with_k256(self, pk, epoch, counter) for the
-        // sk = 1 key:
-        // [DST_DEVICE(32), self(32), x_le(32), y_le(32), epoch(4), counter(8)].
+    fn k256_device_entry_v2_matches_the_by_hand_derivation_for_both_envelopes() {
+        // derive_device_entry_with_k256(self, pk, envelope, epoch, counter)
+        // for the sk = 1 key:
+        // [DST_DEVICE(32), self(32), x_le(32), y_le(32), envelope(1), epoch(4), counter(8)].
+        // Vectors recomputed externally (Python hashlib over the same
+        // concatenation) and asserted against the compiled circuit in
+        // unit-offline.ts, pinning the encoding against joint drift.
         let self_addr = [0x11u8; 32];
         let (x_le, y_le) = (coord_le(GX_BE), coord_le(GY_BE));
-        let via_fab = persistent_hash(&[
-            el_bytes(32, &pad_to(32, b"midnight:account:device:k1:v1")),
-            el_bytes(32, &self_addr),
-            el_bytes(32, &x_le),
-            el_bytes(32, &y_le),
-            el_uint(4, 0),
-            el_uint(8, 0),
-        ])
-        .unwrap();
-        let by_hand = sha256_concat(&[
-            pad_to(32, b"midnight:account:device:k1:v1"),
-            self_addr.to_vec(),
-            x_le.to_vec(),
-            y_le.to_vec(),
-            vec![0u8; 4],
-            vec![0u8; 8],
-        ]);
-        assert_eq!(via_fab, by_hand);
-        // Vector recomputed externally (Python hashlib over the same
-        // concatenation), pinning the encoding against joint drift.
+        for (envelope, pinned) in [
+            (0u8, "f88e6a3085478879ae9e3859c59493a60b2d443c1608f6bcedbdb7ee1a8f5d66"),
+            (1u8, "ae28feb6281f2e2f9d9a0fcda699bb2b3e349d1f20eff7b578afb489b3115d51"),
+        ] {
+            let via_fab = persistent_hash(&[
+                el_bytes(32, &pad_to(32, b"midnight:account:device:k1:v2")),
+                el_bytes(32, &self_addr),
+                el_bytes(32, &x_le),
+                el_bytes(32, &y_le),
+                el_uint(1, u128::from(envelope)),
+                el_uint(4, 0),
+                el_uint(8, 0),
+            ])
+            .unwrap();
+            let by_hand = sha256_concat(&[
+                pad_to(32, b"midnight:account:device:k1:v2"),
+                self_addr.to_vec(),
+                x_le.to_vec(),
+                y_le.to_vec(),
+                vec![envelope],
+                vec![0u8; 4],
+                vec![0u8; 8],
+            ]);
+            assert_eq!(via_fab, by_hand);
+            assert_eq!(hex::encode(via_fab), pinned, "envelope {envelope}");
+        }
+    }
+
+    #[test]
+    fn k256_boot_commitment_v2_matches_the_by_hand_derivation_for_both_envelopes() {
+        // derive_boot_commitment_with_k256(salt, pk, envelope) for sk = 1:
+        // [DST_BOOT(32), salt(32), x_le(32), y_le(32), envelope(1)].
+        let salt = [0x22u8; 32];
+        let (x_le, y_le) = (coord_le(GX_BE), coord_le(GY_BE));
+        for (envelope, pinned) in [
+            (0u8, "bec19e88c6ea0afb279841ca7bfca1aa50a0c046cfff30ea29c819b41d564e63"),
+            (1u8, "14697f9fb98a39cf19fae28e53dd556109237ae719599198937988939f75463b"),
+        ] {
+            let via_fab = persistent_hash(&[
+                el_bytes(32, &pad_to(32, b"midnight:account:boot:k1:v2")),
+                el_bytes(32, &salt),
+                el_bytes(32, &x_le),
+                el_bytes(32, &y_le),
+                el_uint(1, u128::from(envelope)),
+            ])
+            .unwrap();
+            let by_hand = sha256_concat(&[
+                pad_to(32, b"midnight:account:boot:k1:v2"),
+                salt.to_vec(),
+                x_le.to_vec(),
+                y_le.to_vec(),
+                vec![envelope],
+            ]);
+            assert_eq!(via_fab, by_hand);
+            assert_eq!(hex::encode(via_fab), pinned, "envelope {envelope}");
+        }
+    }
+
+    #[test]
+    fn envelope_digests_match_by_hand_and_the_runtime() {
+        // Both envelope digests are plain SHA-256 of the raw concatenation
+        // (a Bytes atom carries no framing). Pinned vectors are recomputed
+        // externally (Python hashlib) and match the compiled circuit's
+        // `envelope_digest`, asserted in unit-offline.ts.
+        let challenge = [0xc7u8; 32];
+        let none = envelope_digest(0, &challenge).unwrap();
+        assert_eq!(none, sha256_concat(&[challenge.to_vec()]));
         assert_eq!(
-            hex::encode(via_fab),
-            "f03ab3c9483be2397f3cadb399a72e8e451a73d96bcde3bba3039a9605530840"
+            hex::encode(none),
+            "fdd64f7423a9bc064e56a085573bf51ff5ea77e8d99322ca7afb7bb58c2b72c1"
         );
+        let connector = envelope_digest(1, &challenge).unwrap();
+        assert_eq!(
+            connector,
+            sha256_concat(&[CONNECTOR_ENVELOPE_PREFIX.to_vec(), challenge.to_vec()])
+        );
+        assert_eq!(
+            hex::encode(connector),
+            "0b389c2c1700fac274dc17f4ec007f807238d66600d14333e6f2f21ae3695364"
+        );
+        assert!(envelope_digest(2, &challenge).is_err());
     }
 
     #[test]
@@ -569,13 +664,13 @@ mod tests {
             amount: "500".into(),
             recipient: hex::encode([0x33u8; 32]),
             auth_nonce: "3".into(),
+            envelope: 0,
         };
         let out = sign_jubjub(&req).unwrap();
         assert!(out.get("sig_s").is_some());
         assert!(out.get("grind_nonce").is_some());
         let challenge = out.get("challenge").unwrap().as_str().unwrap();
-        let challenge_bytes: [u8; 32] =
-            hex::decode(challenge).unwrap().try_into().unwrap();
+        let challenge_bytes: [u8; 32] = hex::decode(challenge).unwrap().try_into().unwrap();
         assert!(hash_below_r(&challenge_bytes));
     }
 }

--- a/contract/src/tests/auth-coinless.ts
+++ b/contract/src/tests/auth-coinless.ts
@@ -61,6 +61,7 @@ import {
   k256Challenges,
   type JubjubAuthorisation,
   type K256Authorisation,
+  K256_ENVELOPE_NONE,
 } from '../wallet/signer.js';
 
 /** The challenge as ECDSA reads it: big-endian integer, reduced mod n. */
@@ -148,7 +149,7 @@ await runScenario('auth-coinless (both arms)', async () => {
     const identity: Secp256k1Point = { x: 0n, y: 0n, identity: true };
     const lPre = await s.account.ledgerState();
     const identityEntry = pureCircuits.derive_device_entry_with_k256(
-      { bytes: s.account.addressBytes }, identity, lPre.device_epoch, 0n,
+      { bytes: s.account.addressBytes }, identity, K256_ENVELOPE_NONE, lPre.device_epoch, 0n,
     );
     const planted = await s.account.addDeviceEntry(j1, identityEntry);
     const lPlanted = await waitForLedger(
@@ -162,13 +163,15 @@ await runScenario('auth-coinless (both arms)', async () => {
     const probe = K256Device.generate();
     const newEntry = probe.entryAt(s.account.addressBytes, lPlanted.device_epoch, 0n);
     const challenge = k256Challenges.addDevice(ctx, identity, newEntry);
-    // Forge: choose s freely, then derive the r that closes the equation.
-    const z = bytesToScalarBE(challenge);
+    // Forge: choose s freely, then derive the r that closes the equation
+    // over the digest the seam verifies (envelope 0: SHA-256(challenge)).
+    const z = bytesToScalarBE(pureCircuits.envelope_digest(K256_ENVELOPE_NONE, challenge));
     const sForged = 0xdeadbeefn;
     const w = secp256k1ScalarInv(sForged);
     const rForged = secp256k1PointX(secp256k1MulGenerator(secp256k1ScalarMul(z, w))) % SECP256K1_N;
     const forged: K256Authorisation = {
       arm: 'k256', pk: identity, use_counter: 0n, sig: { r: rForged, s: sForged },
+      envelope: K256_ENVELOPE_NONE,
     };
     details.identityForgeryAbort = await expectAbort('forged signature under pk = O', () =>
       s.account.addDeviceWithAuth(newEntry, forged));
@@ -183,7 +186,7 @@ await runScenario('auth-coinless (both arms)', async () => {
     // untested, which is exactly how the gap survived its first fix.
     const identityUnflagged: Secp256k1Point = { x: 0n, y: 0n, identity: false };
     const unflaggedEntry = pureCircuits.derive_device_entry_with_k256(
-      { bytes: s.account.addressBytes }, identityUnflagged, lPlanted.device_epoch, 0n,
+      { bytes: s.account.addressBytes }, identityUnflagged, K256_ENVELOPE_NONE, lPlanted.device_epoch, 0n,
     );
     if (Buffer.compare(Buffer.from(unflaggedEntry), Buffer.from(identityEntry)) !== 0) {
       throw new Error('the two identity encodings no longer share an entry; revisit this test');

--- a/contract/src/tests/auth-crossimpl.ts
+++ b/contract/src/tests/auth-crossimpl.ts
@@ -17,6 +17,7 @@ import { standardSetup } from './flow.js';
 import { userAddressBytes } from '../node/wallet.js';
 import { bytesToHex } from '../wallet/hex.js';
 import { SIGNER_BIN, rustKeygenK256, rustSignWithdrawUnshieldedK256 } from './crossimpl-offline.js';
+import { K256_ENVELOPE_NONE } from '../wallet/signer.js';
 import { pureCircuits } from '../wallet/contract.js';
 
 const NIGHT = new Uint8Array(32);
@@ -47,7 +48,7 @@ await runScenario('auth-crossimpl', async () => {
   // use counter 0) — the same path a cross-arm add takes.
   const l0 = await s.account.ledgerState();
   const rustEntry = pureCircuits.derive_device_entry_with_k256(
-    { bytes: s.account.addressBytes }, rust.pk, l0.device_epoch, 0n,
+    { bytes: s.account.addressBytes }, rust.pk, K256_ENVELOPE_NONE, l0.device_epoch, 0n,
   );
   await s.account.addDeviceEntry(s.device, rustEntry);
   s.account.registerDevice(rust.pk);
@@ -76,6 +77,7 @@ await runScenario('auth-crossimpl', async () => {
     pk: sig.pk,
     use_counter: 0n,
     sig: sig.sig,
+    envelope: K256_ENVELOPE_NONE,
   });
   details.withdrawTx = r.txId;
   await waitForLedger(

--- a/contract/src/tests/crossimpl-offline.ts
+++ b/contract/src/tests/crossimpl-offline.ts
@@ -15,7 +15,10 @@ import { ecAdd, ecMul, ecMulGenerator } from '@midnight-ntwrk/compact-runtime';
 
 import { runScenario, step } from './runner.js';
 import { pureCircuits, type JubjubPoint, type Secp256k1Point } from '../wallet/contract.js';
-import { SECP256K1_N, JUBJUB_R, bytesToBigIntLE, type EcdsaSignature } from '../wallet/signer.js';
+import {
+  SECP256K1_N, JUBJUB_R, bytesToBigIntLE, type EcdsaSignature,
+  K256_ENVELOPE_CONNECTOR, K256_ENVELOPE_NONE,
+} from '../wallet/signer.js';
 import { bytesToHex } from '../wallet/hex.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -32,7 +35,7 @@ export interface CallParams {
   authNonce: bigint;
 }
 
-function signRequest(arm: 'jubjub' | 'k256', req: CallParams): any {
+function signRequest(arm: 'jubjub' | 'k256', req: CallParams, envelope = 0): any {
   return JSON.parse(
     execFileSync(SIGNER_BIN, [], {
       input: JSON.stringify({
@@ -45,6 +48,7 @@ function signRequest(arm: 'jubjub' | 'k256', req: CallParams): any {
         amount: req.amount.toString(),
         recipient: bytesToHex(req.recipient),
         auth_nonce: req.authNonce.toString(),
+        envelope,
       }),
       encoding: 'utf-8',
     }),
@@ -57,6 +61,9 @@ export interface K256RustSignature {
   pk: Secp256k1Point;
   sig: EcdsaSignature;
   challenge: string;
+  /** hex; the envelope digest the signature covers (envelope 0 here). */
+  digest: string;
+  envelope: number;
 }
 
 export function rustKeygenK256(): { sk: string; pk: Secp256k1Point } {
@@ -72,6 +79,8 @@ export function rustSignWithdrawUnshieldedK256(req: CallParams): K256RustSignatu
     pk: { x: BigInt(out.pk.x), y: BigInt(out.pk.y), identity: false },
     sig: { r: BigInt(out.sig.r), s: BigInt(out.sig.s) },
     challenge: out.challenge,
+    digest: out.digest,
+    envelope: out.envelope,
   };
 }
 
@@ -158,16 +167,39 @@ if (isMain) {
     }
     console.log(`  ✓ identical: ${kSig.challenge.slice(0, 32)}…`);
 
-    step('[k256] the ECDSA signature verifies over the digest');
+    step('[k256] envelope 0: Rust digest vs the contract pure circuit, and the signature');
     if (!(kSig.sig.r > 0n && kSig.sig.r < SECP256K1_N)) throw new Error('r outside [1, n)');
     if (!(kSig.sig.s > 0n && kSig.sig.s < SECP256K1_N)) throw new Error('s outside [1, n)');
+    const kDigest = pureCircuits.envelope_digest(K256_ENVELOPE_NONE, kExpected);
+    if (kSig.digest !== Buffer.from(kDigest).toString('hex')) {
+      throw new Error('Rust envelope-0 digest differs from envelope_digest(0, challenge)');
+    }
+    console.log(`  ✓ identical: ${kSig.digest.slice(0, 32)}…`);
     const ok = secp256k1.verify(
       new secp256k1.Signature(kSig.sig.r, kSig.sig.s).toBytes('compact'),
-      kExpected,
+      kDigest,
       secp256k1.Point.fromAffine({ x: kSig.pk.x, y: kSig.pk.y }).toBytes(false),
       { prehash: false, lowS: false }, // the circuit accepts both S forms
     );
-    if (!ok) throw new Error('Rust signature does not verify over the challenge digest');
-    console.log('  ✓ verify(challenge, (r, s), pk) with the Rust-produced signature');
+    if (!ok) throw new Error('Rust signature does not verify over the envelope-0 digest');
+    console.log('  ✓ verify(envelope_digest(0, challenge), (r, s), pk) with the Rust-produced signature');
+
+    step('[k256/connector] envelope 1: Rust digest vs the contract pure circuit, and the signature');
+    const cOut = signRequest(
+      'k256', { sk: k.sk, contractAddress, color, amount, recipient, authNonce }, 1,
+    );
+    const cExpectedDigest = pureCircuits.envelope_digest(K256_ENVELOPE_CONNECTOR, kExpected);
+    if (cOut.digest !== Buffer.from(cExpectedDigest).toString('hex')) {
+      throw new Error('Rust envelope-1 digest differs from envelope_digest(1, challenge)');
+    }
+    console.log(`  ✓ identical: ${cOut.digest.slice(0, 32)}…`);
+    const cOk = secp256k1.verify(
+      new secp256k1.Signature(BigInt(cOut.sig.r), BigInt(cOut.sig.s)).toBytes('compact'),
+      cExpectedDigest,
+      secp256k1.Point.fromAffine({ x: BigInt(cOut.pk.x), y: BigInt(cOut.pk.y) }).toBytes(false),
+      { prehash: false, lowS: false },
+    );
+    if (!cOk) throw new Error('Rust connector signature does not verify over the envelope digest');
+    console.log('  ✓ verify(envelope digest, (r, s), pk) with the Rust-produced connector signature');
   });
 }

--- a/contract/src/tests/unit-offline.ts
+++ b/contract/src/tests/unit-offline.ts
@@ -10,7 +10,7 @@
 // against a node (auth-conformance.ts); this file guards the
 // vacuous-verifier hazard (MIP-0013 S10) cheaply on every change.
 
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import {
   ecAdd,
@@ -36,6 +36,8 @@ import {
   SECP256K1_N,
   bytesToBigIntLE,
   type CallContext,
+  K256_ENVELOPE_CONNECTOR,
+  K256_ENVELOPE_NONE,
 } from '../wallet/signer.js';
 import { generateEncKeyPair, sealInboxEntry, openInboxEntry, ENTRY_SIZE } from '../wallet/inbox.js';
 
@@ -199,23 +201,37 @@ await runScenario('unit-offline', async () => {
       { bytes: addr }, { x, y }, 0n, 0n,
     );
     const asK256 = pureCircuits.derive_device_entry_with_k256(
-      { bytes: addr }, { x, y, identity: false }, 0n, 0n,
+      { bytes: addr }, { x, y, identity: false }, K256_ENVELOPE_NONE, 0n, 0n,
     );
     assert(
       !Buffer.from(asJubjub).equals(Buffer.from(asK256)),
       '[both arms] identical coordinates derive different entries under each arm',
     );
     const bootJ = pureCircuits.derive_boot_commitment_with_jubjub(addr, { x, y });
-    const bootK = pureCircuits.derive_boot_commitment_with_k256(addr, { x, y, identity: false });
+    const bootK = pureCircuits.derive_boot_commitment_with_k256(addr, { x, y, identity: false }, K256_ENVELOPE_NONE);
     assert(
       !Buffer.from(bootJ).equals(Buffer.from(bootK)),
       '[both arms] the boot commitment is arm-marked, so only one arm can activate',
     );
   }
 
-  step('[k256] signing pipeline: ECDSA over the challenge digest');
+  step('[k256] signing pipeline: ECDSA over the envelope digest (envelope 0)');
   const kH = k256Challenges.withdrawUnshielded(ctx, kDevice.pk, color, 100n, recipient);
   const kAuth = kDevice.sign(kH, 0n);
+  // The signature covers the envelope digest, never the challenge itself.
+  // Envelope 0 has no prefix: the digest is plain SHA-256 of the challenge
+  // bytes, which is what ordinary ECDSA-SHA256 over the challenge as a
+  // message computes.
+  const kDigest = kDevice.signedDigest(kH);
+  assert(kAuth.envelope === K256_ENVELOPE_NONE, '[k256] the authorisation carries envelope 0');
+  assert(
+    Buffer.from(kDigest).equals(createHash('sha256').update(Buffer.from(kH)).digest()),
+    '[k256] envelope_digest(0, h) == SHA-256(h), recomputed independently',
+  );
+  assert(
+    !nobleVerify(kAuth.sig, kH, kDevice.pk),
+    '[k256] the signature does NOT verify over the raw challenge (no prehash mode exists)',
+  );
   assert(kAuth.sig.r > 0n && kAuth.sig.r < SECP256K1_N, '[k256] r in [1, n)');
   assert(kAuth.sig.s > 0n && kAuth.sig.s < SECP256K1_N, '[k256] s in [1, n)');
   assert(kAuth.sig.s <= SECP256K1_N >> 1n, '[k256] signer emits low-S (the circuit accepts both forms)');
@@ -223,11 +239,11 @@ await runScenario('unit-offline', async () => {
     Buffer.from(kH).equals(Buffer.from(k256Challenges.withdrawUnshielded(ctx, kDevice.pk, color, 100n, recipient))),
     '[k256] challenge deterministic',
   );
-  assert(nobleVerify(kAuth.sig, kH, kDevice.pk), '[k256] signature verifies on an independent stack (noble)');
+  assert(nobleVerify(kAuth.sig, kDigest, kDevice.pk), '[k256] signature verifies on an independent stack (noble)');
   // Replicate the in-circuit verify with the runtime's own curve built-ins
-  // (the same functions the generated verifier calls): z = BE(challenge)
+  // (the same functions the generated verifier calls): z = BE(digest)
   // mod n, w = s⁻¹, then x(z·w·G + r·w·pk) mod n == r.
-  const z = bytesToBigIntBE(kH) % SECP256K1_N;
+  const z = bytesToBigIntBE(kDigest) % SECP256K1_N;
   const w = secp256k1ScalarInv(kAuth.sig.s);
   const point = secp256k1Add(
     secp256k1MulGenerator(secp256k1ScalarMul(z, w)),
@@ -238,14 +254,14 @@ await runScenario('unit-offline', async () => {
     '[k256] x(u1·G + u2·pk) mod n == r (the verify equation, off-circuit)',
   );
   assert(
-    !nobleVerify(kAuth.sig, kH, kOther.pk),
+    !nobleVerify(kAuth.sig, kDigest, kOther.pk),
     '[k256] verification fails for a different pk (non-vacuous verifier, S10)',
   );
-  const hBad = new Uint8Array(kH);
+  const hBad = new Uint8Array(kDigest);
   hBad[0] ^= 0x01;
-  assert(!nobleVerify(kAuth.sig, hBad, kDevice.pk), '[k256] verification fails for a tampered challenge');
+  assert(!nobleVerify(kAuth.sig, hBad, kDevice.pk), '[k256] verification fails for a tampered digest');
   assert(
-    !nobleVerify({ r: kAuth.sig.r, s: (kAuth.sig.s + 1n) % SECP256K1_N }, kH, kDevice.pk),
+    !nobleVerify({ r: kAuth.sig.r, s: (kAuth.sig.s + 1n) % SECP256K1_N }, kDigest, kDevice.pk),
     '[k256] verification fails for a tampered s',
   );
   // Malleability, deliberately accepted (see the contract header): the
@@ -253,9 +269,83 @@ await runScenario('unit-offline', async () => {
   // regardless because the device entry is consumed (AUTH-9) and
   // auth_nonce advances (AUTH-8).
   assert(
-    nobleVerify({ r: kAuth.sig.r, s: SECP256K1_N - kAuth.sig.s }, kH, kDevice.pk),
+    nobleVerify({ r: kAuth.sig.r, s: SECP256K1_N - kAuth.sig.s }, kDigest, kDevice.pk),
     '[k256] the high-S twin verifies too (accepted; replay-dead via AUTH-8/9)',
   );
+
+  step('[k256/connector] envelope 1: the connector signData digest; envelopes are enrolled, not chosen');
+  // A connector device: its key sits behind the connector's `signData`
+  // surface (the `ecdsa_secp256k1_sha256` scheme), which signs the
+  // mandatory envelope digest SHA-256("midnight_signed_message:32:" || data)
+  // and never the data itself.
+  const cDevice = K256Device.generateConnector();
+  const cH = k256Challenges.withdrawUnshielded(ctx, cDevice.pk, color, 100n, recipient);
+  const envelopePrefix = Buffer.from('midnight_signed_message:32:', 'utf8');
+  const envelopeByHand = createHash('sha256')
+    .update(Buffer.concat([envelopePrefix, Buffer.from(cH)]))
+    .digest();
+  const envelopeViaCircuit = pureCircuits.envelope_digest(K256_ENVELOPE_CONNECTOR, cH);
+  assert(
+    Buffer.from(envelopeViaCircuit).equals(envelopeByHand),
+    '[k256/connector] envelope_digest(1, h) == SHA-256(prefix || h), recomputed independently',
+  );
+  const cAuth = cDevice.sign(cH, 0n);
+  assert(cAuth.envelope === K256_ENVELOPE_CONNECTOR, '[k256/connector] the authorisation carries envelope 1');
+  assert(
+    nobleVerify(cAuth.sig, envelopeViaCircuit, cDevice.pk),
+    '[k256/connector] the signature verifies over the connector envelope digest (independent stack)',
+  );
+  assert(
+    !nobleVerify(cAuth.sig, pureCircuits.envelope_digest(K256_ENVELOPE_NONE, cH), cDevice.pk),
+    '[k256/connector] the same signature does NOT verify under envelope 0 (envelopes cannot alias)',
+  );
+  // The envelope is part of the enrolled identity: the same key derives
+  // disjoint entries and boot commitments under each envelope, so a device
+  // can never be driven under an envelope it was not enrolled with.
+  const noneTwin = new K256Device(cDevice.sk, K256_ENVELOPE_NONE);
+  const envAddr = new Uint8Array(randomBytes(32));
+  assert(
+    !Buffer.from(cDevice.entryAt(envAddr, 0n, 0n)).equals(
+      Buffer.from(noneTwin.entryAt(envAddr, 0n, 0n)),
+    ),
+    '[k256/connector] entries are disjoint across envelopes for the same key',
+  );
+  assert(
+    !Buffer.from(cDevice.bootCommitment(envAddr)).equals(
+      Buffer.from(noneTwin.bootCommitment(envAddr)),
+    ),
+    '[k256/connector] boot commitments are envelope-marked too',
+  );
+  // Unknown envelope ids abort the pure circuit.
+  let unknownAborted = false;
+  try { pureCircuits.envelope_digest(2n, cH); } catch { unknownAborted = true; }
+  assert(unknownAborted, '[k256] envelope_digest aborts on an unknown envelope id');
+
+  step('[k256] v2 derivation vectors (pinned; shared with signer-rs, recomputed with hashlib)');
+  // sk = 1 (pk = G), self = 0x11*32, salt = 0x22*32, epoch 0, counter 0.
+  // Preimages: entry = DST32 || self || x_le || y_le || envelope(1) || epoch(4) || counter(8);
+  //            boot  = DST32 || salt || x_le || y_le || envelope(1).
+  const gPk = pureCircuits.compute_public_point_with_k256(1n);
+  const pinAddr = new Uint8Array(32).fill(0x11);
+  const pinSalt = new Uint8Array(32).fill(0x22);
+  const pins = [
+    [K256_ENVELOPE_NONE,
+      'f88e6a3085478879ae9e3859c59493a60b2d443c1608f6bcedbdb7ee1a8f5d66',
+      'bec19e88c6ea0afb279841ca7bfca1aa50a0c046cfff30ea29c819b41d564e63'],
+    [K256_ENVELOPE_CONNECTOR,
+      'ae28feb6281f2e2f9d9a0fcda699bb2b3e349d1f20eff7b578afb489b3115d51',
+      '14697f9fb98a39cf19fae28e53dd556109237ae719599198937988939f75463b'],
+  ] as const;
+  for (const [env, entryHex, bootHex] of pins) {
+    assert(
+      Buffer.from(pureCircuits.derive_device_entry_with_k256({ bytes: pinAddr }, gPk, env, 0n, 0n)).toString('hex') === entryHex,
+      `[k256] derive_device_entry_with_k256 v2 vector, envelope ${env}`,
+    );
+    assert(
+      Buffer.from(pureCircuits.derive_boot_commitment_with_k256(pinSalt, gPk, env)).toString('hex') === bootHex,
+      `[k256] derive_boot_commitment_with_k256 v2 vector, envelope ${env}`,
+    );
+  }
 
   step('[k256] challenge domain separation (AUTH-3) and witness binding (AUTH-10)');
   const kShieldedH = k256Challenges.withdrawShielded(ctx, kDevice.pk, recipient, color, 100n, witnessCoin);

--- a/contract/src/wallet/signer.ts
+++ b/contract/src/wallet/signer.ts
@@ -238,13 +238,26 @@ export interface K256Authorisation {
    *  (AUTH-9). Not part of the challenge; bound by entry consumption. */
   use_counter: bigint;
   sig: EcdsaSignature;
+  /** The device's envelope id: the signature covers
+   *  SHA-256(prefix(envelope) || challenge) (`envelope_digest` in the
+   *  contract). Bound into the device's entry derivation, so it is a
+   *  property of the enrolled device, not of one call. */
+  envelope: K256Envelope;
 }
+
+/** Envelope 0: no prefix. The digest is plain SHA-256 of the challenge
+ *  bytes, i.e. ordinary ECDSA-SHA256 over the challenge as the message. */
+export const K256_ENVELOPE_NONE = 0n;
+/** Envelope 1: the dApp-connector `signData` envelope, prefix
+ *  "midnight_signed_message:32:" (the `ecdsa_secp256k1_sha256` scheme). */
+export const K256_ENVELOPE_CONNECTOR = 1n;
+export type K256Envelope = typeof K256_ENVELOPE_NONE | typeof K256_ENVELOPE_CONNECTOR;
 
 export class K256Device {
   readonly arm = 'k256' as const;
   readonly pk: Secp256k1Point;
 
-  constructor(readonly sk: bigint) {
+  constructor(readonly sk: bigint, readonly envelope: K256Envelope = K256_ENVELOPE_NONE) {
     this.pk = pureCircuits.compute_public_point_with_k256(sk);
   }
 
@@ -252,25 +265,44 @@ export class K256Device {
     return new K256Device(randomSecp256k1Scalar());
   }
 
+  /** A device whose key sits behind the dApp-connector `signData`
+   *  surface (the `ecdsa_secp256k1_sha256` scheme): envelope 1. */
+  static generateConnector(): K256Device {
+    return new K256Device(randomSecp256k1Scalar(), K256_ENVELOPE_CONNECTOR);
+  }
+
   /** The device's rolling entry at a given account/epoch/counter. */
   entryAt(contractAddress: Uint8Array, epoch: bigint, counter: bigint): Uint8Array {
     return pureCircuits.derive_device_entry_with_k256(
-      { bytes: contractAddress }, this.pk, epoch, counter,
+      { bytes: contractAddress }, this.pk, this.envelope, epoch, counter,
     );
   }
 
-  /** The boot commitment for this device's arm. */
+  /** The boot commitment for this device's arm and envelope. */
   bootCommitment(salt: Uint8Array): Uint8Array {
-    return pureCircuits.derive_boot_commitment_with_k256(salt, this.pk);
+    return pureCircuits.derive_boot_commitment_with_k256(salt, this.pk, this.envelope);
   }
 
-  /** ECDSA-sign the 32-byte challenge digest (prehashed — the digest IS
-   *  the message). `useCounter` is carried alongside for the seam's entry
+  /** The 32-byte digest this device signs for a challenge:
+   *  SHA-256(prefix(envelope) || challenge), recomputed through the
+   *  contract's own exported pure circuit so wallet and circuit can never
+   *  disagree. Never the challenge itself. */
+  signedDigest(challenge: Uint8Array): Uint8Array {
+    return pureCircuits.envelope_digest(this.envelope, challenge);
+  }
+
+  /** ECDSA-sign the envelope digest of the 32-byte challenge (passed to
+   *  the curve library as a prehash, since the envelope hash is already
+   *  applied). `useCounter` is carried alongside for the seam's entry
    *  consumption. */
   sign(challenge: Uint8Array, useCounter: bigint): K256Authorisation {
-    const sigBytes = secp256k1.sign(challenge, scalarToBytesBE(this.sk), { prehash: false });
+    const digest = this.signedDigest(challenge);
+    const sigBytes = secp256k1.sign(digest, scalarToBytesBE(this.sk), { prehash: false });
     const { r, s } = secp256k1.Signature.fromBytes(sigBytes);
-    return { arm: 'k256', pk: this.pk, use_counter: useCounter, sig: { r, s } };
+    return {
+      arm: 'k256', pk: this.pk, use_counter: useCounter, sig: { r, s },
+      envelope: this.envelope,
+    };
   }
 }
 
@@ -320,5 +352,5 @@ export type Authorisation = JubjubAuthorisation | K256Authorisation;
 export function authArgs(a: Authorisation): unknown[] {
   return a.arm === 'jubjub'
     ? [a.pk, a.use_counter, a.sig_r, a.sig_s, a.grind_nonce]
-    : [a.pk, a.use_counter, a.sig];
+    : [a.pk, a.use_counter, a.sig, a.envelope];
 }


### PR DESCRIPTION
Follow-up to #151, which established that every Midnight wallet key can
sign an account challenge but that the account contract cannot verify
either connector scheme. This PR closes the half that needs **no
upstream work**: a key on the connector's `ecdsa_secp256k1_sha256`
scheme (MPC and HSM signers, and wallets exposing ECDSA through
`signData`) can now be enrolled as an account device and authorise
gated operations.

### The mechanism

A conforming `signData` wallet signs the mandatory envelope digest
`SHA-256("midnight_signed_message:32:" || challenge)`, never the bytes
it is handed. The digest is recomputable in-circuit today because
`persistentHash` IS SHA-256 and a tuple of `Bytes` hashes as the raw
concatenation (established in #151, probe G and the byte-exactness
evidence).

ECDSA signs a 32-byte digest, and signers wrap the challenge
differently before hashing it. The k256 arm therefore **always assumes a
prefix, possibly empty**, and the signature always covers
`SHA-256(prefix(envelope) || challenge)`. The envelope is an enumerated
id fixed at enrolment:

| id | envelope | prefix | who signs it |
|---|---|---|---|
| 0 | none | (empty) | software, HSM, and MPC signers driven directly: ordinary ECDSA-SHA256 over the challenge bytes as the message |
| 1 | connector | `midnight_signed_message:32:` | keys behind the dApp-connector `signData` surface |

- **One API per curve.** The gated k256 ABIs are
  `(…args, pk, use_counter, sig, envelope)` for every envelope, and the
  exported pure circuit `envelope_digest(envelope, challenge)` lets
  independent signers reproduce the digest bit-exactly. The former
  prehash mode (signing the challenge itself) is retired; no signer
  outside our own test harness used it.
- **An id, not the prefix bytes.** Compact has no variable-length
  `Bytes`: a `Bytes<N>` parameter hashes at its full width, padding
  included, so an empty prefix cannot be a shorter value of the same
  field, and a prefix of another length would be another type and so
  another ABI. The id selects among fixed hash shapes instead.
- **Bound at enrolment.** The id is part of the device's entry and boot
  derivations (DST families bump to `midnight:account:device:k1:v2` and
  `midnight:account:boot:k1:v2`; v2 appends the one-byte id after the
  key coordinates), so the caller can present only the envelope the
  device was enrolled with: a wrong id fails the membership assert
  before any signature is examined. Unknown ids abort.

### Compatibility

The challenge preimages (`midnight:account:auth:k1:v1:*`) are unchanged.
The ledger schema is untouched, so the change deploys as a
circuit-maintenance update at the same address. Existing k256 entries
(v1 preimage) do not carry over; no deployment beyond localnet holds
any. The gated k256 ABIs gain one trailing `Uint<8>`, so callers and
verifier keys change. Cost: one extra `persistentHash` per k256
authorisation.

### Validation

- Keyed compile on the pinned toolchain.
- `test:unit` (offline): `envelope_digest(0, h) == SHA-256(h)` and
  `envelope_digest(1, h) == SHA-256(prefix || h)` against independent
  recomputation; each signature verifies over its own envelope digest
  and neither over the raw challenge nor under the other envelope;
  entries and boot commitments are envelope-disjoint for the same key;
  unknown ids abort; the v2 derivation vectors (pk = G, fixed self and
  salt, both envelopes) are pinned identically in signer-rs and
  recomputed with hashlib. PASS.
- `test:crossimpl-offline`: both envelopes cross-language, signer-rs
  digest bit-equal to the contract's pure circuit and the signature
  verifies over it. PASS.
- signer-rs unit tests: by-hand v2 entry and boot vectors for both
  envelopes, both envelope digests, unknown id rejected. PASS.
- Not run here: the on-chain matrix (localnet); the on-chain suites
  compile against the new ABI. To be exercised with the next deploy
  wave.

### What this deliberately does not do

The wallet default scheme (`schnorr_bip340`, every stock wallet's
`signData`) remains blocked on upstream: the BIP-340 group equation
needs point addition and scalar multiplication, which Compact does not
expose (#151 carries the measured relation and the narrowed upstream
ask). This arm covers the connector's ECDSA scheme only.
