### PR TITLE
Draft the scoped grants and dApp connection MIP

### DIFF
--- a/docs/mps-mip/README.md
+++ b/docs/mps-mip/README.md
@@ -59,8 +59,11 @@ together; the upstream copies are canonical.
   `GrantRequest`, passkey consent, one device-gated `issue_grant`, and a
   return leg the dApp verifies against chain state. Read access is the
   MIP-0012 viewing capability sealed to a dApp key and recorded
-  declaratively. Requires a `spec_version = 2` redeploy. Open rulings
-  are tagged in the text; the external co-author is not yet named.
+  declaratively. Requires a `spec_version = 2` redeploy. Reviewed
+  through four lenses; the open items for editors and the Foundation
+  (co-author, companion erratum wording, salt and commitment rulings)
+  are collected in an editors' note at the head of the file, and the
+  external co-author is not yet named.
 - **Recovery paths (building block three; not yet drafted)**:
   total-loss recovery behind the seam; the prototype realises this
   with BUSS, and the standard stays scheme-agnostic at the contract

--- a/docs/mps-mip/README.md
+++ b/docs/mps-mip/README.md
@@ -62,8 +62,8 @@ together; the upstream copies are canonical.
   declaratively. Requires a `spec_version = 2` redeploy. Reviewed
   through four lenses; the open items for editors and the Foundation
   (co-author, companion erratum wording, salt and commitment rulings)
-  are collected in an editors' note at the head of the file, and the
-  external co-author is not yet named.
+  are collected in an editors' note at the head of the file. Co-authored
+  with the Midnight Foundation.
 - **Recovery paths (building block three; not yet drafted)**:
   total-loss recovery behind the seam; the prototype realises this
   with BUSS, and the standard stays scheme-agnostic at the contract

--- a/docs/mps-mip/README.md
+++ b/docs/mps-mip/README.md
@@ -48,6 +48,19 @@ together; the upstream copies are canonical.
   length-agnostic client-data hashing, [CRYPTO] envelope-binding and
   malleability-inertness review, [RULING] the k1 Interim-status
   registration. Tracked by passport issue #51 and PR #146.
+- `mips/mip-xxxx-scoped-grants.md` — **Scoped Grants and dApp Connection
+  for Custody Accounts (C10, C11, C12, C23)**: the successor extension
+  MIP-0013 reserves behind `require_authorised()`. A grant is a
+  contract-maintained record admitting one grantee key of a registered
+  scheme to a bounded subset of the asset-facing circuits (operations,
+  one color, per-call and cumulative caps, recipient pin, expiry),
+  enforced in-circuit and revocable from chain state; the connection
+  ceremony is a redirect to an authoriser carrying a canonical
+  `GrantRequest`, passkey consent, one device-gated `issue_grant`, and a
+  return leg the dApp verifies against chain state. Read access is the
+  MIP-0012 viewing capability sealed to a dApp key and recorded
+  declaratively. Requires a `spec_version = 2` redeploy. Open rulings
+  are tagged in the text; the external co-author is not yet named.
 - **Recovery paths (building block three; not yet drafted)**:
   total-loss recovery behind the seam; the prototype realises this
   with BUSS, and the standard stays scheme-agnostic at the contract

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -48,7 +48,7 @@ MPS: MPS-0018
      | O12 | Replaces: none per the brief and the published family | adopted |
      | O13 | Security Considerations rendered as a table where the published family uses bold-titled Sn bullets | table retained; the divergence is offered to the editors |
      | O14 | approved deviation from brief T5: canonical JSON (RFC 8785, JCS) replaced by signing the `request` parameter bytes as received, with the proof carried as a detached `proof` fragment parameter and no canonicalisation step anywhere | adopted (sections 9.1 to 9.4, 9.6, R10, R21) |
-     | O15 | E1 stage one folded: the grant seam compiled and measured on the reference contract at spec_version 2 (k256 grantee arm, unshielded and shielded twins, lifecycle on the k256 device arm, 27 recipe vectors agreed three ways). The brief's section 13 [CIRCUIT] items are settled (struct as Map value, Boolean in a hash tuple, tuple arity above ten, kernel.blockTimeLessThan in an assert, if-guarded lifecycle bodies, the Map reset primitive, cost figures) except two: proving times per twin and the change-description precomputation on node (6.5); the node's unit of block time is settled by E3 (O4) | fifteen corrections applied in the text; the remainder is stage two (Path to Active E1) |
+     | O15 | E1 folded, both stages, and the on-node conformance run (E2) with it: the grant seam is compiled and measured on the reference contract at spec_version 2 over the whole thirty-circuit roster, both grantee arms, 34 recipe vectors agreed three ways, and the seam is exercised on node. Every [CIRCUIT] item of the brief's section 13 is now settled, including the two that were open: proving times are measured for every circuit the on-node run exercised, which is three of the six grant twins (6.7), and the change-description precomputation is evidenced on node (6.5); the node's unit of block time is settled by E3 (O4) | both correction lists applied in the text; what remains is the residue named in Path to Active E2 and E6 and in Implementation |
 
      Upstream dependencies: secp256r1 in the Compact language surface (r1
      arm); secp256k1 point operations (schnorr_bip340); a connector
@@ -315,14 +315,19 @@ Rules:
 
 #### 3.3 Key validation
 
-Key validation is exactly the following and no more, performed by the
-authoriser at issuance and by the seam at every use:
+Key validation is exactly the following and no more. The seam performs
+its half at every use. The authoriser's half is an obligation on the
+issuing client, and the contract cannot perform it: `issue_grant` takes
+`grant_id` and never the key, so a weak, off-curve, invalid-curve, or
+foreign key is given a live, well-formed record without complaint and
+the only thing that can refuse it is the seam at use (measured on node,
+Implementation).
 
-| Arm | Check | Not yet evidenced in-circuit |
+| Arm | Check | In-circuit status |
 |---|---|---|
-| `k1` | the coordinate pair `(0, 0)` rejected in either identity-flag encoding (the point at infinity) | on-curve membership; the cofactor is 1, so subgroup membership is vacuous |
-| `v1` | `[8]P != O` (the identity and the whole 8-torsion) | on-curve membership |
-| `r1` | the point at infinity rejected; both coordinates below `p`; `y^2 == x^3 - 3x + b (mod p)` (SEC 1 point validation); at the authoriser, a CBOR Object Signing and Encryption (COSE) key that is not an uncompressed EC2 P-256 key with canonical coordinates is rejected | the curve equation is the in-circuit half not yet evidenced |
+| `k1` | the coordinate pair `(0, 0)` rejected in either identity-flag encoding (the point at infinity) | measured on node in both encodings, which share one `grant_id` because the identity preimage binds `x` and `y` and not the flag, and which one assert refuses. On-curve membership is not checked: the cofactor is 1, so subgroup membership is vacuous, but an off-curve pair, a genuine point of another curve of the same shape, and another arm's coordinates carried as a `k1` key all pass the guard and the scope predicates and are refused only at step 6, as `invalid grant signature` |
+| `v1` | `[8]P != O` (the identity and the whole 8-torsion) | measured on node for the identity `(0, 1)`, refused at the cofactor-clearing assert. No other point outside the prime-order subgroup reaches the assert: the runtime's own curve operations abort on an order-2 point and on an off-curve pair, so such a key cannot be presented through this runtime at all and the operator sees a runtime error rather than a named assert |
+| `r1` | the point at infinity rejected; both coordinates below `p`; `y^2 == x^3 - 3x + b (mod p)` (SEC 1 point validation); at the authoriser, a CBOR Object Signing and Encryption (COSE) key that is not an uncompressed EC2 P-256 key with canonical coordinates is rejected | not evidenced in-circuit; the arm does not ship |
 
 The `r1` key checks are not optional: under the identity key `Q = O`,
 ECDSA verification computes `R' = u1 * G`, so `s = 1` and
@@ -333,10 +338,30 @@ proof is the assertion itself, let an attacker fabricate a
 `clientDataJSON` naming any origin. The identity key is an r1 negative
 vector of Testing item 5; the same correction is raised against the
 schemes MIP, whose section 3.3 item 5 lists signature-side checks only.
-Whether a witness point can be constructed off-curve is not evidenced;
-before this MIP leaves Draft the seam either gains an on-curve assertion
-or cites type-level evidence, and Testing item 2 carries off-curve and
-invalid-curve keys.
+The off-curve open item is settled on the two shipping arms, and not in
+the same way on both. On `v1` the rejection is real but it is the
+runtime's rather than the contract's, so a conformance suite can assert
+the abort and not its message. On `k1` it is settled in the negative:
+nothing stands between an invalid-curve key and the seam except the
+arithmetic of the signature check, which refuses such a key as
+`invalid grant signature`. That message is the absence of a
+curve-membership objection and not evidence that the seam verified
+anything, and an implementation MUST read it so. Before this MIP leaves
+Draft the `k1` seam either gains an on-curve assertion or this section
+stands as the record that curve membership on that arm rests on the
+signature arithmetic alone; Testing item 2 carries the measured
+off-curve and invalid-curve rows on both arms. The `r1` checks remain
+unevidenced in-circuit.
+
+GR-2 is an authoriser obligation and nothing more, measured as such: a
+key enrolled as a device of the account was issued a grant and spent
+under the grant seam, with the record advancing. The seam looks a
+grantee key up in `grants` under the grant tag family and finds a live
+record; nothing in the contract can see that the same key also holds a
+device entry, because device entries are salted rolling commitments and
+not stored keys. The two authorities stay disjoint in the sense GR-2
+states, in that no one credential satisfies both seams in one call, but
+the refusal to issue is enforceable off-chain only.
 
 #### 3.4 Wire forms of keys and off-chain signatures
 
@@ -351,7 +376,12 @@ A wire coordinate at or above the field modulus is not the encoding of
 any point and MUST be rejected, never reduced: the compiled encoding
 writes the canonical residue of each coordinate, so only canonical
 coordinates reproduce the circuit's digest by plain SHA-256, and a
-coordinate of an on-curve point is always canonical.
+coordinate of an on-curve point is always canonical. The rule is
+enforced by the encoding itself rather than by an assert: a `k1`
+coordinate pair presented as a `v1` key is refused by the client's own
+encoder as out of bounds for the prime field, before any transaction
+exists, so a cross-arm key in that direction never reaches the seam
+(measured on node, Implementation).
 
 Wire `scheme` names, keyed to the registry arm. The arm, not the wire
 name, selects the DST marker of section 6.3 and the identity tag of
@@ -600,13 +630,20 @@ the network refuses at admission. The node's admission-time block time
 runs about one block interval plus a network-defined tolerance ahead of
 the wall clock (measured 8.2 to 10.2 s ahead on a 6 s-block localnet;
 the tolerance is the node's and is not pinned here), so `expires_at` is
-a bound, and the grant stops being usable about that margin before it.
-Clients MUST sanity-check a non-zero `expires_at` against their own wall
-clock and a freshly read head block time before signing, SHOULD treat a
-value within one block interval plus the tolerance of the head block
-time as already expired, and an authoriser SHOULD refuse a value already
-in the past. There is no `network_id` cell (R15); the wire `chain`
-member remains normative for the request.
+a bound. The usable horizon is narrower than that margin, because the
+grantee's own proving time falls between its clock reading and the
+node's evaluation: a grant call on a shielded twin at k = 17 measured
+14.5 s from build to the node's refusal, nearly all of it the proof. The
+horizon is therefore one block interval plus the network tolerance plus
+the call's own prove-and-balance time, of the order of 20 s for a
+shielded twin on the reference stack, and a wallet that offers a
+five-second grant offers one that cannot be exercised. Clients MUST
+sanity-check a non-zero `expires_at` against their own wall clock and a
+freshly read head block time before signing, SHOULD treat a value less
+than one block interval plus the tolerance plus their own proving time
+ahead of that head block time as already expired, and an authoriser
+SHOULD refuse a value already in the past. There is no `network_id` cell
+(R15); the wire `chain` member remains normative for the request.
 
 #### 5.2 Feature strings and the mapping table
 
@@ -750,7 +787,20 @@ order:
 The custody chip runs unchanged after step 7. The shielded twins then,
 under a disclosed statement-level branch on whether the send produced
 change, append `change_entry` through the inbox chip in the same circuit
-and return the chip's result.
+and return the chip's result. The seam never checks `change_entry`
+against the coin that send produces: it is an opaque 192-byte argument,
+bound into the challenge of section 6.3 and appended verbatim, so a
+grantee that seals the wrong description strands its own change and
+nothing in the seam refuses it. Sealing the right description is the
+grantee's obligation alone (section 6.5).
+
+Because step 5 precedes step 6, a byte-identical resubmission is refused
+at the scope predicates and never reaches the signature check: once
+`nonce` has moved, the spent-commitment opening no longer matches and
+either that opening or the cumulative cap dominates. A conformance suite
+MUST admit any step-5 needle on a replay row rather than naming one
+(Testing item 2), and exercising the signature on a replay would need an
+opening that still matches, which the seam makes impossible.
 
 This discharges the custody MIP's S5 (a seam MUST NOT be satisfiable by
 circuit-unconstrained data): `origin_hash`, `slot`, `envelope`, and `pk`
@@ -797,9 +847,26 @@ thirteen declared tuple members (the `QualifiedShieldedCoinInfo` is one
 member), sixteen encoded elements, and 568 preimage bytes; the
 unshielded one 256 bytes. Both compile and hash as the raw
 concatenation, so no pre-hashing of the operation arguments is needed
-on the ECDSA arms. The JubJub shielded challenge has fourteen members
-and, by the recipe, 640 bytes (the two 64-byte point elements and the
-grinding nonce); it is not yet compiled and is measured in stage two.
+on the ECDSA arms. The JubJub shielded challenge has fourteen declared
+members, nineteen encoded elements, and 640 preimage bytes, and compiles
+and hashes the same way.
+
+Preimage widths of the compiled encoding, in bytes, for the three grant
+challenges and the three lifecycle challenges of section 6.1:
+
+| Recipe | `k1` | `v1` |
+|---|---|---|
+| `withdraw_unshielded` grant challenge | 256 | 328 |
+| `withdraw_shielded` grant challenge | 568 | 640 |
+| `withdraw_shielded_to_contract` grant challenge | 568 | 640 |
+| `issue_grant` | 200 | 272 |
+| `revoke_grant` | 168 | 240 |
+| `revoke_all_grants` | 136 | 208 |
+
+Every `v1` recipe is its `k1` twin plus 72 bytes: the 64-byte `sig_r`
+element and the 8-byte grinding nonce. A point element counts as one
+declared member and two encoded elements, and the qualified coin as one
+member and four elements.
 
 #### 6.4 Signing (grantee side)
 
@@ -821,8 +888,30 @@ A grantee MUST re-read `nonce` and `enc_key` and re-sign if its
 transaction is not included, and MUST persist `scope_salt`, the
 returned scope, and its running `spent` alongside the key.
 
+On the `v1` arm an authorisation that does not match the call it is
+presented with produces one of two refusals, and a conforming client
+expects both. The seam casts the challenge to a field element before
+evaluating the Schnorr equation, and a challenge the signer did not
+grind is below the field modulus only about 45 per cent of the time, so
+about 55 per cent of such calls abort at the cast's range check and the
+rest at `invalid grant signature`. Which one fires is a property of the
+challenge bytes and not of the seam, so a conformance suite MUST admit
+either needle on that arm. The ECDSA arms do not show it, since their
+challenge is a message and is never cast.
+
+Every in-circuit refusal of section 6.2 arrives at build time in one
+shape, `Unexpected error executing scoped transaction '<unnamed>':
+Error: failed assert: <needle>`, where the needle is the assert's own
+message as this MIP names it; no refusal text outside the specification
+was observed on node. An implementer matches on the needle and MUST NOT
+take the wrapper as the classifier, because the submission phase carries
+a different one (`Unexpected error submitting ...`), which is what a
+proving failure or a mempool refusal produces, and because refusals also
+arrive from the runtime (section 3.3), from the client's encoder
+(section 3.4), and from the node at admission.
+
 Expiry surfaces as one of two signals, both leaving state untouched and
-the signed challenge valid: a build-time abort (`failed assert:
+the signed challenge valid: a build-time abort (`failed assert: grant
 expired`) when the grantee's own clock is at or past `expires_at`, and
 a mempool refusal when the network's admission-time block time is (the
 node answers `Invalid Transaction: Custom error: 104` on a transcript
@@ -830,12 +919,15 @@ read mismatch, which the client submission layer surfaces as a
 `SubmissionError` whose reason is visible only in the RPC log line). On
 either signal the grantee MUST re-read the grant record and the chain
 head, and MUST re-sign only if `expires_at` is `0` or exceeds the head's
-block time by more than the inclusion margin of section 5.1; otherwise
-it treats the grant as expired and requests a new one. Retrying an
-admission refusal without re-reading is pointless, since the network's
-time only advances. A grantee SHOULD NOT take an indexer's latest-block
-timestamp as the head time (measured two blocks behind the node on the
-reference stack).
+block time by more than the inclusion margin of section 5.1, which
+includes the call's own proving time: a k = 17 shielded twin measured
+14.5 s from build to the node's refusal, so a client that budgets only
+the 8.2 to 10.2 s of section 5.1 will sign grants that cannot land.
+Otherwise it treats the grant as expired and requests a new one.
+Retrying an admission refusal without re-reading is pointless, since
+the network's time only advances. A grantee SHOULD NOT take an
+indexer's latest-block timestamp as the head time (measured two blocks
+behind the node on the reference stack).
 
 #### 6.5 Grantee private state and coin selection
 
@@ -845,13 +937,43 @@ scopes imply `read`) and reconstructs coin descriptions and `mt_index`
 values from the inbox and chain data before it can prove. Owner and
 grantee select coins independently; clients SHOULD apply a deterministic
 rule (the smallest coin of the color that covers `amount`, ties broken
-by `mt_index`). The failure modes are a proving failure when both select
-the same coin (no transaction exists, INV-5) and a fee-wasting race when
-both submit; a mis-spend is not one of them. The change description is
-precomputable before proving because the standard library evolves the
-output coin's nonce deterministically from the input coin's (not yet
-evidenced; the fallback is a bounded standalone append twin with an
-`append_budget` in the scope).
+by `mt_index`). The failure modes are a fee-wasting race when both
+submit and, when both select the same coin, a refusal of the loser by
+the node as a double spend; a mis-spend is not one of them, and neither
+is a proving failure, since proving a spend consults the commitment tree
+and not the nullifier set, so the loser's call still proves against the
+post-spend state (INV-5).
+
+The change description is precomputable before proving, and is measured
+so. The standard library derives both output nonces from the input
+coin's nonce, the sent coin under the kernel tag
+`midnight:kernel:nonce_evolve` and the change coin under
+`midnight:kernel:nonce_evolve/2`, each the transient hash of the tag and
+the degraded input nonce, upgraded from transient. A grantee therefore
+computes the change coin, seals it as `change_entry`, and signs over it
+before the call is built. Ten of ten predictions matched the coin the
+circuit returned, on nonce and value alike, and a composed
+contract-recipient call additionally matched the sent coin's nonce,
+which is the pair a composing client needs to build the payee's claim in
+the same transaction. Nothing in the seam checks the seal (section 6.2),
+so a grantee that seals the wrong description strands its own change.
+
+One qualification stands between that rule and a working client. The
+change output is not reliably the last commitment of the spend
+transaction's window, and a contract-owned deposit commitment is not
+reliably the first of its own, so the qualified coin's `mt_index` is
+resolved by trying candidates, and every retry of a signed call costs a
+fresh signature as well as a proof, because the qualified coin is in the
+challenge (section 6.3). Measured over one run: of eleven spends that
+resolved their index by signing and submitting a candidate, six needed a
+second candidate and none needed a third; of eight resolved by
+prove-only trials, which submit nothing, four needed a second trial. A
+grantee SHOULD therefore resolve `mt_index` by prove-only trials before
+it signs. A wrong candidate is not self-describing and MUST NOT be read
+as a diagnosis of the index: the call fails at the prover before
+submission and carries the prover's own error text, or aborts in circuit
+execution with a bare `unreachable`, and nothing reaches the node in
+either case, which is what makes prove-only resolution safe.
 
 #### 6.6 Disclosure
 
@@ -881,49 +1003,127 @@ Over the corresponding device twin a grant twin replaces two
 device-entry hashes with one identity hash and three commitment hashes,
 and adds one map lookup and insert, one widened comparison, one kernel
 comparison, and on shielded twins one inbox insert. Measured on the
-reference contract at `spec_version = 2` (E1 stage one, the k256 arms;
-proving times are not yet measured):
+reference contract at `spec_version = 2` over the whole thirty-circuit
+roster, both device arms and both grantee arms; prover keys are rounded
+from the measured bytes:
 
 | Circuit | k | Rows | Prover key |
 |---|---|---|---|
-| `withdraw_unshielded_with_k256` (device twin, for comparison) | 16 | 61,003 | 117 MB |
-| `withdraw_shielded_with_k256` (device twin, for comparison) | 17 | 74,587 | 235 MB |
-| `withdraw_unshielded_with_grant_k256` | 17 | 64,352 | 235 MB |
-| `withdraw_shielded_with_grant_k256` | 17 | 91,862 | 235 MB |
+| `deposit_unshielded` | 9 | 311 | 0.4 MB |
+| `deposit_shielded` | 13 | 6,484 | 11 MB |
+| `activate_initial_device_with_jubjub` | 14 | 13,412 | 25 MB |
+| `add_device_with_jubjub` | 15 | 26,771 | 49 MB |
+| `remove_device_with_jubjub` | 15 | 32,730 | 49 MB |
+| `rotate_enc_key_with_jubjub` | 15 | 26,725 | 49 MB |
+| `append_inbox_with_jubjub` | 16 | 32,790 | 99 MB |
+| `withdraw_unshielded_with_jubjub` | 15 | 28,877 | 49 MB |
+| `withdraw_shielded_with_jubjub` | 16 | 50,055 | 99 MB |
+| `withdraw_shielded_to_contract_with_jubjub` | 16 | 55,758 | 99 MB |
+| `activate_initial_device_with_k256` | 14 | 14,094 | 29 MB |
+| `add_device_with_k256` | 16 | 58,897 | 117 MB |
+| `remove_device_with_k256` | 16 | 65,404 | 117 MB |
+| `rotate_enc_key_with_k256` | 16 | 58,851 | 117 MB |
+| `append_inbox_with_k256` | 16 | 64,924 | 117 MB |
+| `withdraw_unshielded_with_k256` | 16 | 61,003 | 117 MB |
+| `withdraw_shielded_with_k256` | 17 | 74,587 | 235 MB |
+| `withdraw_shielded_to_contract_with_k256` | 17 | 80,290 | 235 MB |
+| `issue_grant_with_jubjub` | 16 | 52,227 | 99 MB |
+| `revoke_grant_with_jubjub` | 15 | 26,871 | 49 MB |
+| `revoke_all_grants_with_jubjub` | 15 | 26,645 | 49 MB |
+| `withdraw_unshielded_with_grant_jubjub` | 16 | 38,514 | 99 MB |
+| `withdraw_shielded_with_grant_jubjub` | 17 | 66,014 | 197 MB |
+| `withdraw_shielded_to_contract_with_grant_jubjub` | 17 | 71,717 | 197 MB |
 | `issue_grant_with_k256` | 17 | 78,604 | 235 MB |
 | `revoke_grant_with_k256` | 16 | 58,997 | 117 MB |
 | `revoke_all_grants_with_k256` | 16 | 58,771 | 117 MB |
+| `withdraw_unshielded_with_grant_k256` | 17 | 64,355 | 235 MB |
+| `withdraw_shielded_with_grant_k256` | 17 | 91,865 | 235 MB |
+| `withdraw_shielded_to_contract_with_grant_k256` | 17 | 97,568 | 235 MB |
 
-The unshielded grant twin costs 3,349 rows more than its device twin
-and crosses to k=17, doubling the prover key; the shielded grant twin
-costs 17,275 rows more and stays at its device twin's k. The envelope
-is not a circuit-shape parameter (both digests are computed on every
-call), so k does not vary by envelope. k is not a pure function of the
-row count (device circuits of 64,924 and 65,404 rows fit k=16 while the
-unshielded grant twin at 64,352 needs k=17), so an implementation
-quotes k and rows as measured and never predicts one from the other.
-The jubjub grant twins, the remaining k256 twin, and the p256 twins are
-unmeasured; the standalone gate anchors recorded in Implementation are
-expectations only for those arms.
+The seam's cost over the corresponding device twin is constant within an
+arm and a shape and differs across arms: on the k256 arm each shielded
+twin costs 17,278 rows more than its device twin and the unshielded twin
+3,352 more; on the jubjub arm each shielded twin costs 15,959 more and
+the unshielded twin 9,637 more. The shielded figures carry the inbox
+insert for the change entry, which no device twin performs. The seam
+pushes four of the six twins up one k, the k256 unshielded twin to 17,
+the jubjub unshielded twin to 16, and both jubjub shielded twins to 17,
+while the two k256 shielded twins stay at their device twins' k=17.
+Lifecycle is much cheaper on the normative arm: issuance, the most
+expensive lifecycle circuit on both arms, is 52,227 rows at k=16 on
+jubjub against 78,604 at k=17 on k256, and the two revocation circuits
+about 26,800 rows at k=15 against about 58,900 at k=16.
+
+The envelope is not a circuit-shape parameter (both digests are computed
+on every call), so k does not vary by envelope. k is not a pure function
+of the row count (device circuits of 64,924 and 65,404 rows fit k=16
+while the k256 unshielded grant twin at 64,355 needs k=17), and the
+prover key is not a function of k alone (at k=17 a jubjub circuit is
+about 197 MB and a k256 circuit about 235 MB; at k=16 the split is about
+99 MB against 117 MB), so an implementation quotes k, rows, and key
+sizes as measured and never predicts one from another. The p256 twins
+are unmeasured; the standalone gate anchors recorded in Implementation
+are expectations only for that arm.
+
+Proving times, measured at the proof provider and so excluding building,
+balancing, and submission, on the reference stack (node 2.1.0, proof
+server 9.0.0-rc.6, indexer 4.4.0-rc.2, a single-authority localnet with
+6 s blocks, one machine, one run): about 3.4 s at k=15, 5.6 to 8.0 s at
+k=16, and 11.2 to 17.4 s at k=17; 15.1 s for a cross-contract pair of a
+k=17 grant twin with a k=13 deposit proved in one call, and 19.9 and
+30.8 s for the two proofs of a composed pair of k=17 grant twins, which
+is dearer per proof than either twin alone. A grant spend and an
+issuance cost the same order on the same arm, and the jubjub arm is the
+cheaper one at every k the two share. The figures are one machine's,
+and the proof server was the run's least stable component at k=17.
+Three of the six grant twins carry no on-node timing at all: the two
+unshielded ones, because the reference localnet refuses a contract call
+paired with an unshielded offer, and the jubjub contract-recipient
+twin, which the run never called.
 
 Verifier keys depend on the circuit's shape and not on k: 2,745 bytes
 for every k256 circuit and 2,313 for every jubjub circuit (the deposits
-2,121 and 1,353). The reference implementation already exceeds the
-per-block byte and compute budgets with its 18 existing circuits, so it
-deploys in waves; the stage-one roster of 23 circuits carries 57,663
-verifier bytes (43,938 existing, 13,725 grant) against a 50,000-byte
-per-block write limit with about 9,138 bytes of deploy overhead beyond
-the keys, so a one-transaction deploy is refused and **two waves** are
-needed, the same count as today: the first as today (the two deposits
-and the eight k256 circuits, 25,434 verifier bytes), the second one
-hand-built maintenance update carrying the eight jubjub keys (18,504)
-and the five grant keys (13,725). The thirty-circuit roster (33 with
-p256) carries 74,286 verifier bytes and needs **three waves**, two of
-them maintenance updates. The grant circuits MUST be part of the
-`spec_version = 2` deploy wave plan, and maintenance-authority
-retirement MUST follow the last grant wave: a retired account can never
-receive a future arm's circuits, so an account deployed without the
-grant circuits and then retired can never gain grants and must migrate.
+2,121 and 1,353). The thirty-circuit roster (33 with p256) carries
+74,286 verifier bytes against a 50,000-byte per-block write limit, with
+about 9,138 bytes of deploy overhead beyond the keys; waves are
+mandatory independently of the grant circuits, since the eighteen
+pre-existing ones alone price a deploy at 53,076 bytes written. A
+one-transaction deploy of the whole roster is therefore refused before
+any transaction exists and the roster reaches a live account in **three
+waves**: the deploy, carrying the two deposits and the eight circuits of
+the born arm (25,434 verifier bytes), then two hand-built maintenance
+updates (23,994 and 24,858 verifier bytes), the last of which retires
+the maintenance authority. Each update advances the maintenance
+authority counter by exactly one, which a client reads from chain rather
+than assuming.
+
+The per-update ceiling is network-defined and this MIP bounds it only by
+measurement: on node 2.1.0 an update of 29,484 verifier bytes is
+accepted and one of 32,229 is refused, so the ceiling lies in that
+interval, closed to one verifier key. An implementation MUST pack well
+below it. The reference budget is 25,000 verifier bytes, the largest
+accepted payload less about 15 per cent, the margin covering the Dust
+spend the wallet adds when it balances the update, block fullness at
+submission, and the per-block fee-price adjustment. A budget under the
+ceiling does not by itself fix the wave count, since a greedy packer
+over one key order lands the same roster in four waves at 24,000 and in
+three at 25,000.
+
+The two refusals are different mechanisms at different points, and a
+specification that says an update must fit a block MUST say which one it
+means. The all-operations deploy is refused client-side by the fee
+computation, before a transaction exists. An over-large maintenance
+update is refused by the node at admission (`Invalid Transaction:
+Transaction would exhaust the block limits`) with nothing client-side
+objecting first: the client priced every refused payload without
+complaint, so an implementer gets no warning before submission and a
+refused update leaves the authority counter untouched.
+
+The grant circuits MUST be part of the `spec_version = 2` deploy wave
+plan, and maintenance-authority retirement MUST follow the last grant
+wave: a retired account can never receive a future arm's circuits, so
+an account deployed without the grant circuits and then retired can
+never gain grants and must migrate.
 Pure circuits add no keys.
 
 ### 7. Lifecycle
@@ -933,8 +1133,9 @@ Pure circuits add no keys.
 All three lifecycle circuits are device-gated through the unchanged
 device seam, which advances `auth_nonce` and `round` before the body
 runs; every `Map.lookup` is dominated by a `member` branch (section 6.2
-step 2). The bodies compile and execute off-node on the k256 device arm
-(Implementation); the jubjub device arm is stage two of E1.
+step 2). The bodies compile and execute off-node on both device arms;
+on node, issuance is exercised from both, and revocation and the kill
+from the jubjub arm (Implementation).
 
 `issue_grant(grant_id, <plaintext scope>)`:
 
@@ -1018,8 +1219,44 @@ grant need `N` consecutive counters and `N` signatures; the cumulative
 cap is enforced per call against the record as it stands at that call's
 execution, so a transaction cannot exceed `cap` in aggregate; the
 per-call cap is per circuit invocation, never per transaction; the
-recipient pin is evaluated per call and survives grafting; reordering
-composed calls invalidates the signatures.
+recipient pin is evaluated per call and survives grafting.
+
+Reordering composed calls does not invalidate their signatures: each
+stays a valid signature over its own challenge. What fails is the
+transcript, because the out-of-order call records reads of a record
+state that does not hold when it executes, and the node refuses the
+transaction at admission on a read mismatch. The two produce different
+operator-visible behaviour, and an implementation MUST expect the
+transcript refusal rather than a signature failure.
+
+Two calls on one contract in one transaction are measured (a revocation
+composed with a re-issue over one `grant_id`, a batch of two issuances,
+and two grant calls under one grant at consecutive nonces, the last
+appending both change entries in the same transaction). Three mechanics
+are properties of the ledger and of the client software development kit
+rather than of the seam, and a composing client meets every one:
+
+- the second call MUST be built against the state the first produces.
+  Two calls built independently read the same pre-state and record the
+  same `auth_nonce`, or the same grant `nonce`, and the node refuses the
+  pair with `Transcript(Execution(ReadMismatch ...))`;
+- the second call's shielded offer MUST travel with its intent. An
+  intent carries contract actions and unshielded offers only, so a
+  contract call's shielded inputs and outputs live on the transaction;
+  grafting the intent alone yields a transcript claiming nullifiers no
+  offer carries, refused before execution with
+  `Malformed(EffectsCheck(NullifiersNeqClaimedNullifiers))`;
+- which transcript section a call's coins land in is not stable between
+  runs. A guaranteed offer merges and leaves the intent free to be
+  placed at any segment, while a fallible offer's proofs are bound to
+  their own segment and re-keying it is refused with
+  `Malformed(Zswap(InvalidProof))`, so a call whose coins are fallible
+  keeps its own segment and the relative order of the two calls is
+  whatever the segment draw gave.
+
+A tool that reads transcripts MUST read the guaranteed and the fallible
+section alike, since the same circuit was observed in each on
+consecutive transactions.
 
 #### 7.5 Owner-side records
 
@@ -1673,8 +1910,12 @@ MIP's SIG-1 through SIG-5 for the arms it deploys.
   New cells and structs are a redeploy (Backwards Compatibility
   Assessment); twins, lifecycle circuits, pure derivations, and tag
   families are maintenance updates while the authority is live, under
-  the wave rule of section 6.7. Enabling the window bounds later is a
-  circuit revision (`:v2` twins), not a redeploy.
+  the wave rule of section 6.7. That is measured: the twelve grant
+  circuits reached a live account entirely through maintenance updates,
+  in two batches at the authority counter read from chain, with the
+  authority retired in the same update as the last batch. Enabling the
+  window bounds later is a circuit revision (`:v2` twins), not a
+  redeploy.
 - **Scheme.** A grant scheme is a new tag prefix under the authorisation
   MIP section 10's "policy structure" clause, with `grant` as the
   policy-structure segment; a revision of any construction is a new
@@ -1857,15 +2098,36 @@ measured rather than specified here, which is why section 5.1 states
       key validation, GrantViewSeal and the `read_pk` derivation,
       `signin_digest`, the `envelope_digest` separation, and the
       fork-replay statement.
-- [ ] E1: the grant arm on the reference contract at `spec_version = 2`
-      (all lifecycle circuits on both device arms; k256 twins on both
-      envelopes; jubjub twins), with rows, k, prover-key size, and
-      proving time per twin; the layout, arity, and change-append
-      fallbacks settled; Testing item 1 green (stage one complete: k256
-      grantee arm, two twins, lifecycle on the k256 device arm, vectors;
-      stage two lists the remainder).
+- [x] E1: the grant arm on the reference contract at `spec_version = 2`,
+      both stages complete: the two cells and structs, the pure
+      derivations, the seam chips and three grant twins on each grantee
+      arm, and the three lifecycle circuits on each device arm, with k,
+      rows, and prover-key size measured over the whole thirty-circuit
+      roster and proving times measured for every circuit the
+      conformance run exercised; the layout, arity, and change-append
+      questions settled with no fallback taken; Testing item 1 green.
+      Residue, carried by other criteria and not by this one: three of
+      the six grant twins have no on-node timing, the two unshielded
+      ones because the reference localnet refuses a contract call
+      paired with an unshielded offer and the jubjub contract-recipient
+      twin because the run never called it, and the p256 twins wait on
+      the secp256r1 surface.
 - [ ] E2: Testing item 2 green on a node, each case ending with the
-      invariants it exercises.
+      invariants it exercises. Held: twelve rejection rows and nine
+      grantee-key rows green on node, each ending with no transaction
+      and a byte-identical ledger snapshot either side; the
+      within-the-margin expiry row, which is built and submitted and
+      then refused at admission with the ledger byte-identical either
+      side; and the device-key control that measures GR-2. Open, so
+      the box does not close: the faults Testing
+      item 2 lists as green off-node only (the issue rules, the
+      out-of-scope operation flag, recipient-kind mismatch, a wrong
+      envelope, and a prior-incarnation opening) and those that have not
+      run at all (a cumulative wrap attempt, a foreign-color witness
+      coin, the two clock-skew rows on a grant twin, stale epoch, stale
+      generation, the salt-reuse flag, the two-slot revocation row, and
+      the vacuous-verifier control), and the revoke-plus-issue row over
+      an expired but unrevoked id rather than a live one.
 - [x] E3: the on-chain unit of `kernel.blockTimeLessThan` and the
       never-expires arm pinned on a ledger-9 network and recorded in the
       registry entry, with past, future, zero, and wrong-unit cases
@@ -1877,10 +2139,17 @@ measured rather than specified here, which is why section 5.1 states
       read-only grant, a two-element batch, and a zero-DUST refusal.
 - [ ] E5: the vectors of Testing item 5 published, the Rust side linking
       no compiled contract module.
-- [ ] E6: the deploy budget and wave plan of Testing item 6.
+- [ ] E6: the deploy budget and wave plan of Testing item 6. Held: the
+      thirty-circuit roster deployed on node in three waves at the
+      measured per-update ceiling of section 6.7, each update at the
+      authority counter read from chain, with retirement landing in the
+      last one. Open, so the box does not close: the `spec_version = 1`
+      control, which needs a compiled pre-grants build of the contract.
 - [ ] E7: the read handover of Testing item 7, including the
       two-delegate re-seal case.
-- [ ] E8, E9, E10: Testing items 8, 9, and 10.
+- [ ] E8, E9, E10: Testing items 8, 9, and 10 (item 9 green on node;
+      item 10 partial, with the leg that rotates `enc_key` between
+      signing and submission still open; item 8 not run).
 - [ ] E11: an r1 grantee end to end once the secp256r1 surface ships
       (Testing item 12); until then the r1 arm and `schnorr_bip340` are
       marked pending in the registry.
@@ -1901,8 +2170,10 @@ measured rather than specified here, which is why section 5.1 states
 1. Name the external co-author and settle the open items with the
    Foundation and the editors; fold the outcomes into the text.
 2. Extend the reference contract to `spec_version = 2` and run E1, E2,
-   E6, E9, and E10 (E3 is held); correct any byte recipe the compiled
-   encoding contradicts and publish the E5 vectors.
+   E6, E9, and E10 (E1 and E3 are held; E2, E6, and E10 are held in
+   part and their residue is named in the acceptance criteria); correct
+   any byte recipe the compiled encoding contradicts and publish the E5
+   vectors.
 3. Build a reference authoriser page and a reference dApp against the
    text and run E4 and E7; then E8 with the reference signer as agent.
 4. Commission the cryptographer review; fold findings in before editor
@@ -2012,7 +2283,7 @@ the salt.
 | S32 | Maintenance authority above the seam | grant circuits in the wave plan; authority retired after the last wave (6.7) |
 | S33 | Malleated ECDSA twins | both `s` forms accepted; inert because `nonce` advances (SIG-4) |
 | S34 | Pending private key stored before consent | non-extractable storage SHOULD; unavoidable in kind |
-| S35 | Concurrent coin selection | proving failure or a fee-wasting race, never a mis-spend (INV-5) |
+| S35 | Concurrent coin selection | a fee-wasting race, or the loser refused by the node as a double spend; never a mis-spend, and never a proving failure, since proving consults the commitment tree and not the nullifier set (INV-5) |
 | S36 | Fee-payment linkability | a dApp paying DUST from an address linked to its identity links itself to the account; outside the contract |
 | S37 | Authoriser unavailability | a recoverable error carrying no state; any device-key holder can act as authoriser (11.3) |
 | S38 | Toolchain hazards | the vacuous-verifier control of the authorisation MIP's S10; pinned toolchain versions |
@@ -2027,24 +2298,31 @@ the salt.
 | the reference implementation's wave deploy and block-limit numbers | the deploy budget rule of section 6.7 |
 | E3: the kernel block-time comparison on a ledger-9 node (node 2.1.0): 21 unit and enforcement cases and a 13-case admission-time sweep over a probe contract carrying the seam's comparison shape, each case recording the host clock, the node head, the client phase reached, and the node outcome | the unit is whole seconds since the UNIX epoch on the client and the node alike; the comparison is a transcript read (one public input, no constraints) enforced at client build against the wall clock and at node admission against the node's block context, never by the proof; the never-expires arm records no read; the admission-time block time ran 8.2 to 10.2 s ahead of the wall clock on a 6 s-block localnet; the client-side and node-side refusal texts of section 6.4 |
 | the cross-contract-calls experiment | composition in one transaction |
-| E1 stage one: the grant seam compiled on the reference contract at `spec_version = 2` (the two cells and structs, the pure derivations, the k256 seam chips, the unshielded and shielded k256 grant twins, and the three lifecycle circuits on the k256 device arm), measured at k=16 to 17, 58,771 to 91,862 rows, 2,745-byte k256 and 2,313-byte jubjub verifier keys, and executed off-node in a circuit simulator (lifecycle, the unshielded twin, its rejection matrix) | the circuit items settled: a struct as a `Map` value, `Boolean` as a one-byte hash element, tuple arities of thirteen and seventeen hashed as the raw concatenation, the kernel block-time comparison inside an assert, the `if`-guarded lifecycle bodies, and the `Map` reset primitive; the byte recipes of sections 4 and 6.3 reproduced two ways from the text alone (a TypeScript recipe and a Rust recipe linking no compiled module) against the compiled circuits, 27 vectors and two pinned signatures; the deploy budget of section 6.7 |
+| E1 stage one: the grant seam compiled on the reference contract at `spec_version = 2` (the two cells and structs, the pure derivations, the k256 seam chips, the unshielded and shielded k256 grant twins, and the three lifecycle circuits on the k256 device arm), measured at k=16 to 17 and 58,771 to 91,862 rows, the two grant twins re-measured three rows higher in stage two once the envelope assert landed, 2,745-byte k256 and 2,313-byte jubjub verifier keys, and executed off-node in a circuit simulator (lifecycle, the unshielded twin, its rejection matrix) | the circuit items settled: a struct as a `Map` value, `Boolean` as a one-byte hash element, tuple arities of thirteen and seventeen hashed as the raw concatenation, the kernel block-time comparison inside an assert, the `if`-guarded lifecycle bodies, and the `Map` reset primitive; the byte recipes of sections 4 and 6.3 reproduced two ways from the text alone (a TypeScript recipe and a Rust recipe linking no compiled module) against the compiled circuits, 27 vectors and two pinned signatures; the deploy budget of section 6.7 |
+| E1 stage two: the roster completed on the same contract (the jubjub grantee seam and its three twins, the remaining k256 twin, the three lifecycle circuits on the jubjub device arm, the client and Rust signer surfaces for both grantee arms, and an off-node suite of 121 checks over both arms), with the whole thirty-circuit roster measured from 311 rows at k=9 to 97,568 at k=17 | the six grant twins and six lifecycle circuits of section 6.1 exist on both arms with no exported signature changed; the cost table of section 6.7 and the seam's per-arm row cost; the `v1` challenge and lifecycle recipes of section 6.3 and their measured preimage widths, agreed three ways over 34 vectors and three pinned signatures; the `v1` key guard of section 3.3 and the runtime's refusal of every other point outside the prime-order subgroup |
+| E2: the conformance run on a ledger-9 localnet (node 2.1.0, indexer 4.4.0-rc.2, proof server 9.0.0-rc.6), twelve evidence groups from one account and one chain: the three-wave deploy and a cross-arm enrolment, issuance across both device arms, grant spends on both grantee arms, a twelve-row rejection matrix, ten grantee-key rows, the expiry rows with their transaction transcripts read back, composition of two calls on one contract, the one-coin race, the change prediction, and every proof of the run timed at the proof provider, with the per-update ceiling bisected to one verifier key by a separate probe over throwaway accounts | the seam behaves on node as specified on both grantee arms; the change-precomputation rule and the `mt_index` retry rate of section 6.5; the refusal points and wrapper texts of section 6.4; the key-validation findings of section 3.3, including GR-2 as an authoriser obligation the contract cannot enforce; the composition mechanics of section 7.4; the wave plan, the per-update ceiling, and the proving times of section 6.7; the expiry horizon of section 5.1; Testing items 1, 3, and 9 green and items 2, 6, 10, and 11 in part |
 
-Not yet held: any connection protocol on Midnight, origin binding,
-proving times per twin, the on-node matrix (which carries the expiry
-rows of Testing items 1 and 2 onto the grant twins; E3 pinned the
-comparison on a probe contract), the jubjub grantee twins, the
-remaining k256 twin
-(`withdraw_shielded_to_contract_with_grant_k256`), and the lifecycle
-circuits on the jubjub device arm; these are stage two of E1 and the
-remaining experiments of Path to Active.
+Not yet held: any connection protocol on Midnight and the origin
+binding it carries (E4); the read handover (E7); agent and self
+grantees (E8); the r1 arm and its in-circuit key checks, which wait on
+the secp256r1 surface (E11); the off-chain constructions of Testing item
+5 (`request_digest`, `signin_digest`, the `read_pk` derivation,
+GrantViewSeal, the negative key vectors, and the r1 vectors); the
+`spec_version = 1` control of Testing item 6; the recovery epoch bump of
+Testing item 11, which waits on the recovery seam; the leg of Testing
+item 10 that rotates `enc_key` between signing and submission; the
+faults Testing item 2 lists as not run on node; the on-node behaviour
+and proving cost of the two unshielded grant twins, which the reference
+localnet cannot carry, and of the jubjub contract-recipient twin, which
+the run never called; and the independent cryptographer review the
+acceptance criteria require.
 
-At stage one the reference contract carries the two cells, the two
-structs, the pure derivations, the k256 seam chips, two k256 twins,
-three lifecycle circuits on the k256 device arm, and `spec_version = 2`,
-and the Rust signer produces bit-identical `grant_id`, commitments, and
-k1 challenges from the byte recipes alone; stage two completes three
-twins per grantee arm and three lifecycle circuits per device arm. A
-static consent page implementing section
+The reference contract now carries the two cells, the two structs, the
+pure derivations, the seam chips and three grant twins on each grantee
+arm, three lifecycle circuits on each device arm, and
+`spec_version = 2`, and the Rust signer produces bit-identical
+`grant_id`, commitments, and `k1` and `v1` challenges from the byte
+recipes alone. A static consent page implementing section
 9 and a dApp implementing the return leg and sign-in, each runnable
 locally, are the E4 and E7 artefacts. Companion documents: the MPS-0018
 Recommended MIPs bullet, the erratum of section 12, the custody MIP R9
@@ -2063,24 +2341,32 @@ the following. Each item names the invariants it exercises.
    Expiry rows: a record with `expires_at = 0` and one with
    `expires_at = head + 3600` each execute on node with state advancing,
    and the `0` record produces no time read in the transcript (GR-7).
-   Status: green off-node for the unshielded k256 twin in the circuit
-   simulator (no proof, no node); the shielded twins and the node run
-   are pending; the expiry rows are green on node for the comparison
-   shape in a probe contract (E3) and pending on the grant twins.
+   Status: green on node. Issuance from both device arms; a
+   within-scope spend on both grantee arms, with `nonce`,
+   `spent_commit`, and `round` advancing and `auth_nonce` unchanged;
+   and both expiry rows on the grant twins themselves, the accepted
+   transactions read back through the indexer to show that the `0`
+   record's call records no block-time read and the forward-dated one
+   exactly one. The unshielded twins are exercised off-node only, in
+   the circuit simulator, because the reference localnet refuses a
+   contract call paired with an unshielded offer; that is a property of
+   the network the run used rather than a gap in the item.
 2. **Rejection matrix.** The same call aborts with no state change under
    each single fault: out-of-scope operation; over `per_call_cap`; over
-   `cap`; a cumulative wrap attempt; a witness coin of another color; a
+   `cap`; a cumulative wrap attempt; a wrong `spent_prev` opening; a
+   witness coin of another color; a
    witness coin above `max_coin_value`; wrong recipient under a pin;
    recipient-kind mismatch; a stale `enc_pk`; revoked; `expires_at` in
-   the past (the grantee's build aborts with `failed assert: expired`,
-   nothing is submitted); `expires_at` within one block interval plus
-   tolerance of the wall clock (the build succeeds, the node refuses at
-   admission with `Custom error: 104` on a transcript read mismatch,
-   state unchanged); a client clock skewed behind the network by more
-   than the margin (the same admission refusal, showing the check does
-   not rest on the grantee's clock) and skewed ahead (the client refuses
-   a call the chain would accept, a client-quality control rather than
-   a protocol property); stale epoch; stale generation; identical resubmission after success; a
+   the past (the grantee's build aborts with `failed assert: grant
+   expired`, nothing is submitted); `expires_at` within one block
+   interval plus tolerance of the wall clock (the build succeeds, the
+   node refuses at admission with `Custom error: 104` on a transcript
+   read mismatch, state unchanged); a client clock skewed behind the
+   network by more than the margin (the same admission refusal,
+   showing the check does not rest on the grantee's clock) and skewed
+   ahead (the client refuses a call the chain would accept, a
+   client-quality control rather than a protocol property); stale
+   epoch; stale generation; identical resubmission after success; a
    prior-incarnation signature against a re-issue; a cross-scheme key; a
    wrong envelope (k1); an envelope-1 grantee against any withdraw twin
    refused in-circuit (k1); the identity, small-order, off-curve, and
@@ -2092,10 +2378,52 @@ the following. Each item names the invariants it exercises.
    by the harness as non-conforming; revoke one of two slots held by one
    key, the other still authorises and only that one; `device_count`
    untouched; the vacuous-verifier control (GR-2, GR-3, GR-4, GR-5, GR-6,
-   GR-7, GR-9, GR-12, GR-14; the authorisation MIP's S10).
+   GR-7, GR-9, GR-12, GR-14; the authorisation MIP's S10). One row is a
+   control rather than a fault: a device key issued as a grantee is NOT
+   refused by the seam and spends under it, which is the measured
+   content of GR-2 (section 3.3). The replay row admits any of the
+   step-5 needles and a suite MUST NOT name one (section 6.2), and on
+   the `v1` arm a mismatched authorisation admits either the range
+   error of the challenge cast or `invalid grant signature`
+   (section 6.4).
+
+   Status: partial. Every row below that is green on node left the
+   ledger snapshot byte-identical either side, and every one but the
+   admission-margin row ended with no transaction at all, that row
+   being built, proved, and submitted and then refused at admission.
+   Green on node: over `per_call_cap`; over `cap`; a wrong `spent_prev`
+   opening; a witness coin
+   above `max_coin_value`; wrong recipient under a pin; a
+   stale `enc_pk`; revoked; `expires_at` in the past; `expires_at`
+   inside the admission margin, built by the client and refused by the
+   node; identical resubmission after success; a cross-scheme key in
+   both directions; an envelope-1 grantee against a withdraw twin; a
+   grantee calling a device-gated circuit; the identity on both
+   deployed arms; an off-curve pair and an invalid-curve twin on `k1`;
+   an order-2 point and an off-curve pair on `v1` (secp256k1 has prime
+   order, so the identity is its only small-order point);
+   `device_count` untouched across every row; and the device-key
+   control above. Green off-node only, in the circuit simulator: an
+   out-of-scope operation flag, recipient-kind mismatch, a wrong
+   envelope, a prior-incarnation opening against a re-issue, and the
+   issue rules (re-issue of a live id refused, issue over an absent id
+   succeeding, revoke of an absent id aborting, revoke of a tombstone
+   aborting). Not run anywhere: a cumulative wrap attempt; a witness
+   coin of another color; the two clock-skew rows on a grant twin (E3
+   carries them on a probe contract); stale epoch, since no circuit
+   bumps `device_epoch` until the recovery seam lands; stale
+   generation, structurally unreachable while `revoke_all_grants`
+   clears the register; the reused-`scope_salt` harness flag; the
+   two-slot revocation row; and the vacuous-verifier control. Revoke
+   plus issue over one id in one transaction is green, but over a live
+   id, where this item asks it of an expired but unrevoked one.
 3. **Owner liveness.** A pending owner signature still verifies after a
    grant call; a permissionless deposit between grantee signing and
    submission does not invalidate the grantee's call (GR-5; AUTH-8).
+   Status: green on node, both legs, with the second landing the
+   signature made before the intervening deposit rather than a re-signed
+   call, because the qualified coin's index was resolved by prove-only
+   trials before the grantee signed (section 6.5).
 4. **Redirect attack suite.** Open redirect; injection with a `state`
    mismatch; `iss`, `aud` mismatch; expired request; replayed `nonce`;
    proof failure; `clientDataJSON.origin` mismatch; an `rdns:`
@@ -2126,18 +2454,29 @@ the following. Each item names the invariants it exercises.
    signature vector per arm and a high-S vector per ECDSA arm that MUST
    verify; negative vectors for weak, identity, and low-order keys
    (GR-3, GR-4, GR-14). Status: green offline for every derivation of
-   section 4, the k1 challenges of section 6.3 (unshielded and shielded,
-   with the qualified coin written out) and the three k1 lifecycle
-   challenges, `envelope_digest`, and `origin_hash`, agreed three ways
-   (compiled circuits, TypeScript, Rust) over 27 published vectors with
-   two pinned k1 signatures, the high-S k1 twin included; pending are the
-   v1 and r1 challenges and signature vectors, `request_digest`,
-   `signin_digest`, the `read_pk` derivation, GrantViewSeal, and the
-   negative key vectors.
+   section 4; the `k1` and `v1` challenges of section 6.3 (unshielded,
+   shielded, and shielded-to-contract, with the qualified coin written
+   out) and the six lifecycle challenges; `envelope_digest`;
+   `origin_hash`; and the preimage-width table of section 6.3, agreed
+   three ways (the compiled circuits, a TypeScript recipe, and a Rust
+   implementation linking no compiled module) over 34 published vectors
+   with three pinned signatures, the high-S `k1` twin included. A `v1`
+   challenge commits to its own nonce point and grinding nonce, so it
+   cannot exist before it is signed and a suite verifies such a
+   signature rather than pinning it. Pending are the r1 challenges and
+   signature vectors, `request_digest`, `signin_digest`, the `read_pk`
+   derivation, GrantViewSeal, and the negative key vectors.
 6. **Deploy budget.** The full `spec_version = 2` roster deployed in
    waves within the per-block parameters; authority retirement after the
    last wave; a `spec_version = 1` account shown unable to gain grants
-   (GR-3, GR-13; Backwards Compatibility).
+   (GR-3, GR-13; Backwards Compatibility). Status: partial. Green on
+   node for the three-wave deploy of the thirty-circuit roster at the
+   measured per-update ceiling of section 6.7, each update at the
+   authority counter read from chain, and for the retirement landing in
+   the same update as the last batch. Missing: the `spec_version = 1`
+   control, which needs a compiled pre-grants build of the contract that
+   the reference tree does not carry, since its source is the version-2
+   one.
 7. **Read handover.** Read-only grant; seal, decrypt, verify the secret
    against `enc_key`, inbox walk with commitment verification; rotate-
    before-share hides spent history; a second read grant issued and the
@@ -2151,16 +2490,42 @@ the following. Each item names the invariants it exercises.
    from the owner's client with no authoriser page (GR-1, GR-17).
 9. **Composition.** Revoke plus issue in one transaction; batch issuance
    in one transaction; two grant calls under one grant with consecutive
-   nonces; reordering invalidates (GR-5, GR-11, GR-13).
+   nonces; reordering refused (GR-5, GR-11, GR-13). Status: green on
+   node. Each of the three rides one transaction, the third appending
+   both change entries in it, and the reordered pair is refused at
+   admission on a transcript read mismatch rather than by a signature
+   failure (section 7.4). One run saw the reordered pair included with
+   only one of its two calls applied, which is the same verdict by
+   another route; a record advancing by two under the reordered graft
+   would be the counter-example.
 10. **Change and concurrency.** A grantee shielded spend with the change
     entry appended in the same transaction under one-hop; a
     `rotate_enc_key` between signing and submission aborts the call with
-    no orphaned change; owner and grantee selecting the same coin
-    (proving failure, no mis-spend); a coin above `max_coin_value` aborts
-    (GR-7; INV-3, INV-4, INV-5, INV-6).
+    no orphaned change; owner and grantee selecting the same coin (the
+    loser refused by the node as a double spend, no mis-spend); a coin
+    above `max_coin_value` aborts (GR-7; INV-3, INV-4, INV-5, INV-6).
+    Status: partial. Green on node for the change entry appended in the
+    same transaction under one hop, for a coin above `max_coin_value`
+    aborting, and for the same-coin race: the owner's call landed, the
+    grantee's was refused by the node as a double spend with the grant
+    record untouched, and the same grantee call rebuilt against the
+    post-spend state still proved, so the refusal is the ledger's and
+    not the prover's. The same-transaction reading rests on the contract
+    source, where the append is inside the circuit, and on the chain
+    showing no other contract action between the call and the appended
+    entry; the suite's own assertion is the `inbox_count` delta across
+    the call, which is weaker. Missing: a `rotate_enc_key` between
+    signing and submission shown to abort the call with no orphaned
+    change, which the stale-`enc_pk` row of item 2 does not cover, since
+    it proves the abort and says nothing about the change.
 11. **Kill totality.** `revoke_all_grants` and a recovery epoch bump each
     inert every record; re-issue under the new generation or epoch
-    succeeds (GR-9).
+    succeeds (GR-9). Status: partial. Green on node for
+    `revoke_all_grants`: the generation bumped, the register cleared, a
+    pre-kill grant refused as `unknown grant` with no state change, and a
+    re-issue under the new generation spending. Missing: the recovery
+    epoch bump, which no circuit in the roster performs until the
+    recovery seam lands, so that half cannot be run here at all.
 12. **r1 grantee.** End to end once the secp256r1 surface ships; an
     extension-bearing assertion and the identity key as negative cases;
     `rp_commit` opened at the seam (GR-14, GR-15).
@@ -2239,8 +2604,17 @@ the following. Each item names the invariants it exercises.
   [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
   repository; the commit the evidence was taken at is recorded on
   submission.
-- E1 stage one (Implementation): the findings at `contract/GRANTS-E1.md`
-  and the vectors at `contract/src/tests/vectors/grants-e1.json` on the
+- E1, both stages (Implementation): the findings at
+  `contract/GRANTS-E1.md` and the vectors at
+  `contract/src/tests/vectors/grants-e1.json` on the branch
+  `nicolasdp/grants-seam-e1` of the
+  [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
+  repository.
+- E2 (Implementation): the findings at `contract/GRANTS-E2.md` and the
+  evidence at `contract/evidence/grants-e2-*.json`, twelve files, one
+  per group (deploy, issue, spend, rejections, liveness, direct, kill,
+  keys, expiry, composition, concurrency, and proving), together with
+  the ceiling bisection at `contract/evidence/wave-ceiling.json`, on the
   branch `nicolasdp/grants-seam-e1` of the
   [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
   repository.

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -3,13 +3,12 @@ MIP: xxxx
 Title: Scoped Grants and dApp Connection for Custody Accounts
 Authors:
   - Nicolas Di Prima (NicolasDP)
-  - TBD external co-author [RULING]
 Status: Draft
 Category: Standards
 Created: 2026-09-09
 License: Apache-2.0
 Requires: "MIP-0012: Contract Custody of Midnight-Native Assets", "MIP-0013: Multi-key Account Authorisation for Custody Contracts"
-Replaces: N/A
+Replaces: none
 MPS: MPS-0018
 ---
 
@@ -29,12 +28,31 @@ MPS: MPS-0018
  limitations under the License.
 -->
 
-<!-- WORKING DRAFT. Open items are tagged inline and collected in
-     Specification section 15: [RULING] = pending a product, policy, or
-     editorial decision; [DEP] = blocked on an upstream Compact, ledger,
-     connector, or browser feature; [CIRCUIT] = pending circuit evidence;
-     [CRYPTO] = pending cryptographer review. Every tag carries the
-     default the text currently adopts. -->
+<!-- Open items to settle before this draft is offered for numbering.
+     This block is removed at submission; it is not part of the MIP.
+
+     | Id | Item | Current default in the text |
+     |---|---|---|
+     | O1 | external co-author | the offer in upstream discussion #223 answered first; Acknowledgements reserves the slot |
+     | O2 | one spec_version = 2 redeploy carrying the grant cells and the device-identity remedy for MIP-0013 erratum 8 | SHOULD, in Backwards Compatibility |
+     | O3 | companion erratum to MIP-0013 AUTH-1, AUTH-2, AUTH-9 (section 12); wordings in .planning/grants-mip/erratum-wordings.md, to travel in the erratum PR | acceptance is an acceptance criterion |
+     | O4 | on-chain unit of kernel.blockTimeLessThan, and that the never-expires arm executes | pinned before Draft leaves; recorded in the registry entry |
+     | O5 | tombstone pruning and window enforcement | deferred to a circuit revision |
+     | O6 | one MIP or two | one MIP under MPS-0018; the split offered in the PR body |
+     | O7 | editor deviation from brief T3: rp_id_hash is committed under scope_salt (rp_commit) rather than stored clear, so the "observer does not learn the origin" claim of brief 5.5 holds for r1 grants | commitment; one extra opening on the p256 seam |
+     | O8 | editor deviation from brief section 7: the Expired to Active edge is dropped; renewal is revoke then issue, composable in one transaction | issue_grant does not evaluate expiry |
+     | O9 | the schemes draft is cited, not listed in Requires, per brief 10.1; the r1 checks and witness set are reproduced inline; r1 registration is gated on that draft receiving a number | as sections 3.1 and 14 |
+     | O10 | enc_pk argument on the shielded grant twins, asserted equal to enc_key, so a rotation aborts a pending grant call rather than orphaning change | adopted |
+     | O11 | re-seal obligation toward other live read grants on every rotation | adopted as an authoriser MUST with a roster fallback |
+     | O12 | Replaces: none per the brief and the published family | adopted |
+     | O13 | Security Considerations rendered as a table where the published family uses bold-titled Sn bullets | table retained; the divergence is offered to the editors |
+
+     Upstream dependencies: secp256r1 in the Compact language surface (r1
+     arm); secp256k1 point operations (schnorr_bip340); a connector
+     structured-display surface (envelope-1 spend); WebAuthn PRF in target
+     browsers; the Open Wallet Standard handshake flag and mapping-table
+     acceptance; CAIP-10 for Midnight. Circuit and cryptographer evidence
+     items are the checkboxes of Path to Active. -->
 
 ## Table of contents
 
@@ -42,7 +60,7 @@ MPS: MPS-0018
 - [Motivation](#motivation)
 - [Specification](#specification)
   - [1. Scope of this document](#1-scope-of-this-document)
-  - [2. Terminology](#2-terminology)
+  - [2. Terminology and notation](#2-terminology-and-notation)
   - [3. Grantee keys and arms](#3-grantee-keys-and-arms)
   - [4. Ledger state and grant identity](#4-ledger-state-and-grant-identity)
   - [5. Scope semantics](#5-scope-semantics)
@@ -52,10 +70,9 @@ MPS: MPS-0018
   - [9. GrantRequest and the redirect binding](#9-grantrequest-and-the-redirect-binding)
   - [10. Sign-in](#10-sign-in)
   - [11. Ecosystem carriage](#11-ecosystem-carriage)
-  - [12. Invariants](#12-invariants)
-  - [13. Companion erratum to MIP-0013 section 9](#13-companion-erratum-to-mip-0013-section-9)
+  - [12. Companion erratum to MIP-0013 section 9](#12-companion-erratum-to-mip-0013-section-9)
+  - [13. Invariants](#13-invariants)
   - [14. Versioning](#14-versioning)
-  - [15. Open items](#15-open-items)
 - [Rationale](#rationale)
 - [Path to Active](#path-to-active)
 - [Backwards Compatibility Assessment](#backwards-compatibility-assessment)
@@ -75,103 +92,63 @@ custody account conforming to MIP-0012 and MIP-0013 that admits one
 grantee key of one registered signature scheme to a bounded subset of
 the account's asset-facing operations: three spend circuits, one token
 color, a per-call cap, a cumulative cap, a bound on the value of any
-coin the grantee may touch, an optional recipient pin, and an optional
-expiry. Scope is enforced in-circuit on every call, and any active
-device can revoke a grant from chain state. A grant may also be
-read-only, in which case the record anchors, enumerates, and revokes an
-otherwise invisible viewing capability.
+coin the grantee may touch, an optional recipient pin, and an expiry
+that is always stated, with zero meaning never. Scope is enforced
+in-circuit on every call, and any active device can revoke a grant from
+chain state. A read-only grant is the anchor that makes an otherwise
+invisible viewing capability enumerable and revocable.
 
-The record is keyed by a contract-recomputable identity over the
-account address, the grantee key, its origin, and a small slot number,
-so that one credential has at most one live record per slot and every
-record of a grantee is enumerable from public state. Fields that would
-name a held coin's color, a counterparty, or a released value are
-stored as salted commitments, so the custody invariants of MIP-0012
-hold unchanged. Freshness is a per-grant nonce read from the record
-inside the circuit; grant calls never touch the device counter.
-
-The connection flow is the normative redirect binding of one
-transport-independent `GrantRequest` object: a dApp redirects the user
-to an authoriser page carrying its origin and key with a
-browser-attested proof of possession; the user authenticates with the
-account's device passkey, sees exactly the scope the ledger will
-record, approves; the authoriser submits one device-gated `issue_grant`
-call; the user returns to the dApp, which verifies its grant by reading
-chain state and thereafter signs in with the passkey registered for that
-dApp. The same record and seam serve agents and intra-user delegation
-through non-browser bindings. Read access is delivered as the MIP-0012
-viewing capability sealed to a dApp-supplied key, and the MIP states as
-its dominant residual risk that the ledger enforces spend scope and not
-read scope.
+The record is keyed by a contract-recomputable identity over the account
+address, the grantee key and, on the secp256k1 arm, its envelope id, its
+origin, and a slot number. Fields that would name a held coin's color, a
+counterparty, a released value, or the grantee's origin are stored as
+salted commitments, so the custody invariants of MIP-0012 hold
+unchanged. The connection flow is the normative redirect binding of one
+transport-independent `GrantRequest` object, with a browser-attested
+proof of possession in place of a self-asserted origin and a chain
+record in place of a bearer code. The dominant residual risk is that the
+ledger enforces spend scope and not read scope.
 
 ## Motivation
 
 MIP-0012 fixes how a custody contract holds and releases value behind
 one abstract seam, `require_authorised()`, and its section 2 names
 "delegated or scoped spending policies (grants, allowances, session
-permissions)" as authorisation-policy objects behind that same seam,
-deferred to a conforming extension. MIP-0013 instantiates the seam with
-device keys and states in its section 4 that "scoped grants are
-permitted extensions that interact only with this seam and MUST NOT
-weaken any invariant of section 9". Its security consideration S7
-records the gap that makes the extension necessary: `add_device` grants
-full authority, so today the only way to let any third party act on an
-account is to make it a device. This document is the reserved
-extension.
+permissions)" as authorisation-policy objects behind that seam, deferred
+to a conforming extension. MIP-0013 instantiates the seam with device
+keys and states in its section 4 that "richer on-ledger policies (m-of-n
+across device entries, scoped grants) are permitted extensions that
+interact only with this seam and MUST NOT weaken any invariant of
+section 9". Its S7 records the gap: `add_device` grants full authority,
+so the only way to let a third party act on an account today is to make
+it a device. This document is the reserved extension.
 
-Three inadequacies of the current ecosystem motivate the shape chosen.
+Today a dApp can hold a full device key (total compromise of asset
+release if the dApp is compromised, the authorisation MIP's S5) or hold
+nothing. The account-custody prototype showed a color-scoped,
+value-capped, epoch-bound withdraw grant enforced in-circuit on a devnet
+node; origin binding, expiry, signature-based grantee authentication,
+and a connection protocol are what a standard must supply. The dApp
+connector API and the Open Wallet Standard are wallet-side and
+ephemeral, and MPS-0029 records that Compact exposes no authenticated
+caller identity, so a separate verifier contract cannot know who called
+it.
 
-**There is no bounded authority.** A dApp that wants to show an
-account's holdings, or to move a bounded amount of one token on the
-user's behalf, has today two options on a MIP-0013 account: hold a full
-device key, which is total compromise of asset release if the dApp is
-compromised (MIP-0013 S5), or hold nothing and route every action
-through the owner's own client. Neither is a connection. The
-account-custody prototype demonstrated a colour-scoped, value-capped,
-epoch-bound withdraw grant enforced in-circuit on a devnet node, which
-establishes that bounded authority is expressible at the seam; it did
-not establish origin binding, expiry, signature-based grantee
-authentication, or any connection protocol, which is what a standard
-must supply.
+NEAR's access-key login flow is the closest deployed analogue of the
+connection this MIP specifies: a dApp generates a key, redirects to the
+wallet with its public key and return URL, and the wallet adds the key.
 
-**Connection is not standard, and what exists is the wrong layer.** The
-dApp connector API and the Open Wallet Standard define how a dApp or an
-agent talks to a wallet: session establishment, message signing, and
-client-side policy. Both are wallet-side, off-chain, and ephemeral. The
-Open Wallet Standard's policy design explicitly asks to pair with "an
-account contract that verifies a scoped authorisation in-circuit" and
-states that client-side policy is defence in depth, not the sole gate.
-MPS-0003 frames dApp-to-wallet connection as a chain-identifier problem
-and lists custom connector protocols as the current workaround. MPS-0029
-records that Compact exposes no authenticated caller identity, so a
-separate verifier contract cannot know who called it. None of these
-produces a scoped, revocable, on-chain object that a dApp's signature
-can target; each points at one.
+| NEAR defect | Closed by |
+|---|---|
+| login cross-site request forgery (CSRF): nothing proves the dApp possesses the key or binds the return to the requesting session | a possession proof by the grantee key, a browser-written origin attestation, and a session-bound `state` (section 9) |
+| an open redirector through attacker-controlled return URLs | `redirect_uri` same-origin with the proven origin, matched exactly (section 9.7) |
+| disclosure of the account's whole key list to every dApp | no key list in the response; the dApp reads its own record from chain |
+| a non-expiring default | expiry always stated; never-expiring is an explicit zero |
 
-**The redirect pattern is well known and well known to fail.** NEAR's
-access-key login flow is the closest deployed analogue of the user
-brief's connection: a dApp generates a key, redirects to the wallet with
-its public key and return URL, and the wallet adds the key to the
-account. Its documented defects are login CSRF (nothing proves the dApp
-possesses the key it asks to add, and nothing binds the return to the
-requesting session), an open redirector through attacker-controlled
-return URLs, disclosure of the account's whole key list to every dApp,
-and a non-expiring default. OAuth 2.0 and its security best current
-practice have fixed these classes for a decade. A Midnight standard has
-the opportunity to borrow the fixes and to add the one thing OAuth
-cannot: a browser-written origin attestation (the WebAuthn
-`clientDataJSON.origin`) in place of a self-asserted `from` parameter,
-and a chain record in place of an authorization code.
-
-The absence of a standard here has a demonstrated cost in the adjacent
-upstream proposal for private mandate tokens, which standardises a
-capability-scoped, value-capped, expiring, revocable delegation record
-of exactly this shape but authenticates the agent through an
-unconstrained sender witness, which is the `ownPublicKey()` pattern
-MIP-0012 section 4 forbids, and attaches the record to an
-admin-overwritten balance rather than to custodied assets. The safe
-pattern, a grant verified inside the custody seam by a signature over a
-challenge that binds the call, is what this MIP standardises.
+OAuth 2.0 and its security best current practice fixed these classes a
+decade ago; this MIP borrows the fixes and adds a chain record in place
+of the bearer code an OAuth authorisation server returns (Rationale R9,
+R13).
 
 ## Specification
 
@@ -180,117 +157,88 @@ interpreted as described in RFC 2119.
 
 ### 1. Scope of this document
 
-This MIP standardises:
-
-1. the **grant record** and its identity in the ledger state of a
-   custody account (section 4) and the semantics of its scope fields
-   (section 5);
-2. the **grant seam**: how a grantee key satisfies `require_authorised()`
-   for exactly three asset-releasing circuits, with scope evaluated
-   in-circuit over the values the custody chip consumes (section 6);
-3. the **lifecycle** circuits and state machine: issue, revoke, revoke
-   all, lazy expiry, and re-issue (section 7);
-4. **read-scope delegation**: how the MIP-0012 viewing capability is
-   sealed to a grantee and recorded declaratively (section 8);
-5. the **`GrantRequest`** object and its normative https redirect
-   binding, including the consent screen, the response, the error
-   vocabulary, and the return-leg verification (section 9);
-6. **account-linked sign-in** backed by a live grant (section 10);
-7. how the grant vocabulary is carried in CAIP-25 sessions and mapped to
-   Open Wallet Standard policy terms (section 11).
-
-`issue_grant` is a device-gated circuit that the owner can call with no
-ceremony from their own client, offline from any authoriser page; a
+This MIP standardises the grant record and its identity (section 4), its
+scope semantics (section 5), the grant seam through which a grantee key
+satisfies `require_authorised()` for exactly three asset-releasing
+circuits (section 6), the lifecycle (section 7), read-scope delegation
+(section 8), the `GrantRequest` object and its normative https redirect
+binding (section 9), account-linked sign-in (section 10), and carriage
+in Chain Agnostic Improvement Proposal (CAIP) sessions and Open Wallet
+Standard policy terms (section 11). `issue_grant` is a device-gated
+circuit the owner can call with no ceremony from their own client; a
 conforming account is fully usable with no authoriser in existence. The
-`GrantRequest` object is the interoperable way a third party asks for a
-grant; the redirect is one binding of it. The same record, identity,
-seam, and lifecycle serve intra-user delegation (a user's second device,
-a script, a household member) through the `self:` grantee form, so no
-parallel mechanism exists for it.
+same record, seam, and lifecycle serve intra-user delegation through the
+`self:` grantee form.
 
-Out of scope, with the successor or owner named where one exists:
+Out of scope:
 
-- a new injected wallet API, connector method, or Open Wallet Standard
-  capability definition (only the object they carry);
-- a client-side policy language (Open Wallet Standard PE-1 owns it);
-- proving and submission transport, fee sponsorship, and remote proving;
-  this MIP says only what the transaction must contain;
-- unlinkable, address-hiding sign-in and any authoriser-signed identity
-  assertion or pairwise pseudonym (the sign-in MIP recommended by the
-  planning register, hereafter "the sign-in MIP");
-- selective-disclosure credential proofs attached to or required by a
-  grant, and non-asset objects (contracts, attestations);
-- per-grantee, hierarchical, or epoch-scoped viewing keys and the
-  per-coin mirror mode (the MIP-0012 R9 successor, the named dependency
-  for spend without full disclosure); proxied reads;
-- chain-agnostic or "all chains" grants: a grant authorises calls on one
-  contract on one chain by construction; a chain-agnostic record class,
-  if needed, lives at the intent layer; a request MAY carry other
-  CAIP-217 scope objects this MIP does not enforce;
-- a general "callable contracts" object; the account contract has no
-  call-forwarding circuit;
-- grant delegation chains; grants are non-delegable;
-- m-of-n device policy, two-of-n revocation of high-value grants,
-  threshold grantee keys beyond what the JubJub arm permits, per-device
-  scheme agility;
-- the device-identity remedy for MIP-0013 erratum 8 itself
-  (recommended to share the schema bump, specified by MIP-0013 errata);
-- the `schnorr_bip340` grantee arm (pending upstream point operations),
-  activation of the r1 arm `[DEP]`, and spend through wallet-provider
-  keys `[DEP]`;
-- window-bounded rate limits (schema reserved; enforcement is a circuit
-  revision), tombstone pruning, automatic expiry cleanup;
-- authoriser discovery beyond a chooser and manual entry;
-- authenticated request objects (`.well-known` client metadata) for
-  browser clients without WebAuthn `[DEP]`, Related Origin Requests, and
-  any passkey shared across the authoriser and dApp origins;
-- merging device and grant twins into one circuit;
-- seed-anchored `deriveSecret` counterparts (MIP-0015); the grantee's
-  own per-origin passkey answers the durable-secret need;
-- migration of `spec_version = 1` accounts, the recovery seam's
-  internals, how the viewing secret reaches a second authoriser device
-  (MIP-0012), agent identity registration, and Zswap user-held coins;
-- address-only disclosure ceremonies with no on-chain effect; the
-  address is public information the user can share.
+- **Successor documents.** Unlinkable, address-hiding sign-in and any
+  authoriser-signed identity assertion belong to a separate, not yet
+  filed proposal, referred to below as "the sign-in MIP". Per-grantee or
+  epoch-scoped viewing keys and the per-coin mirror are the MIP-0012 R9
+  successor, the named dependency for spend without full disclosure.
+  The device-identity remedy for the authorisation MIP's erratum 8,
+  which records that removal retires a set element rather than a
+  device, is specified by that MIP's errata and recommended to share
+  this MIP's schema bump.
+- **Upstream dependencies.** The `schnorr_bip340` grantee arm (secp256k1
+  point operations); activation of the r1 arm (the secp256r1 language
+  surface); spend through wallet-provider keys (a connector surface
+  displaying a decoded grant call); `.well-known` client metadata; a
+  CAIP-10 account form for Midnight.
+- **Non-goals.** A new injected wallet API or connector method; a
+  client-side policy language (Open Wallet Standard PE-1); proving,
+  submission, and fee sponsorship; credential proofs and non-asset
+  objects; chain-agnostic grants (a grant authorises calls on one
+  contract on one chain by construction); a "callable contracts" object;
+  delegation chains; m-of-n device policy and threshold grantee keys;
+  window-bounded rate limits (schema reserved), tombstone pruning, and
+  automatic expiry cleanup; authoriser discovery; Related Origin
+  Requests and passkeys shared across the authoriser and dApp origins;
+  merging device and grant twins; `deriveSecret` counterparts
+  (MIP-0015); migration of `spec_version = 1` accounts; how the viewing
+  secret reaches a second authoriser device (MIP-0012); Zswap user-held
+  coins; address-only disclosure ceremonies.
 
-### 2. Terminology
+### 2. Terminology and notation
 
-- **Account**: a custody contract instance conforming to MIP-0012 and
-  MIP-0013 (hereafter "the custody MIP" and "the authorisation MIP").
-- **Device**, **device key**, **device entry**, **epoch**,
-  **`auth_nonce`**: as defined by the authorisation MIP. A grantee is
-  not a device and never counts toward `device_count`.
-- **Grant**: a record in the account's ledger state admitting one
-  grantee key to a bounded subset of operations under stated bounds.
-- **Grantee**: the holder of the grantee key: a browser dApp, a wallet
-  provider, an agent, or the owner acting through a delegate key.
-- **Grantee key**: a `(scheme, pk)` pair drawn from the signature-scheme
-  registry, plus, for the k1 arm only, an envelope id (section 3).
-- **Arm**: the per-scheme circuit family of the registry: `v1` (Schnorr
-  over JubJub), `k1` (ECDSA over secp256k1), `r1` (ECDSA over secp256r1
-  through the WebAuthn envelope).
+- **Account**: a custody contract instance conforming to MIP-0012 ("the
+  custody MIP") and MIP-0013 ("the authorisation MIP"). **Device**,
+  **device entry**, **epoch**, **`auth_nonce`**, **viewing
+  capability**, **viewing secret**, **inbox**, **coin store**, **color**:
+  as defined there. A grantee is not a device and never counts toward
+  `device_count`.
+- **Grant**: a record in the account's ledger state admitting one grantee
+  key to a bounded subset of operations. **Grantee**: its holder: a
+  browser dApp, a wallet provider, an agent, or the owner through a
+  delegate key. **Grantee key**: a `(scheme, pk)` pair from the
+  signature-scheme registry, plus, for k1 only, an envelope id.
+- **Arm**: the per-scheme circuit family: `v1` (Schnorr over JubJub),
+  `k1` (ECDSA over secp256k1), `r1` (ECDSA over secp256r1 through the
+  WebAuthn envelope).
 - **Origin**: the normalised identity of the grantee (section 4.4): an
-  RFC 6454 web origin for browser clients, or an `rdns:`, `mais:`, or
-  `self:` identifier for non-browser clients.
+  RFC 6454 web origin for browser clients; a reverse-DNS name (`rdns:`),
+  a Midnight Agent Identity Standard identifier (`mais:`), or an
+  owner-chosen label (`self:`) for non-browser clients.
 - **Grant identity** (`grant_id`): the contract-recomputable hash keying
-  the record (section 4.3).
-- **Slot**: a dApp-chosen byte distinguishing up to 256 records of one
-  key at one origin.
-- **Scope**: the immutable bounds of a grant (section 5); **plaintext
-  scope**: the scope as the approver consents to it, before commitment.
+  the record (section 4.3). **Slot**: a dApp-chosen byte, default `0`,
+  distinguishing up to 256 records of one key at one origin.
+- **Scope**: the immutable bounds of a grant; **plaintext scope**: the
+  scope as the approver consents to it, before commitment.
 - **Grant twin**: a gated circuit `<operation>_with_grant_<arm>` that
-  verifies a grant in the position where the device twin verifies a
-  device signature.
-- **Authoriser**: a role, not a service (section 11.3): a party holding
-  a device key of the account that renders a `GrantRequest`, drives
-  `issue_grant`, and, to serve `read`, holds the account viewing secret.
-- **Viewing capability**, **viewing secret**, **inbox**, **coin store**,
-  **color**: as defined by the custody MIP.
-- **Browser binding**: the delivery of a `GrantRequest` by top-level
-  navigation to an authoriser page (section 9). **Non-browser binding**:
-  any other delivery (a pasted or scanned object, a local channel).
-- **`pad(N, s)`**: the ASCII bytes of `s` followed by zero bytes to a
-  total width of `N` bytes. **`H(x)`**: SHA-256 of the byte string `x`.
+  verifies a grant where the device twin verifies a device signature.
+- **Authoriser**: a role (section 11.3): a party holding a device key of
+  the account that renders a `GrantRequest`, drives `issue_grant`, and,
+  to serve `read`, holds the viewing secret.
+- **Browser binding**: delivery of a `GrantRequest` by top-level
+  navigation to an authoriser page. **Non-browser binding**: any other
+  delivery (a pasted or scanned object, a local channel).
+- **Notation.** `H(x)` is SHA-256 of `x`. `pad(N, s)` is the ASCII bytes
+  of `s` followed by zero bytes to `N` bytes; `s` longer than `N` is
+  invalid. `u8(n)`, `u64(n)`, `u128(n)` serialise `n` little-endian at 1,
+  8, and 16 bytes. `flag(b)` is `0x01` for true and `0x00` for false.
+  `int_le(x)` is the integer whose little-endian encoding is `x`. `||`
+  is byte concatenation.
 
 ### 3. Grantee keys and arms
 
@@ -298,120 +246,130 @@ Out of scope, with the successor or owner named where one exists:
 
 A grantee key is a `(scheme, pk)` pair from the signature-scheme
 registry of the authorisation MIP's successor scheme document
-(hereafter "the schemes MIP"), plus, for `k1` only, an `envelope` id.
-Three grantee arms are registered by this MIP:
+(hereafter "the schemes MIP", cited in References and not yet
+numbered), plus, for `k1` only, an `envelope` id. Its rows are
+reproduced here; the `r1` row is registered when the schemes MIP
+receives a number and the secp256r1 surface ships, and the checks it
+needs are stated in full in sections 3.3 and 6.2.
 
 | Arm | Scheme | Envelope | Registry status | Today |
 |---|---|---|---|---|
 | `v1` | Schnorr over JubJub | intrinsic (none) | Active | yes |
-| `k1` | ECDSA over secp256k1 | `0` none, `1` connector prefix | Interim, inherited from the schemes MIP with its sunset | yes |
-| `r1` | ECDSA over secp256r1 through the WebAuthn envelope | intrinsic (WebAuthn message) | Active upon `[DEP]` secp256r1 language surface | no |
+| `k1` | ECDSA over secp256k1 | `0` none, `1` connector prefix | Interim, with the schemes MIP's sunset | yes |
+| `r1` | ECDSA over secp256r1 through the WebAuthn envelope | intrinsic (WebAuthn message) | Active upon the secp256r1 surface | no |
 
 `envelope` is the k1 digest selector and nothing else: the k1 arm
-verifies over `envelope_digest(envelope, h)` where
+verifies over `envelope_digest(envelope, h)`, where
 `envelope_digest(0, h) = H(h)` and
-`envelope_digest(1, h) = H(pad(27, "midnight_signed_message:32:") || h)`,
-the mandatory prefix of the dApp connector's `signData` surface. It is
-absent from the wire form and from the identity preimage for `v1` and
-`r1`, whose digest wrapping is intrinsic to the scheme. No `2 =
-webauthn` envelope id is filed. The `schnorr_bip340` scheme the
-connector also emits is reserved and `[DEP]` on upstream secp256k1
-point operations.
+`envelope_digest(1, h) = H("midnight_signed_message:32:" || h)`, the
+27-byte mandatory prefix of the dApp connector's `signData` surface. It
+is absent from the wire form and the identity preimage for `v1` and
+`r1`. No `2 = webauthn` envelope id is filed. The connector's
+`schnorr_bip340` scheme is reserved pending upstream secp256k1 point
+operations.
 
 #### 3.2 Grantee forms
 
-Five grantee forms are admitted through one table; none is privileged
-in the schema:
-
-| Form | Arm, envelope | Today | Origin proof at issuance | Scopes admitted | Serves |
+| Form | Arm, envelope | Today | Origin proof at issuance | Scopes | Serves |
 |---|---|---|---|---|---|
-| Per-dApp WebAuthn credential on the dApp origin | `r1` | `[DEP]` | the assertion itself (`clientDataJSON.origin`) | all | browser dApps once secp256r1 ships |
+| Per-dApp WebAuthn credential on the dApp origin | `r1` | pending | the assertion itself (`clientDataJSON.origin`) | all | browser dApps once secp256r1 ships |
 | Per-connection software key gated by a companion passkey on the dApp origin | `k1` envelope `0`, or `v1` | yes | WebAuthn assertion by the companion passkey over `request_digest`, which covers the software key | all | browser dApps now |
-| Wallet-provider key through the connector `signData` | `k1` envelope `1`; `schnorr_bip340` reserved `[DEP]` | yes | WebAuthn assertion by a companion passkey on the dApp origin, exactly as the software form; `signData` supplies possession only | `read` only in v1 `[RULING]` | "connect my wallet to my account" |
-| Agent or vaulted key (`rdns:`, `mais:` identity) | `v1` or `k1` envelope `0` | yes | operator assertion in the non-browser binding, displayed as such | all | agents, servers |
-| Intra-user delegate (`self:<label>` identity) | `v1` or `k1` envelope `0` | yes | none needed: approved in person on the owner's own device in the non-browser binding | all | a second device, a script, a household member |
+| Wallet-provider key through the connector `signData` | `k1` envelope `1` | yes | as the software form; `signData` supplies possession only | `read` only | "connect my wallet to my account" |
+| Agent or vaulted key (`rdns:`, `mais:`) | `v1` or `k1` envelope `0` | yes | operator assertion in the non-browser binding, displayed as such | all | agents, servers |
+| Intra-user delegate (`self:<label>`) | `v1` or `k1` envelope `0` | yes | none: approved in person on the owner's own device | all | a second device, a script, a household member |
 
 Rules:
 
 - Grantee keys MUST be generated per connection: one key per account per
-  origin. A key MUST NOT be reused across accounts or origins.
+  origin; a key MUST NOT be reused across accounts or origins.
 - An authoriser MUST refuse to issue a grant to a `pk` it knows to be
-  enrolled as a device key of the same account. The contract cannot
-  check this, since device keys are not stored; the rule is part of
-  GR-2.
-- **Wallet-provider keys are restricted to `read` in v1** `[RULING]`.
-  Connector `signData` under envelope `1` is a blind 32-byte
-  message-signing surface. Once a grant exists for a wallet key, every
-  element of a spend challenge is public or attacker-chosen (the tag,
-  the account address, the wallet key, `grant_id`, `issued_at`, the
-  record's `nonce`, and the operation arguments), so any other site the
-  user connects the same wallet to could compute a valid spend challenge
-  and obtain a signature by asking the wallet to sign a message the user
-  cannot interpret. An authoriser MUST return `unsupported_scheme` for
-  any withdraw string requested by an envelope-1 grantee. Spend through
-  envelope `1` is `[DEP]` on a connector surface that displays a
-  decoded, structured description of a grant call with per-call
-  confirmation.
+  enrolled as a device key of the same account (GR-2); the contract
+  cannot check this, since device keys are not stored.
+- **Wallet-provider keys are restricted to `read`.** Connector
+  `signData` under envelope `1` is a blind 32-byte signing surface, and
+  every element of the unshielded twin's challenge is public or
+  attacker-chosen (the shielded twins additionally need only the viewing
+  secret, which every read-granted party holds), so any other site the
+  same wallet connects to could obtain a valid spend signature by asking
+  the wallet to sign an opaque message. An authoriser MUST return `unsupported_scheme` for any withdraw string
+  requested by an envelope-1 grantee. Spend through envelope `1` waits
+  on a connector surface that displays a decoded grant call with
+  per-call confirmation.
 
 #### 3.3 Key validation
 
-Key validation is exactly what the following table says and no more,
-performed by the authoriser at issuance and again by the seam at every
-use:
+Key validation is exactly the following and no more, performed by the
+authoriser at issuance and by the seam at every use:
 
-| Arm | Check | Not checked |
+| Arm | Check | Not yet evidenced in-circuit |
 |---|---|---|
-| `k1` | coordinate pair `(0, 0)` rejected in either identity-flag encoding (the point at infinity) | on-curve membership `[CIRCUIT]`; the cofactor is 1, so subgroup membership is vacuous |
-| `v1` | `[8]P != O` (the identity and the whole 8-torsion) | on-curve membership `[CIRCUIT]` |
-| `r1` | `r != 0`, `s != 0`, recomputed point non-identity (schemes MIP section 3.3 item 5) | on-curve membership of the public key `[CIRCUIT]` |
+| `k1` | the coordinate pair `(0, 0)` rejected in either identity-flag encoding (the point at infinity) | on-curve membership; the cofactor is 1, so subgroup membership is vacuous |
+| `v1` | `[8]P != O` (the identity and the whole 8-torsion) | on-curve membership |
+| `r1` | the point at infinity rejected; both coordinates below `p`; `y^2 == x^3 - 3x + b (mod p)` (SEC 1 point validation); at the authoriser, a CBOR Object Signing and Encryption (COSE) key that is not an uncompressed EC2 P-256 key with canonical coordinates is rejected | the curve equation is the in-circuit half not yet evidenced |
 
-Whether a `Secp256k1Point` or `JubjubPoint` can be constructed off-curve
-from witness data is not evidenced. Before this MIP leaves Draft, the
-seam either gains an on-curve assertion or cites type-level evidence
-that the runtime enforces membership `[CIRCUIT]`; the negative
-conformance suite (Testing item 2) carries off-curve and invalid-curve
-grantee keys beside the identity and small-order ones.
+The `r1` key checks are not optional: under the identity key `Q = O`,
+ECDSA verification computes `R' = u1 * G`, so `s = 1` and
+`r = x(z * G) mod n` verify any message with no secret while passing
+every signature-side check of section 6.2 step 6. That would make an r1
+grant issued to `pk = O` spendable by anyone and, since the r1 origin
+proof is the assertion itself, let an attacker fabricate a
+`clientDataJSON` naming any origin. The identity key is an r1 negative
+vector of Testing item 5; the same correction is raised against the
+schemes MIP, whose section 3.3 item 5 lists signature-side checks only.
+Whether a witness point can be constructed off-curve is not evidenced;
+before this MIP leaves Draft the seam either gains an on-curve assertion
+or cites type-level evidence, and Testing item 2 carries off-curve and
+invalid-curve keys.
 
-#### 3.4 Wire form of a grantee key
+#### 3.4 Wire forms of keys and off-chain signatures
 
-`pk` is 128 lowercase hexadecimal characters encoding the affine
-coordinates `x || y`, each a 32-byte little-endian integer, for every
-curve. Inputs in SEC 1 form (compressed or uncompressed, big-endian)
-MUST be decompressed and byte-reversed per coordinate before use; a
-normalisation vector is published with the conformance vectors (Testing
-item 5). Wire `scheme` names are the connector's spellings where they
-exist and two registry spellings where they do not, mapped to the
-registry markers by one normative table `[RULING]`:
+`pk` on the wire is lowercase hexadecimal:
 
-| Wire `scheme` | Registry arm | `envelope` member | Source of the spelling |
+| Arm | `pk` | Preimage element |
+|---|---|---|
+| `k1`, `r1` | 128 hex: affine `x \|\| y`, each a 32-byte little-endian integer; SEC 1 inputs (compressed or uncompressed, big-endian) MUST be decompressed and byte-reversed per coordinate before use | `x`, `y` as given |
+| `v1` | 64 hex: the 32-byte `JubjubPoint` encoding in the layout this MIP publishes with its vectors (the type is opaque in Compact; the layout is the one the reference signer reproduces for the device family) | the 32 bytes as given |
+
+Wire `scheme` names:
+
+| Wire `scheme` | Registry arm | `envelope` member | Source |
 |---|---|---|---|
 | `ecdsa_secp256k1_sha256` | `k1` | MUST, `0` or `1` | dApp connector specification |
-| `schnorr_bip340` | reserved | absent | dApp connector specification; `[DEP]` |
+| `schnorr_bip340` | reserved | absent | dApp connector specification |
 | `schnorr_jubjub` | `v1` | absent | this MIP, filed into the schemes MIP registry |
 | `ecdsa_secp256r1_webauthn` | `r1` | absent | this MIP, filed into the schemes MIP registry |
+
+Off-chain signatures by a grantee key over a fixed 32-byte digest `d`
+(`request_digest`, section 9.2; `signin_digest`, section 10). Every
+verifier MUST accept both `s` forms of an ECDSA signature, matching the
+in-circuit policy (SIG-4); a high-S vector per ECDSA arm that MUST verify
+is published with Testing item 5.
+
+| Arm | Signs | Encoding |
+|---|---|---|
+| `k1` | `envelope_digest(envelope, d)` | 128 hex: `r \|\| s`, each a 32-byte little-endian integer |
+| `r1` | a WebAuthn assertion with `challenge = d` on the dApp origin | the authenticator's ASN.1 DER `ECDSA-Sig-Value`, base64url, with `clientDataJSON` and `authenticatorData` beside it |
+| `v1` | key-prefixed Schnorr: `c = int_le(H(R \|\| pk \|\| d)) mod r_J`, `s = r + c * sk mod r_J` | 128 hex: `R \|\| s`, `R` in the `JubjubPoint` layout, `s` a 32-byte little-endian integer below `r_J` |
+
+The `v1` off-chain form differs from the in-circuit form (unprefixed,
+ground challenge); separation rests on the tag and the key prefix, a
+cryptographer-review item.
 
 ### 4. Ledger state and grant identity
 
 #### 4.1 New cells and structs (`spec_version = 2`)
 
-A grant-capable account extends the custody MIP's and the authorisation
-MIP's ledger state with two cells. This is a schema change: the account
-exposes `spec_version = 2` (custody MIP section 8), and a
-`spec_version = 1` account cannot gain grants by maintenance update
-(Backwards Compatibility Assessment). The redeploy SHOULD land together
-with the device-identity remedy for the authorisation MIP's erratum 8
-`[RULING]`.
+A grant-capable account extends the parent MIPs' ledger state with two
+cells; this is a schema change and the account exposes `spec_version = 2`
+(Backwards Compatibility Assessment). Ledger-schema excerpt, not
+implementation code:
 
 ```compact
-export ledger grants:           Map<Bytes<32>, GrantRecord>;
-// keyed by grant_id (section 4.3)
-
-export ledger grant_generation: Uint<32>;
-// bumped only by revoke_all_grants; every record carries the value
-// at issue and is inert once it differs
+export ledger grants:           Map<Bytes<32>, GrantRecord>;  // keyed by grant_id
+export ledger grant_generation: Uint<32>;  // bumped only by revoke_all_grants
 ```
 
-`GrantScope` (immutable after issue; 164 bytes of payload):
+`GrantScope` (immutable after issue; 164 bytes):
 
 | Field | Type | Width | Meaning |
 |---|---|---|---|
@@ -422,11 +380,11 @@ export ledger grant_generation: Uint<32>;
 | `object_commit` | `Bytes<32>` | 32 | salted commitment to `color`, `recipient_kind`, `recipient`, `max_coin_value` (section 4.5) |
 | `per_call_cap` | `Uint<128>` | 16 | `amount <= per_call_cap` on every call; MUST be `<= cap` |
 | `cap` | `Uint<128>` | 16 | `spent + amount <= cap` cumulatively |
-| `expires_at` | `Uint<64>` | 8 | in the unit of `kernel.blockTimeLessThan` on the target ledger `[CIRCUIT]`; `0` means never, explicitly |
-| `rp_id_hash` | `Bytes<32>` | 32 | `r1` grantees only: SHA-256 of the dApp host; zero otherwise |
+| `expires_at` | `Uint<64>` | 8 | in the unit of `kernel.blockTimeLessThan`; `0` means never |
+| `rp_commit` | `Bytes<32>` | 32 | salted commitment to `rp_id_hash` (SHA-256 of the dApp host for `r1`, zero otherwise); committed for every arm so the record reveals neither host nor arm |
 | `read_pk_hash` | `Bytes<32>` | 32 | SHA-256 of the delegate's X25519 `read_pk` when `read`; zero otherwise |
-| `window_len` | `Uint<64>` | 8 | reserved; MUST be `0` in v1 `[RULING]` |
-| `window_cap` | `Uint<128>` | 16 | reserved; MUST be `0` in v1 `[RULING]` |
+| `window_len` | `Uint<64>` | 8 | reserved; MUST be `0` |
+| `window_cap` | `Uint<128>` | 16 | reserved; MUST be `0` |
 
 `GrantRecord` (81 bytes plus the scope):
 
@@ -434,90 +392,75 @@ export ledger grant_generation: Uint<32>;
 |---|---|---|---|---|
 | `epoch` | `Uint<32>` | 4 | contract, at issue | `device_epoch` observed inside `issue_grant` |
 | `gen` | `Uint<32>` | 4 | contract, at issue | `grant_generation` observed inside `issue_grant` |
-| `issued_at` | `Uint<64>` | 8 | contract, at issue | `auth_nonce` as advanced by the device seam of the issuing call; unique per issuance |
-| `nonce` | `Uint<64>` | 8 | contract, every grant call | per-grant freshness; read into the challenge and advanced by every grant call |
-| `spent_commit` | `Bytes<32>` | 32 | contract, at issue and every grant call | salted commitment to the cumulative value released under this grant (section 4.5) |
-| `window_start` | `Uint<64>` | 8 | reserved | `0` in v1 |
-| `window_spent` | `Uint<128>` | 16 | reserved | `0` in v1 |
+| `issued_at` | `Uint<64>` | 8 | contract, at issue | `auth_nonce` as advanced by the issuing call's device seam; unique per issuance |
+| `nonce` | `Uint<64>` | 8 | contract, every grant call | per-grant freshness; read into the challenge and advanced |
+| `spent_commit` | `Bytes<32>` | 32 | contract, at issue and every grant call | salted commitment to the cumulative value released |
+| `window_start` | `Uint<64>` | 8 | reserved | `0` |
+| `window_spent` | `Uint<128>` | 16 | reserved | `0` |
 | `active` | `Boolean` | 1 | contract | `false` is a tombstone (revoked) |
 | `scope` | `GrantScope` | 164 | contract, at issue | immutable after issue |
 
-Byte budget: about 277 bytes per grant including the 32-byte key,
-before the ledger's field alignment; one hundred grants, live or
-tombstoned, are about 28 KB of contract state. The record stores no
-key, no origin, and no scheme. `[CIRCUIT]`: a struct embedding a struct
-as a `Map` value is not evidenced (the prototype's map value is a struct
-of scalar fields only); the flattened fallback (the scope fields inlined
-into `GrantRecord`) changes no wire form, no challenge preimage, and no
-byte recipe.
+About 277 bytes per grant including the 32-byte map key (`grant_id`);
+one hundred grants are about 28 KB. The record stores no key, no origin,
+and no scheme. A struct as a `Map` value is not yet evidenced; a
+flattened layout, if adopted, changes no wire form or byte recipe but is
+a different ledger schema and takes its own `spec_version` (section 14).
 
 #### 4.2 Plaintext scope
 
 The plaintext scope the approver consents to, and that `issue_grant`
-takes as arguments, is:
+takes as arguments:
 
 | Argument | Type | Rule |
 |---|---|---|
 | the four flags | `Boolean` each | at least one operation flag or `read` MUST be set; shielded flags imply `read` |
 | `color` | `Bytes<32>` | the token color; all-zero is Night |
 | `recipient_kind` | `Uint<8>` | `0` any, `1` `UserAddress`, `2` `ZswapCoinPublicKey`, `3` `ContractAddress` |
-| `recipient` | `Bytes<32>` | the address bytes when `recipient_kind != 0`, else zero |
+| `recipient` | `Bytes<32>` | when `recipient_kind != 0`, the `bytes` field of the recipient struct, as is (each of the three Compact types is `{ bytes: Bytes<32> }`); zero otherwise |
 | `max_coin_value` | `Uint<128>` | a shielded twin aborts if the consumed coin's value exceeds it; MUST be `>= per_call_cap` when any spend flag is set |
-| `per_call_cap`, `cap`, `expires_at`, `rp_id_hash`, `read_pk_hash`, `window_len`, `window_cap` | as in `GrantScope` | as in `GrantScope` |
-| `scope_salt` | `Bytes<32>` | chosen by the authoriser at issue; a readability key for the record, never an authorisation secret |
+| `rp_id_hash` | `Bytes<32>` | `H(host(client_id))` for an `r1` grantee; zero otherwise |
+| `per_call_cap`, `cap`, `expires_at`, `read_pk_hash`, `window_len`, `window_cap` | as in `GrantScope` | as in `GrantScope` |
+| `scope_salt` | `Bytes<32>` | see below |
 
-The circuit computes `object_commit` and the initial `spent_commit` from
-these; `color`, `recipient`, and `max_coin_value` never appear in ledger
-state in the clear. The salt is bound in the device challenge, delivered
-to the grantee in the response, and kept in the owner's roster.
+`scope_salt` MUST be 32 bytes drawn fresh from a cryptographically secure
+random source at every issuance, MUST NOT be reused across grants,
+accounts, or re-issues of the same id, and MUST NOT be derived from any
+public value. It is necessary to open the record's commitments and
+therefore required to construct any grant call, but not sufficient for
+authority, which rests on the grantee signing key alone. The circuit
+computes `object_commit`, `rp_commit`, and the initial `spent_commit`
+from these arguments; `color`, `recipient`, `max_coin_value`, and
+`rp_id_hash` never appear in ledger state in the clear. The salt is bound
+in the device challenge, delivered to the grantee in the response, and
+kept in the owner's roster (section 7.5); the authoriser SHOULD NOT
+retain it after the response is delivered.
 
 #### 4.3 Grant identity
 
 `grant_id` is a deterministic commitment recomputed in-circuit from the
 presented key at every use and pre-derived by the authoriser at issue.
-Every preimage in this MIP is defined normatively as a byte
-concatenation of fixed-width elements hashed with SHA-256; the exported
-pure circuits of a conforming contract are one implementation of the
-recipe, not its definition, so a dApp recomputes its `grant_id` with
-plain SHA-256 and no Midnight stack. The recipes rely on the fact that
-Compact's `persistentHash` over a tuple of byte atoms is SHA-256 of
-their raw concatenation. Integer elements are serialised at the width
-of their Compact type, little-endian, as the coordinates are `[CIRCUIT]`
-(the published vectors of Testing item 5 pin the compiled encoding; a
-divergence is corrected in the recipe, never in the vectors).
+Every preimage in this MIP is a byte concatenation of fixed-width
+elements hashed with SHA-256 (`persistentHash` over byte atoms is
+SHA-256 of their raw concatenation); the exported pure circuits are one
+implementation of the recipe, not its definition, so a dApp recomputes
+`grant_id` with plain SHA-256. Integers are little-endian at their
+Compact width; the vectors of Testing item 5 pin the compiled encoding,
+and a divergence is corrected in the recipe, never in the vectors.
 
 | Arm | `grant_id` preimage (in order) | Width |
 |---|---|---|
 | `k1` | `pad(32, "midnight:account:grant:id:k1:v1") \|\| self \|\| x \|\| y \|\| u8(envelope) \|\| origin_hash \|\| u8(slot)` | 162 |
 | `r1` | `pad(32, "midnight:account:grant:id:r1:v1") \|\| self \|\| x \|\| y \|\| origin_hash \|\| u8(slot)` | 161 |
-| `v1` | `pad(32, "midnight:account:grant:id:v1") \|\| self \|\| pk_jubjub \|\| origin_hash \|\| u8(slot)` | 129 |
+| `v1` | `pad(32, "midnight:account:grant:id:v1") \|\| self \|\| pk \|\| origin_hash \|\| u8(slot)` | 129 |
 
-where `self` is the account's own contract address (32 bytes), `x` and
-`y` are the 32-byte little-endian affine coordinates of the grantee key,
-and `pk_jubjub` is the 32-byte encoding of the `JubjubPoint` element in
-the layout this MIP publishes with its vectors `[CIRCUIT]` (the type is
-opaque in Compact, with no evidenced coordinate accessor; the layout is
-the one the reference signer already reproduces for the device family
-without the compiled module). `envelope` is present only in the `k1`
-preimage.
-
-Consequences that are normative:
-
-- one tuple `(account, arm, key, [envelope,] origin, slot)` has at most
-  one live record; issuance fails while a live record exists under that
-  id; revocation retires the id;
-- a key holds at most 256 records at one origin, every one of them
-  enumerable by anyone who knows the key and the origin, in at most 256
-  lookups;
-- an unregistered key, a wrong origin, a wrong slot, a key of another
-  arm, and, on `k1`, a wrong envelope all fail identically at the
-  membership assert, before any signature is examined;
-- no secret lives in the identity preimage; grant security rests on the
-  grantee signing key alone. `[CRYPTO]`: the hiding argument for
-  `grant_id` rests on the entropy of a per-connection key; for a
-  publicly known key (the wallet-provider form) the dictionary test "is
-  key K connected to origin X on account A" is trivially answerable, and
-  this MIP says so (Security Considerations).
+where `self` is the account's contract address (32 bytes) and the key
+elements are the wire forms of section 3.4. The consequences are GR-3:
+one tuple has at most one live record, every record of a key at an
+origin is enumerable in at most 256 lookups, and any mismatch of key,
+origin, slot, arm, or envelope fails at the membership assert. No secret
+lives in the identity; `grant_id` hides in the entropy of a
+per-connection key, and for a publicly known key the test "is key K
+connected to origin X on account A" is trivially answerable (S27).
 
 #### 4.4 Origin normalisation and `origin_hash`
 
@@ -526,48 +469,60 @@ computed off-chain, where `client_id` is normalised exactly:
 
 - browser clients: the lowercase ASCII RFC 6454 serialisation of the
   origin (`https://bank.example`): scheme and host lowercase, default
-  port omitted, non-default port kept, no path, no trailing slash, IDN
-  hosts in punycode;
-- non-browser clients: `rdns:<reverse-dns>`, `mais:<id>`, or
-  `self:<label>`, lowercase.
+  port omitted, non-default port kept, no path, no trailing slash,
+  internationalised domain names in punycode;
+- non-browser clients: one of
+  - `rdns:<reverse-dns>`, a dot-separated sequence of LDH labels
+    (letters, digits, and hyphen), lowercase, at most 253 bytes;
+  - `mais:<id>`, the agent identifier of the Midnight Agent Identity
+    Standard proposed under MPS-0015, lowercase, at most 128 bytes,
+    drawn from the unreserved URI characters of RFC 3986 section 2.3;
+  - `self:<label>`, at most 64 bytes of lowercase ASCII letters, digits,
+    hyphen, and underscore, chosen by the owner.
 
-`origin_hash` is a private argument of every grant twin and of nothing
-else; it never appears in ledger state; it is derived from public
-information and is not a secret. `slot`, `scope_salt`, and `spent_prev`
-are likewise private arguments.
+A `client_id` matching none of these productions, or carrying any other
+byte, MUST be rejected with `invalid_request`. No Unicode normalisation
+applies, because no non-ASCII byte is admitted. `origin_hash` is a
+private argument of every grant twin and of nothing else, never appears
+in ledger state, and is derived from public information. `slot`,
+`scope_salt`, `rp_id_hash`, and `spent_prev` are likewise private
+arguments.
 
 #### 4.5 Commitments and the scope digest
 
-| Derivation | Preimage (in order) | Tag width |
-|---|---|---|
-| `object_commit` | `pad(32, "midnight:account:grant:obj:v1") \|\| scope_salt \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value)` | 32 |
-| `spent_commit` | `pad(32, "midnight:account:grant:spent:v1") \|\| scope_salt \|\| u128(spent)` | 32 |
-| `scope_digest` | `pad(32, "midnight:account:grant:scope:v1") \|\| flag(op_withdraw_unshielded) \|\| flag(op_withdraw_shielded) \|\| flag(op_withdraw_shielded_to_contract) \|\| flag(read) \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value) \|\| u128(per_call_cap) \|\| u128(cap) \|\| u64(expires_at) \|\| rp_id_hash \|\| read_pk_hash \|\| u64(window_len) \|\| u128(window_cap) \|\| scope_salt` | 32 |
+| Derivation | Preimage (in order) |
+|---|---|
+| `object_commit` | `pad(32, "midnight:account:grant:obj:v1") \|\| scope_salt \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value)` |
+| `spent_commit` | `pad(32, "midnight:account:grant:spent:v1") \|\| scope_salt \|\| u128(spent)` |
+| `rp_commit` | `pad(32, "midnight:account:grant:rp:v1") \|\| scope_salt \|\| rp_id_hash` |
+| `scope_digest` | `pad(32, "midnight:account:grant:scope:v1") \|\| scope_salt \|\| flag(op_withdraw_unshielded) \|\| flag(op_withdraw_shielded) \|\| flag(op_withdraw_shielded_to_contract) \|\| flag(read) \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value) \|\| u128(per_call_cap) \|\| u128(cap) \|\| u64(expires_at) \|\| rp_id_hash \|\| read_pk_hash \|\| u64(window_len) \|\| u128(window_cap)` |
 
-`flag(b)` is the single byte `0x01` for true and `0x00` for false, so
-the recipe does not depend on hashing a `Boolean` in-circuit
-`[CIRCUIT]` (inside the pure circuit the flags enter as `Uint<8>` values
-through a select if `Boolean` tuple elements are not supported).
-`scope_digest` is the single element through which the device challenge
-of `issue_grant` binds the whole plaintext scope (AUTH-3 by collision
-resistance), keeping that challenge within the evidenced tuple arity.
-The `scope` tag family is `[RULING]` (added by this document; the
-derivation is named by the design record without a tag). `[CIRCUIT]`:
-the sixteen-element `scope_digest` tuple exceeds the largest evidenced
-arity of ten; the fallback is a two-stage hash, in which case this
-recipe is revised before Proposed.
+The hiding of all three commitments rests on `scope_salt` meeting
+section 4.2 and staying with the owner and the grantee; a constant or
+reused salt makes `object_commit` dictionary-testable over the public
+list of colors, turns `spent_commit` into a lookup table publishing
+every released amount, and equates grants. Salt reuse is a negative
+conformance item (Testing item 2). `scope_digest` is the single element
+through which the `issue_grant` device challenge binds the whole
+plaintext scope (AUTH-3 by collision resistance); flags enter as single
+bytes. The `scope` tag family is new here and its registration is an
+acceptance criterion. Its seventeen elements exceed the largest
+evidenced tuple arity of ten; if a two-stage hash is needed, the revised
+recipe takes a new trailing tag version before Proposed.
 
 ### 5. Scope semantics
 
-#### 5.1 Axes
+#### 5.1 Axes and issue rules
 
 A grant realises three axes: the **operation** axis as three Booleans
 and a declarative `read`; the **object** axis as one token color and an
 optional recipient pin, committed; the **quantitative** axis as
 `per_call_cap`, `cap`, `max_coin_value`, and `expires_at`. Rate windows
-are reserved in the schema and not enforced in v1.
+are reserved in the schema and not enforced.
 
-Rules asserted at issue:
+Rules asserted at issue, in this order; the `expires_at` checks that
+fall on the client and the authoriser rather than on the circuit are
+stated below:
 
 1. at least one operation flag or `read` MUST be set (no "empty means
    all");
@@ -576,176 +531,169 @@ Rules asserted at issue:
 3. `per_call_cap <= cap`;
 4. any spend flag requires `cap > 0` and `max_coin_value >= per_call_cap`;
 5. `read` requires a non-zero `read_pk_hash`;
-6. `window_len == 0` and `window_cap == 0`.
+6. `window_len == 0` and `window_cap == 0`;
+7. a record with no operation flag set MUST carry an all-zero `color`,
+   `recipient_kind = 0`, an all-zero `recipient`, and `max_coin_value`,
+   `per_call_cap`, and `cap` all zero, so that `object_commit` over a
+   read-only grant is determined by `scope_salt` alone.
 
-`max_coin_value` exists because the value at risk from a shielded grant
-is the coin the grantee selects, not the cap: a grantee capped at `C`
-may present a coin of value `V` much greater than `C`, send `C`, and
-never record the change, orphaning `V - C`. The field makes the value at
-risk a number the consent screen displays and the approver narrows.
-Clients SHOULD recommend `max_coin_value == cap` where the owner can
+`max_coin_value` bounds the value at risk from a shielded grant, which
+is the coin the grantee selects and could leave without change (R7);
+clients SHOULD recommend `max_coin_value == cap` where the owner can
 pre-split coins.
 
-`expires_at` is expressed in the unit of `kernel.blockTimeLessThan` on
-the target ledger, with `0` meaning never, stated explicitly (the UCAN
-`exp: null` convention); a non-expiring grant is a declaration, never an
-omission. `[CIRCUIT]`: the corpus evidences that the comparison compiles
-and executes, not the node's unit; a millisecond clock would make every
-second-denominated grant born expired. The unit is pinned on a ledger-9
-network before this MIP leaves Draft and recorded in the grant scheme's
-registry entry; clients MUST sanity-check a candidate `expires_at`
-against a freshly read block time before signing.
-
-There is no `network_id` cell. A contract address is derived from the
-deploy transaction's content, so two independent deployments already
-have distinct addresses, and `kernel.self()` is bound in every grant
-challenge and inside `grant_id`. Cross-network separation therefore
-rests on `kernel.self()` plus a client obligation never to reuse deploy
-transaction content across networks; a state-preserving fork is not
-defeated by any cell, and expiry and revocation on the surviving chain
-are the defence. The wire `chain` member remains normative for the
-request, where it tells the authoriser which chain to serve.
+`expires_at` is in the unit of `kernel.blockTimeLessThan` on the target
+ledger, with `0` meaning never, stated explicitly. Neither the node's
+unit nor the never-expires arm is yet evidenced on node; both are pinned
+on a ledger-9 network before this MIP leaves Draft and recorded in the
+registry entry. Clients MUST sanity-check a non-zero `expires_at`
+against a freshly read block time before signing, and an authoriser
+SHOULD refuse a value already in the past. There is no `network_id`
+cell (R15); the wire `chain` member remains normative for the request.
 
 #### 5.2 Feature strings and the mapping table
 
 Scope travels on the wire as feature strings named after the circuit
-exports. Each maps to exactly one Boolean; the grant string is canonical
-on the wire and the Boolean is canonical in the record:
+exports. Each maps to exactly one Boolean; the string is canonical on
+the wire and the Boolean in the record:
 
-| Feature string | Record field | Gated twin | Implies | C23 / Open Wallet Standard scope string | Notes |
-|---|---|---|---|---|---|
-| `midnight:account:withdraw_unshielded` | `op_withdraw_unshielded` | `withdraw_unshielded_with_grant_<arm>` | | `midnight:unshielded` | |
-| `midnight:account:withdraw_shielded` | `op_withdraw_shielded` | `withdraw_shielded_with_grant_<arm>` | `read` | `midnight:shielded` | |
-| `midnight:account:withdraw_shielded_to_contract` | `op_withdraw_shielded_to_contract` | `withdraw_shielded_to_contract_with_grant_<arm>` | `read` | `midnight:shielded` | |
-| `midnight:account:read` | `read` | none (section 8) | | `midnight:shielded` (read side) | unshielded balances are public and need no capability |
-| `midnight:account:signin` | none | none | | none | reserved for the sign-in MIP; v1 authorisers MUST refuse it with `invalid_scope` |
+| Feature string | Record field | Gated twin | Implies | Connection scope string (Open Wallet Standard) |
+|---|---|---|---|---|
+| `midnight:account:withdraw_unshielded` | `op_withdraw_unshielded` | `withdraw_unshielded_with_grant_<arm>` | | `midnight:unshielded` |
+| `midnight:account:withdraw_shielded` | `op_withdraw_shielded` | `withdraw_shielded_with_grant_<arm>` | `read` | `midnight:shielded` |
+| `midnight:account:withdraw_shielded_to_contract` | `op_withdraw_shielded_to_contract` | `withdraw_shielded_to_contract_with_grant_<arm>` | `read` | `midnight:shielded` |
+| `midnight:account:read` | `read` | none (section 8); unshielded balances are public and need no capability | | `midnight:shielded` (read side) |
+| `midnight:account:signin` | none | none; reserved for the sign-in MIP, refused with `invalid_scope` | | none |
 
-The mapping is many-to-one: a coarse connection scope string covers
-several grant strings, so a peer translating in the other direction
-MUST ask for the grant strings it needs rather than infer them. The
-strings travel in a dedicated `midnight:account:grants` member of a
-CAIP-25 session (or in CAIP-25 `scopedProperties`) alongside their
-bounds, never in the CAIP-217 `methods` member, which is reserved for
-JSON-RPC method names; a CAIP-25 peer MUST NOT treat a grant feature
-string as invokable (section 11.1).
-
-A request whose bounds are inconsistent with its strings is rejected as
-the error table of section 9.6 says: a spend string without `color`,
-`cap`, `max_coin_value`, and `expires_at`; `per_call_cap > cap`;
-`max_coin_value < per_call_cap`; a recipient kind that no requested
-operation can honour (`invalid_scope`); a withdraw string from an
-envelope-1 grantee (`unsupported_scheme`).
+The mapping is many-to-one, so a peer translating from a coarse
+connection scope MUST ask for the grant strings it needs. The strings
+travel in the CAIP-25 `scopedProperties` member (section 11.1), never in
+`methods`, and a CAIP-25 peer MUST NOT treat one as invokable. A spend
+string without `color`, `cap`, `max_coin_value`, and `expires_at`,
+`per_call_cap > cap`, `max_coin_value < per_call_cap`, or a recipient
+kind no requested operation can honour is `invalid_scope`; a withdraw
+string from an envelope-1 grantee is `unsupported_scheme`.
 
 ### 6. The grant seam
 
 #### 6.1 Circuit list
 
-Per grantee arm `s` in `{jubjub, k256}` today and `{p256}` upon `[DEP]`,
-a conforming contract exports exactly three grant twins over the
-unchanged custody chips:
+Per grantee arm `s` in `{jubjub, k256}` today and `{p256}` once the
+secp256r1 surface ships, a conforming contract exports exactly three
+grant twins over the unchanged custody chips, plus the pure circuits
+they and their callers need:
 
 - `withdraw_unshielded_with_grant_<s>(color: Bytes<32>, amount: Uint<128>, recipient: UserAddress, ...grant auth): []`
-- `withdraw_shielded_with_grant_<s>(recipient: ZswapCoinPublicKey, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, ...grant auth): Maybe<ShieldedCoinInfo>`
-- `withdraw_shielded_to_contract_with_grant_<s>(recipient: ContractAddress, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, ...grant auth): [ShieldedCoinInfo, Maybe<ShieldedCoinInfo>]`
-- exported pure `challenge_<operation>_with_grant_<s>` for each of the three;
-- exported pure `derive_grant_id_with_<s>`.
+- `withdraw_shielded_with_grant_<s>(recipient: ZswapCoinPublicKey, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, enc_pk: Bytes<32>, ...grant auth): Maybe<ShieldedCoinInfo>`
+- `withdraw_shielded_to_contract_with_grant_<s>(recipient: ContractAddress, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, enc_pk: Bytes<32>, ...grant auth): [ShieldedCoinInfo, Maybe<ShieldedCoinInfo>]`
+- exported pure `challenge_<operation>_with_grant_<s>` for each of the
+  three, and `derive_grant_id_with_<s>`.
 
-`...grant auth` trails the operation arguments, in this order:
+`enc_pk` is the value of the `enc_key` cell the grantee encrypted
+`change_entry` to (section 6.2 step 5). `...grant auth` trails the
+operation arguments, in this order:
 
 | Arm | Grant authorising material |
 |---|---|
 | `k256` | `pk: Secp256k1Point, envelope: Uint<8>, origin_hash: Bytes<32>, slot: Uint<8>, scope_salt: Bytes<32>, recipient_kind: Uint<8>, pinned_recipient: Bytes<32>, max_coin_value: Uint<128>, spent_prev: Uint<128>, sig: Secp256k1EcdsaSignature` |
 | `jubjub` | `pk: JubjubPoint, origin_hash: Bytes<32>, slot: Uint<8>, scope_salt: Bytes<32>, recipient_kind: Uint<8>, pinned_recipient: Bytes<32>, max_coin_value: Uint<128>, spent_prev: Uint<128>, sig_r: JubjubPoint, sig_s: Field, grind_nonce: Uint<64>` |
-| `p256` | as `k256` without `envelope` and with the WebAuthn witness set of the schemes MIP section 3.3 in place of `sig` |
+| `p256` | as `k256` without `envelope`, with `rp_id_hash: Bytes<32>` after `max_coin_value`, and with the WebAuthn witness set (`client_data_json` bytes, `authenticator_data: Bytes<37>`, `sig`) in place of `sig` |
 
 There is no nonce argument: the record's `nonce` is read in-circuit.
-The authorising material is witness data and MUST NOT be disclosed by
-the circuit.
+The authorising material is witness data and MUST NOT be disclosed.
 
 Per device arm `a` in `{jubjub, k256}`, device-gated through the
 unchanged device seam:
 
-- `issue_grant_with_<a>(grant_id: Bytes<32>, <plaintext scope fields of section 4.2>, scope_salt: Bytes<32>, ...device auth): []`
+- `issue_grant_with_<a>(grant_id: Bytes<32>, <plaintext scope of section 4.2>, ...device auth): []`
 - `revoke_grant_with_<a>(grant_id: Bytes<32>, ...device auth): []`
 - `revoke_all_grants_with_<a>(...device auth): []`
-- exported pure `derive_grant_scope_digest`, `derive_grant_object_commit`, `derive_grant_spent_commit`;
-- exported pure `challenge_issue_grant_with_<a>`, `challenge_revoke_grant_with_<a>`, `challenge_revoke_all_grants_with_<a>` in the existing device tag family (`midnight:account:auth:v1:issue_grant`, `midnight:account:auth:k1:v1:issue_grant`, and so on), where the `issue_grant` challenge's argument list is `[grant_id, scope_digest]`.
+- exported pure `derive_grant_scope_digest`, `derive_grant_object_commit`,
+  `derive_grant_spent_commit`, `derive_grant_rp_commit`, and
+  `challenge_<lifecycle circuit>_with_<a>` in the existing device tag
+  family (`midnight:account:auth:v1:issue_grant`,
+  `midnight:account:auth:k1:v1:issue_grant`, and so on); the
+  `issue_grant` challenge's argument list is `[grant_id, scope_digest]`.
 
-No grant twin exists for `rotate_enc_key`, `add_device`, `remove_device`,
-`append_inbox`, `issue_grant`, `revoke_grant`, or `revoke_all_grants`. A
-`spec_version = 2` account therefore carries 30 non-pure circuits (18
-existing, 6 grant twins, 6 lifecycle circuits), 33 with the p256 twins.
+No grant twin exists for `rotate_enc_key`, `add_device`,
+`remove_device`, `append_inbox`, or any lifecycle circuit. A
+`spec_version = 2` account carries 30 non-pure circuits (18 existing, 6
+grant twins, 6 lifecycle circuits), 33 with the p256 twins.
 
 #### 6.2 Seam chip, ordered steps
 
 The grant seam is written once per grantee arm as three chips
-(`authenticate_grant`, `check_spend_scope`, `settle_grant`) so the three
-twins share code. Every predicate is evaluated over the value the
-custody chip will consume, never over an argument that merely selects
-it: shielded twins invoke `held_coin(color)` before step 5 and test the
-returned coin's `color` and `value`; the unshielded twin tests its
-`color` argument, which is what its chip consumes. A grant twin
-performs, in order:
+(`authenticate_grant`, `check_spend_scope`, `settle_grant`) shared by the
+three twins. Every predicate is evaluated over the value the custody chip
+will consume, never over an argument that merely selects it: shielded
+twins invoke `held_coin(color)` before step 5 and test the returned
+coin's `color` and `value`; the unshielded twin tests its `color`
+argument, which is what its chip consumes. A grant twin performs, in
+order:
 
-1. **Key guard.** Per the table of section 3.3: `k256` rejects the point
-   at infinity in either encoding; `jubjub` asserts `[8]pk != O`; `p256`
-   per the schemes MIP. On-curve membership `[CIRCUIT]`.
+1. **Key guard.** Per section 3.3: `k256` rejects the point at infinity
+   in either encoding; `jubjub` asserts `[8]pk != O`; `p256` rejects the
+   identity and asserts the coordinates below `p` and on the curve.
 2. **Identity.** `id = derive_grant_id_with_<s>(kernel.self(), pk, [envelope,] origin_hash, slot)`,
    disclosed; assert `grants.member(id)`; `g = grants.lookup(id)`. A
-   lookup MUST be dominated by a membership assert and never combined
-   with it in one boolean expression, because both operands of a
-   conjunction are evaluated and a lookup of a non-member has no defined
-   value.
-3. **Liveness.** Assert `g.active`; assert `g.epoch == device_epoch`;
-   assert `g.gen == grant_generation`; assert
+   lookup MUST be dominated by a membership assert, never combined with
+   it in one boolean expression, since both operands are evaluated.
+3. **Liveness.** Assert `g.active`, `g.epoch == device_epoch`,
+   `g.gen == grant_generation`, and
    `g.scope.expires_at == 0 || kernel.blockTimeLessThan(g.scope.expires_at)`
    (a select, both sides evaluated; the comparison argument reaches the
-   public transcript, which is harmless because the record is public).
-4. **Operation.** Assert the twin's own flag (`g.scope.op_<this twin>`),
-   a per-twin constant selection over the three Booleans.
+   public transcript, harmless because the record is public).
+4. **Operation.** Assert the twin's own flag.
 5. **Object and bounds.** With `obj_color = coin.color` on the shielded
    twins and `obj_color = color` on the unshielded twin:
    - assert `derive_grant_object_commit(scope_salt, obj_color, recipient_kind, pinned_recipient, max_coin_value) == g.scope.object_commit`;
-   - shielded twins: assert `coin.value <= max_coin_value`;
+   - `p256` only: assert `derive_grant_rp_commit(scope_salt, rp_id_hash) == g.scope.rp_commit`;
+   - shielded twins: assert `coin.value <= max_coin_value` and
+     `enc_pk == enc_key`, so a rotation between the grantee's signing
+     and inclusion aborts the call instead of orphaning change;
    - assert `amount <= g.scope.per_call_cap`;
    - assert `derive_grant_spent_commit(scope_salt, spent_prev) == g.spent_commit`;
    - compute `wide = spent_prev + amount` in the widened type; assert
      `wide <= g.scope.cap`; then narrow to `new_spent: Uint<128>` (the
-     narrowing cannot fail once the cap assert passed, since `cap` is a
-     `Uint<128>`; the order is normative and the two failures are
-     distinct);
-   - assert `recipient_kind == 0 || (recipient_kind == <this twin's kind> && pinned_recipient == recipient bytes)`.
+     order is normative; the two failures are distinct);
+   - assert `recipient_kind == 0 || (recipient_kind == <this twin's kind> && pinned_recipient == recipient.bytes)`.
 6. **Challenge and verification.** `h = challenge_<operation>_with_grant_<s>(...)`
-   over the preimage of section 6.3. `k256`: `secp256k1EcdsaVerify(envelope_digest(envelope, h), sig, pk)`,
-   both `s` forms accepted. `jubjub`: `ecMulGenerator(sig_s) == ecAdd(sig_r, ecMul(pk, h as Field))`
-   with the grinding rule of the authorisation MIP section 5.2. `p256`:
-   the WebAuthn envelope of the schemes MIP section 3.3 with
-   `rpIdHash == g.scope.rp_id_hash`, the user-verified flag set, and an
-   `authenticatorData` of exactly 37 bytes (ED flag clear; the
-   fixed-width envelope cannot verify an extension-bearing assertion).
+   over the preimage of section 6.3. `k256`:
+   `secp256k1EcdsaVerify(envelope_digest(envelope, h), sig, pk)`, both
+   `s` forms accepted. `jubjub`:
+   `ecMulGenerator(sig_s) == ecAdd(sig_r, ecMul(pk, h as Field))` with
+   the grinding rule of the authorisation MIP section 5.2. `p256`, the
+   WebAuthn envelope: `client_data_json` begins with the exact 36-byte
+   prefix `{"type":"webauthn.get","challenge":"` followed by the 43-byte
+   unpadded base64url encoding of `h` and a closing quote;
+   `authenticator_data` is exactly 37 bytes (ED flag clear, so an
+   extension-bearing assertion cannot verify) with
+   `authenticator_data[0..32] == rp_id_hash` and the user-present and
+   user-verified bits set;
+   `z = int_be(H(authenticator_data || H(client_data_json))) mod n`;
+   ECDSA verification of `(r, s)` against `pk` with `r != 0`, `s != 0`,
+   the recomputed point non-identity, and `R.x mod n == r`, both `s`
+   forms accepted; `signCount` carries no constraint.
 7. **Write-back.** `grants.insert(id, g')` where `g'` is `g` with
    `nonce + 1` and `spent_commit = derive_grant_spent_commit(scope_salt, new_spent)`,
-   spelled out as a full struct literal; then `round += 1`. `auth_nonce`,
-   `devices`, `device_count`, and `enc_key` are neither read nor written.
+   spelled out as a full struct literal, each field disclosed; then
+   `round += 1`. `auth_nonce`, `devices`, `device_count`, and `enc_key`
+   are never written by a grant twin; `enc_key` is read only for step 5.
 
-The custody chip (`do_withdraw_unshielded`, `do_withdraw_shielded`,
-`do_withdraw_shielded_to_contract`) runs unchanged after step 7, as it
-does after the device seam. The shielded twins then, under a disclosed
-statement-level branch on whether the send produced change, append
-`change_entry` through the inbox chip in the same circuit, so the change
-entry is written in the same transaction as the spend, and return the
-chip's result. The signature is not what enforces the object scope
-under a grant, since the grantee signs its own witness choice; that is
-why step 5 tests `coin.color` and `coin.value` directly.
+The custody chip runs unchanged after step 7. The shielded twins then,
+under a disclosed statement-level branch on whether the send produced
+change, append `change_entry` through the inbox chip in the same circuit
+and return the chip's result.
 
-The commitment openings (`scope_salt`, `recipient_kind`,
-`pinned_recipient`, `max_coin_value`, `spent_prev`) are private
-arguments verified by equality against the record and bound
-transitively through `grant_id`, which determines the record, which
-determines the commitments; a substituted opening aborts at the
-commitment assert rather than authorising anything. `[CRYPTO]`: confirm
-that the transitive binding satisfies AUTH-3; the fallback binds the
-openings directly at the cost of tuple arity.
+This discharges the custody MIP's S5 (a seam MUST NOT be satisfiable by
+circuit-unconstrained data): `origin_hash`, `slot`, `envelope`, and `pk`
+are pinned by the `grant_id` membership assert; `scope_salt`,
+`recipient_kind`, `pinned_recipient`, and `max_coin_value` by
+`object_commit`; `rp_id_hash` by `rp_commit`; `spent_prev` by
+`spent_commit`; `enc_pk` by `enc_key`. The openings are bound
+transitively through `grant_id`, which determines the record and its
+commitments; that this satisfies AUTH-3 is a cryptographer-review item,
+and the fallback binds the openings directly at the cost of arity.
 
 #### 6.3 Challenge preimages
 
@@ -764,54 +712,60 @@ the 64-byte width is a normative budget on future operation names.
 | ECDSA arms (`k1`, `r1`) | `DST \|\| self \|\| x \|\| y \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce)` |
 | JubJub arm (`v1`) | `DST \|\| self \|\| sig_r \|\| pk \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce) \|\| u64(grind_nonce)` |
 
-`...args` are the operation arguments that vary per call, in
-declaration order with their Compact types: `color`, `amount`,
-`recipient`, and for the shielded twins `change_entry`.
-`...witness_values` is the qualified coin returned by `held_coin` on
-the shielded twins and empty on the unshielded twin (AUTH-10). `g.nonce`
-and `g.issued_at` are read from the record inside the circuit, exactly
-as the device arms read `auth_nonce`. ECDSA preimages exclude signature
-material (SIG-3) and need no grinding; the JubJub arm grinds
-`grind_nonce` until the little-endian value of `h` is below the subgroup
-order, as the authorisation MIP section 5.2. `k1` verifies over
-`envelope_digest(envelope, h)`; `r1` over the WebAuthn message whose
-`clientDataJSON.challenge` is `h`. `[CIRCUIT]`: the shielded ECDSA
-preimage has twelve elements and the JubJub one fourteen against a
-largest evidenced arity of ten; the fallback pre-hashes the operation
-arguments into one `args_digest` element.
+`...args` are the operation arguments in declaration order at their
+Compact widths: the unshielded twin's `color`, `u128(amount)`,
+`recipient.bytes`; the shielded twins' `recipient.bytes`, `color`,
+`u128(amount)`, `change_entry` (192 bytes), `enc_pk`.
+`...witness_values` is empty on the unshielded twin and, on the shielded
+twins, the `QualifiedShieldedCoinInfo` returned by `held_coin`,
+flattened in declaration order: `nonce` (32 bytes), `color` (32 bytes),
+`u128(value)`, `u64(mt_index)` (AUTH-10). `g.nonce` and `g.issued_at`
+are read from the record inside the circuit. ECDSA preimages exclude
+signature material (SIG-3); the JubJub arm grinds `grind_nonce` until
+the little-endian value of `h` is below the subgroup order (the
+authorisation MIP section 5.2). The shielded ECDSA preimage has thirteen
+elements and the JubJub one fourteen against an evidenced arity of ten;
+if the operation arguments must be pre-hashed into one `args_digest`
+element, the revised recipe takes a new trailing tag version before
+Proposed.
 
-Binding `grant_id` makes one signature unusable across two grants of
-the same key; binding `issued_at` makes one signature unusable across
-two issuances of the same id (GR-6); per-operation tags keep SIG-1;
-malleated ECDSA twins authorise one execution because `nonce` advances
-(SIG-4).
+#### 6.4 Signing (grantee side)
 
-#### 6.4 Grantee private state and coin selection
+A grantee needs only curve arithmetic and SHA-256. In order:
 
-A grantee spending shielded value maintains a wallet-local coin store
-per the custody MIP section 6.5 (it holds the viewing secret, since
-shielded scopes imply `read`) and reconstructs coin descriptions and
-`mt_index` values from the inbox and chain data before it can prove.
-Owner and grantee, or two grantees, select coins independently with no
-coordination protocol. Clients SHOULD apply a deterministic selection
+1. read `grants[grant_id]`, `device_epoch`, `grant_generation`, and
+   `enc_key` from chain state; take `nonce` and `issued_at` from the
+   record and confirm it is live;
+2. on the shielded twins, resolve the qualified coin the call will
+   consume from the local coin store and precompute `change_entry`
+   encrypted to the `enc_key` just read, which becomes `enc_pk`;
+3. build the preimage of section 6.3 with those values and the openings
+   of section 6.2 step 5;
+4. on the `v1` arm, grind `grind_nonce` until the little-endian value of
+   `h` is below the subgroup order;
+5. sign in the arm's form of section 6.2 step 6.
+
+A grantee MUST re-read `nonce` and `enc_key` and re-sign if its
+transaction is not included, and MUST persist `scope_salt`, the
+returned scope, and its running `spent` alongside the key.
+
+#### 6.5 Grantee private state and coin selection
+
+A grantee spending shielded value maintains a wallet-local coin store per
+the custody MIP section 6.5 (it holds the viewing secret, since shielded
+scopes imply `read`) and reconstructs coin descriptions and `mt_index`
+values from the inbox and chain data before it can prove. Owner and
+grantee select coins independently; clients SHOULD apply a deterministic
 rule (the smallest coin of the color that covers `amount`, ties broken
-by `mt_index`). The failure modes are: a proving failure when both
-select the same coin (no transaction exists, INV-5); a fee-wasting race
-when both submit; and the zombie-state class the atomic change backfill
-exists to prevent.
+by `mt_index`). The failure modes are a proving failure when both select
+the same coin (no transaction exists, INV-5) and a fee-wasting race when
+both submit; a mis-spend is not one of them. The change description is
+precomputable before proving because the standard library evolves the
+output coin's nonce deterministically from the input coin's (not yet
+evidenced; the fallback is a bounded standalone append twin with an
+`append_budget` in the scope).
 
-The change description is precomputable before proving because the
-standard library evolves the output coin's nonce deterministically from
-the input coin's `[CIRCUIT]`; the grantee encrypts it to `enc_key` and
-passes it as `change_entry`, bound in the challenge. A garbage entry
-remains possible and is bounded by `max_coin_value` and detected by the
-owner's discovery walk, which recomputes each candidate coin's
-commitment against chain data (custody MIP section 6.5). The fallback,
-if the description proves not precomputable, is a bounded standalone
-append twin (`append_budget` in the scope, `appends` in the record)
-`[RULING]`.
-
-#### 6.5 Disclosure
+#### 6.6 Disclosure
 
 Disclosed per grant call: `grant_id` (lookup and write-back), the
 rewritten `nonce` and `spent_commit`, the `expires_at` argument of the
@@ -819,53 +773,43 @@ kernel comparison, and what the custody chip already discloses
 (`color`, `amount`, and `recipient` on the unshielded twin, whose
 balances are public; the contract address of a contract-recipient
 output; the change-entry ciphertext on a shielded twin). Not disclosed:
-`pk`, `origin_hash`, `slot`, `scope_salt`, the openings, `spent_prev`,
-the signature, the qualified coin, and on shielded twins `color`,
-`amount`, and a `ZswapCoinPublicKey` recipient, which feed the send
-path's commitments exactly as under a device twin.
+`pk`, `origin_hash`, `slot`, `scope_salt`, `rp_id_hash`, the openings,
+`spent_prev`, `enc_pk`, the signature, the qualified coin, and on
+shielded twins `color`, `amount`, and a `ZswapCoinPublicKey` recipient,
+which feed the send path's commitments exactly as under a device twin.
 
 The record publishes the operation flags, `read`, `per_call_cap`, `cap`,
-`expires_at`, `rp_id_hash`, `read_pk_hash`, `nonce` (the call count),
-and `active`; it commits to `color`, the recipient pin,
-`max_coin_value`, and `spent`. `grant_id` is a stable per-grant
-pseudonym disclosed on every call: it hides in the entropy of a
-per-connection key, is unequal across accounts because `kernel.self()`
-is in the preimage, and is confined to grant-authorised calls (device
-calls never touch `grants`); for a publicly known key it is trivially
-computable. Its relation to AUTH-9 is settled by the companion erratum
-of section 13 `[CRYPTO]`.
+`expires_at`, `read_pk_hash`, `nonce` (the call count), and `active`;
+it commits to `color`, the recipient pin, `max_coin_value`, the dApp
+host, and `spent`. `grant_id` is a stable per-grant pseudonym disclosed
+on every call, unequal across accounts because `kernel.self()` is in the
+preimage; its relation to AUTH-9 is settled by the companion erratum of
+section 12.
 
-#### 6.6 Cost
+#### 6.7 Cost and deploy budget
 
-Over the corresponding device twin, per arm: the identity hash replaces
-the two device-entry hashes (the `k1` identity preimage is 162 bytes
-against the `k1` device entry's 140; the `v1` identity preimage 129
-against the `v1` device entry's 108), so the net change in hashing is
-minus one hash plus the two commitment openings and one re-commit
-(three hashes over three to six elements, about two SHA-256
-compressions each), one map lookup and one insert of a 245-byte struct,
-one `Uint<128>` addition with the widened comparison, about a dozen
-comparisons, one kernel block-time comparison, and on shielded twins
-one inbox insert of 192 bytes under a disclosed branch. Anchors: the
-k256 device seam at k=15, 31,046 rows (envelope `0`) and k=16, 32,900
-rows (envelope `1`), about 0.5 to 0.8 s; the P-256 WebAuthn envelope at
-k=16, 36,466 rows, 1.1 to 1.2 s; JubJub well below (49 MB against 117 MB
-prover keys). Expected: k256 grant twins at k=16 on either envelope,
-p256 at k=16, jubjub at its device twin's k or one above; all inside the
-browser-provable envelope. `[CIRCUIT]`: all figures to be measured.
+Over the corresponding device twin a grant twin replaces two
+device-entry hashes with one identity hash and three commitment hashes,
+and adds one map lookup and insert, one widened comparison, one kernel
+comparison, and on shielded twins one inbox insert. Anchors, all to be
+re-measured on the grant twins (E1):
 
-Deploy budget, stated as a total: the reference implementation already
-exports 18 non-pure circuits and prices at 53,076 bytes written against
-a 50,000-byte per-block budget and 2.011 s of compute against 2.000 s,
-so it deploys in waves. A `spec_version = 2` account carries 30 non-pure
-circuits (33 with p256) at about 2,950 bytes of verifier key each, about
-88 KB; roughly three waves. Waves after the first are hand-built
-maintenance-update transactions. The grant circuits MUST be part of the
-`spec_version = 2` deploy wave plan, and maintenance-authority
-retirement MUST follow the last grant wave: a retired account can never
-receive a future arm's circuits, so a `spec_version = 2` account
-deployed without the grant circuits and with the authority retired can
-never gain grants and must migrate. Pure circuits add no keys.
+| Arm | Measured anchor | Expected grant twin |
+|---|---|---|
+| `k256` | device seam k=15, 31,046 rows (envelope `0`); k=16, 32,900 rows (envelope `1`); 0.5 to 0.8 s | k=16 on either envelope |
+| `p256` | WebAuthn envelope k=16, 36,466 rows, 1.1 to 1.2 s | k=16 |
+| `jubjub` | well below (49 MB against 117 MB prover keys) | the device twin's k, or one above |
+
+The reference implementation already exports 18 non-pure circuits and
+exceeds the per-block byte and compute budgets, so it deploys in waves;
+a `spec_version = 2` account carries 30 (33 with p256) at about 2,950
+bytes of verifier key each, at least two waves, the later ones hand-built
+maintenance updates. The grant circuits MUST be part of the
+`spec_version = 2` deploy wave plan, and maintenance-authority retirement
+MUST follow the last grant wave: a retired account can never receive a
+future arm's circuits, so an account deployed without the grant circuits
+and then retired can never gain grants and must migrate. Pure circuits
+add no keys.
 
 ### 7. Lifecycle
 
@@ -873,153 +817,149 @@ never gain grants and must migrate. Pure circuits add no keys.
 
 All three lifecycle circuits are device-gated through the unchanged
 device seam, which advances `auth_nonce` and `round` before the body
-runs. A ledger `Map.lookup` MUST be dominated by a `member` branch or a
-preceding assert (section 6.2 step 2). `[CIRCUIT]`: the bodies below are
-pending compilation; "issue over an absent id" and "revoke an absent id"
-are conformance items.
+runs; every `Map.lookup` is dominated by a `member` branch (section 6.2
+step 2). The bodies are pending compilation.
 
-`issue_grant(grant_id, <plaintext scope>, scope_salt)`:
+`issue_grant(grant_id, <plaintext scope>)`:
 
 1. Disclose `grant_id` as `id`.
-2. If `grants.member(id)`: read the old record and assert that it is
-   not live, that is, `!old.active || old.epoch != device_epoch || old.gen != grant_generation`
+2. If `grants.member(id)`: read the old record and assert that it is not
+   live, that is,
+   `!old.active || old.epoch != device_epoch || old.gen != grant_generation`
    ("grant already active"). Issue over an absent id, a tombstone, or an
-   inert record succeeds.
-3. Assert the issue rules of section 5.1 in order: non-empty scope;
-   shielded implies `read`; `per_call_cap <= cap`; spend requires
-   `cap > 0` and `max_coin_value >= per_call_cap`; `read` requires a
-   non-zero `read_pk_hash`; window fields zero.
+   inert record succeeds; `issue_grant` does not evaluate expiry, so an
+   expired but unrevoked record is live for this test (section 7.2).
+3. Assert the issue rules of section 5.1 in the order listed there.
 4. Write the whole record: `epoch = device_epoch`,
    `gen = grant_generation`, `issued_at = auth_nonce` (already advanced
    by the device seam, so unique per issuance), `nonce = 0`,
    `spent_commit = derive_grant_spent_commit(scope_salt, 0)`, window
    fields zero, `active = true`, and the scope with
    `object_commit = derive_grant_object_commit(scope_salt, color, recipient_kind, recipient, max_coin_value)`
-   and the clear fields disclosed. `color`, `recipient`, and
-   `max_coin_value` are never disclosed; only their commitment is.
+   and `rp_commit = derive_grant_rp_commit(scope_salt, rp_id_hash)`, the
+   clear fields disclosed. `color`, `recipient`, `max_coin_value`, and
+   `rp_id_hash` are never disclosed; only their commitments are.
 
-`revoke_grant(grant_id)`:
+`revoke_grant(grant_id)`: disclose `grant_id`; assert `grants.member(id)`
+("unknown grant"); assert `active` ("grant not live"); rewrite the record
+unchanged except `active = false`.
 
-1. Disclose `grant_id`; assert `grants.member(id)` ("unknown grant").
-2. Read the record; assert `active` ("grant not live").
-3. Rewrite the record unchanged except `active = false`.
+`revoke_all_grants()`: `grant_generation += 1`; optionally clear the map
+for state relief (a reset primitive is not evidenced); the generation
+check carries safety.
 
-`revoke_all_grants()`:
+The reference contract uses no spread or update syntax, so a conforming
+implementation spells every struct literal out in full.
 
-1. `grant_generation += 1`.
-2. Optionally clear the map for state relief `[CIRCUIT]` (availability
-   of a reset primitive is not evidenced); the generation check carries
-   safety.
-
-Since the reference contract uses no spread or update syntax, a
-conforming implementation spells every struct literal out in full.
-
-#### 7.2 State machine
-
-```mermaid
-stateDiagram-v2
-    [*] --> Active: issue_grant (device)\nepoch = device_epoch, gen = grant_generation,\nissued_at = auth_nonce, nonce = 0, spent_commit = C(0)
-    Active --> Active: grant twin\nnonce += 1, spent_commit = C(spent + amount)
-    Active --> Revoked: revoke_grant (device)\nactive = false
-    Active --> Expired: block time reaches expires_at\n(lazy, no write)
-    Active --> Inert: device_epoch bump (recovery)\nor grant_generation bump (revoke_all_grants)
-    Revoked --> Active: issue_grant (device)\nnew issued_at, nonce = 0, spent_commit = C(0)
-    Expired --> Active: issue_grant (device)\nre-issue with a new expiry
-    Inert --> Active: issue_grant (device)\nunder the new epoch or generation
-    Revoked --> Inert: epoch or generation bump
-    Expired --> Inert: epoch or generation bump
-```
+#### 7.2 State transitions
 
 | From | Event | To | Written |
 |---|---|---|---|
 | absent, tombstone, or inert | `issue_grant` | active (epoch `e`, gen `g`, `issued_at` `i`) | whole record |
 | active | grant twin succeeds | active | `nonce + 1`, `spent_commit` |
-| active | `revoke_grant` | tombstone | `active = false` |
+| active or expired | `revoke_grant` | tombstone | `active = false` |
 | active | block time reaches `expires_at` | expired (lazy; record unchanged) | nothing |
 | any | recovery bumps `device_epoch` | inert by epoch | nothing (MAY clear the map) |
 | any | `revoke_all_grants` bumps `grant_generation` | inert by generation | `grant_generation` |
 | tombstone, expired, or inert | grant twin | abort, no state change | nothing |
 
-Rules: every transition into Active is device-gated and carries fresh
+Rules: every transition into active is device-gated and carries fresh
 consent over the whole scope; no in-place modification exists;
-modification is revoke then issue under fresh consent, composable in one
-transaction `[CIRCUIT]`; Revoked, Expired, and Inert all abort every
-grant twin with no state change; only `revoke_all_grants` and recovery
-are O(1) over the whole register; `remove_device` has no edge in this
-machine. Re-issue over a tombstone is permitted and yields a new
-incarnation with `nonce = 0`, a fresh `spent_commit` to zero, and a
-fresh `issued_at`; dApps SHOULD choose a fresh `slot` on re-issue where
-one is free. Tombstones are kept in v1 for enumerability and audit;
-pruning is a revision item `[RULING]`. Counters are `Uint<32>` or wider
-and owner-driven only. Grants belong to the account, not to the issuing
-device; no `issued_by` is recorded, since it would disclose a stable
-device identifier contrary to AUTH-9.
+modification, and renewal of an expired record, is `revoke_grant` then
+`issue_grant`, composable in one transaction (section 7.4), or
+`issue_grant` under a fresh `slot`; only `revoke_all_grants` and
+recovery are O(1) over the register; `remove_device` has no edge. Re-
+issue yields a new incarnation with `nonce = 0`, a fresh `spent_commit`,
+a fresh `scope_salt`, and a fresh `issued_at`; dApps SHOULD choose a
+fresh `slot` where one is free. Tombstones are kept for enumerability;
+pruning is a revision item. Counters are `Uint<32>` or wider. No
+`issued_by` is recorded, since it would disclose a stable device
+identifier contrary to AUTH-9.
 
 #### 7.3 Recovery and device removal
 
 The recovery seam of the authorisation MIP section 8 is unchanged in its
-obligation: it bumps `device_epoch`, and the in-circuit equality check
-of section 6.2 step 3 makes every grant inert. Clearing `grants` at
-recovery is state hygiene a recovery circuit MAY perform; safety does
-not depend on it.
+obligation: it bumps `device_epoch`, and the equality check of section
+6.2 step 3 makes every grant inert. Clearing `grants` at recovery is
+hygiene a recovery circuit MAY perform; safety does not depend on it.
 
-Single-device removal does not cascade to grants in the contract
-`[RULING]`. On removing a device for suspected compromise the owner's
-client MUST call `revoke_all_grants` in the same transaction or
-immediately after, because a briefly compromised device can have issued
-grants with `expires_at = 0`, maximum caps, and no recipient pin to keys
-it controls, and the grant seam checks only `active`, `epoch`, and
-`gen`. The alternative, `remove_device_with_<arm>` bumping
-`grant_generation` internally, is a circuit change with no schema change
-and is recorded in Rationale R19 with its cost.
+Single-device removal does not cascade to grants in the contract. On
+removing a device for suspected compromise the owner's client MUST call
+`revoke_all_grants` in the same transaction or immediately after,
+because a briefly compromised device can have issued unbounded grants to
+keys it controls (R19).
 
 #### 7.4 Composition in one transaction
 
 A grant call MAY be composed with other calls of the same or other
-contracts, including a device call of the same account or another
-account's call. Each grant call consumes exactly one `nonce` increment,
-so `N` composed calls under one grant need `N` consecutive counters and
-`N` signatures; the cumulative cap is enforced per call against the
-record as it stands at that call's execution, so a transaction cannot
-exceed `cap` in aggregate; the per-call cap is per circuit invocation,
-never per transaction; the recipient pin is evaluated per call and
-survives grafting; reordering composed calls invalidates the signatures.
+contracts, including a device call of the same account. Each grant call
+consumes exactly one `nonce` increment, so `N` composed calls under one
+grant need `N` consecutive counters and `N` signatures; the cumulative
+cap is enforced per call against the record as it stands at that call's
+execution, so a transaction cannot exceed `cap` in aggregate; the
+per-call cap is per circuit invocation, never per transaction; the
+recipient pin is evaluated per call and survives grafting; reordering
+composed calls invalidates the signatures.
+
+#### 7.5 Owner-side records
+
+Because the record holds no key, origin, or scheme, a conforming owner
+client MUST maintain a grant roster of `grant_id`, `client_id`, grantee
+key, `[envelope,]` `slot`, `scope_salt`, the approved plaintext scope,
+and every re-seal, rebuildable from the issuing device, and MUST
+reconcile the live ids in `grants` against it on every account view,
+surfacing any unrecognised live id as possible compromise with
+`revoke_all_grants` as the remedy. An owner holding only chain state can
+revoke by id and revoke all but cannot attribute. An optional
+`origin_hint`, the origin sealed under the account encryption secret and
+written at issue, is a MAY; it discloses the account's other connections
+to every read-granted party.
 
 ### 8. Read-scope delegation
 
-Read is the custody MIP's viewing capability (its R9), not a circuit.
-The on-chain `read` flag is declarative: it lets the owner enumerate
-from chain state which grants hold the viewing secret, anchors the
-consent wording to a stored field, and lets the shielded-implies-read
-rule be asserted at issue. The ledger enforces spend scope and not read
-scope.
+Read is the custody MIP's viewing capability (its R9), not a circuit. The
+on-chain `read` flag is declarative: it lets the owner enumerate which
+grants hold the viewing secret, anchors the consent wording to a stored
+field, and lets the shielded-implies-read rule be asserted at issue. The
+ledger enforces spend scope and not read scope.
 
 1. **Delegate key.** The request carries `read_pk`, a 32-byte X25519
-   public key. Browser grantees derive the corresponding secret from the
-   WebAuthn PRF output of their per-origin passkey, so the capability is
-   usable only after the user authenticates on the dApp origin; agents
-   use a vault key. The PRF evaluation is a separate `credentials.get`
-   from any grant-call assertion (an assertion requesting an extension
-   sets the ED flag and appends CBOR output, so its `authenticatorData`
-   exceeds the 37 bytes the r1 gate verifies); its output never enters a
-   circuit. `[DEP]` PRF availability in target browsers. The authoriser
-   MUST reject the twelve known low-order X25519 points and MUST abort on
-   an all-zero shared secret (the RFC 7748 contributory check) with
-   `invalid_request`. `read_pk_hash = H(read_pk)` is stored in the
-   scope.
+   public key, hex, in the canonical little-endian encoding of a
+   coordinate below `p` with the top bit clear; a non-canonical
+   encoding, any of the twelve known low-order points, or an all-zero
+   shared secret (the RFC 7748 contributory check) is `invalid_request`.
+   `read_pk_hash = H(read_pk)` is stored in the scope. Browser grantees
+   derive the secret from the WebAuthn pseudo-random function (PRF)
+   extension of their per-origin passkey, pending PRF availability in
+   target browsers:
+   `sk = clamp(PRF(first = "midnight:account:grant:read:v1" || account))`,
+   with `account` the 32-byte contract address and `clamp` the RFC 7748
+   section 5 scalar clamp; `read_pk = X25519(sk, 9)`. The key is per
+   origin and per account, so `read_pk_hash` correlates nothing across
+   accounts, and any client holding the same credential derives the same
+   key (section 9.8). The PRF evaluation is a separate `credentials.get`
+   from any grant-call assertion (an extension-bearing assertion exceeds
+   the 37 bytes the r1 gate verifies); its output never enters a circuit.
+   Agents use a vault key.
 2. **Rotate before share.** Before issuing any grant with `read = true`
    the authoriser MUST perform `rotate_enc_key` and re-encrypt live
    holdings into fresh inbox entries (custody MIP section 6.7), so the
    delegated secret reads current and future holdings but not spent
-   history `[RULING]`.
-3. **Sealing.** The authoriser seals the 32-byte account encryption
-   secret to `read_pk`: `shared = X25519(eph_sk, read_pk)`;
+   history. Every rotation blinds every delegate holding the previous
+   secret, so on any rotation performed under this MIP the authoriser
+   MUST either re-seal the new secret to every other live grant whose
+   `read_pk_hash` is non-zero, or mark those grants in the owner's roster
+   as requiring reconnection and surface it. A grantee whose pending call
+   encrypted change to the previous key aborts at section 6.2 step 5 and
+   re-signs.
+3. **Sealing.** `shared = X25519(eph_sk, read_pk)`;
    `key = HKDF-SHA256(ikm = shared, salt = empty, info = "midnight:account:grant:view:v1" || grant_id, L = 32)`;
-   AEAD AES-256-GCM with a random 12-byte nonce and associated data
-   `version || suite || eph_pk || grant_id || account`, so that the
-   ephemeral key, the grant, and the account are authenticated in the
-   container. The container, **GrantViewSeal v1**, is 94 bytes with its
-   own version and suite numbering space, distinct from InboxEntry:
+   authenticated encryption with associated data (AEAD) AES-256-GCM with
+   a random 12-byte nonce and associated data
+   `version || suite || eph_pk || grant_id || account`. The container,
+   **GrantViewSeal v1**, is 94 bytes with its own version and suite
+   numbering space; readers MUST check the length before the version, so
+   an InboxEntry is never parsed as a seal:
 
    | Offset | Length | Field |
    |---|---|---|
@@ -1030,63 +970,49 @@ scope.
    | 46 | 16 | AEAD tag |
    | 62 | 32 | ciphertext of the account encryption secret |
 
-   It is delivered base64url in the response fragment as `view`, never
-   written to chain, never in a query component. `[CRYPTO]`: the sealing
-   suite, the PRF-to-X25519 derivation on the dApp side, and the
-   low-order rejection.
-4. **Reading.** The dApp reads by enumerating the account's contract
-   actions and decrypting locally (custody MIP section 6.5), verifying
-   every candidate coin by recomputing its commitment against chain
-   data before treating the entry as authentic and quarantining the
-   rest; no indexer receives the secret. This check is a MUST for every
-   inbox reader: `deposit_shielded` is permissionless and the contract
-   cannot verify the correspondence between a coin and its entry, so a
-   holder of the viewing secret can write plausible but unverifiable
-   entries; a conforming reader treats them as inert noise. This MIP
-   raises a companion note to the custody MIP's R9 that "pure viewing
-   capability" should read "viewing capability plus the ability to write
-   undecryptable or unverifiable noise into the inbox".
-5. **Re-seal.** Any re-seal (silent reconnect, section 9.8) MUST target
-   the key whose hash is `read_pk_hash`; a differing `read_pk` is
-   `invalid_request`. The authoriser MUST record every re-seal in the
-   owner's roster.
+   It is delivered base64url in the response as `view`, never written
+   to chain, never in a query component. The dApp MUST verify that
+   `X25519(secret, 9)` equals the account's `enc_key` cell before
+   treating the capability as live, and treat a mismatch as a faulty or
+   compromised authoriser.
+4. **Reading.** The dApp enumerates the account's contract actions and
+   decrypts locally (custody MIP section 6.5), verifying every candidate
+   coin by recomputing its commitment against chain data before treating
+   the entry as authentic and quarantining the rest; no indexer receives
+   the secret. This is a MUST for every inbox reader: `deposit_shielded`
+   is permissionless, so a holder of the viewing secret can write
+   plausible but unverifiable entries, which a conforming reader treats
+   as inert noise (the companion note to the custody MIP's R9).
+5. **Re-seal.** Any re-seal (silent reconnect, section 9.8; the rotation
+   obligation of item 2) MUST target the key whose hash is
+   `read_pk_hash`; a differing `read_pk` is `invalid_request`. Every
+   re-seal is recorded in the owner's roster.
 6. **Revocation.** On revocation of any grant with `read = true` the
-   owner's client MUST `rotate_enc_key` and re-encrypt live holdings;
-   the delegate keeps what it already read (custody MIP S2); the consent
-   screen says so in advance.
-7. **Coarseness, stated as the dominant residual risk.** `read` delivers
-   the account encryption secret itself, which decrypts the whole inbox,
-   every color, current and future until rotation. A grant tightly
-   scoped in the spend dimension is therefore unscoped in the disclosure
-   dimension, and no schema field can bound it; every read-granted party
-   holds the same secret, so grants are not isolated from each other
-   (one dApp sees another dApp's activity and the owner's), and revoking
-   one blinds all until re-consent. This is the coarsest scope the
-   standard admits; spend without full disclosure awaits the custody
-   MIP's R9 successor (per-grantee or epoch-scoped viewing keys), which
-   this MIP records as its named successor dependency. The consent
-   screen carries the disclosure sentence as its first item for any
-   request that implies `read`.
-8. **Read-only grants** are in scope and first-class: a dApp that shows
-   balances holds a grant with `read = true` and no operation flag; the
-   record earns its transaction by being the enumerable, revocable
-   anchor of an otherwise invisible capability. Unshielded balances are
-   public and need no capability; every grant discloses the account
-   address, which is all an unshielded read needs.
-9. **Authoriser capability.** Possession of the viewing secret is an
-   independent capability of the authoriser role; an authoriser holding
-   only a device key cannot serve a read request and MUST refuse it with
-   `read_unavailable`. How the secret reaches a second device is the
-   custody MIP's business.
+   owner's client MUST `rotate_enc_key` and re-encrypt live holdings,
+   with the re-seal obligation of item 2 toward the remaining delegates;
+   the revoked delegate keeps what it already read (custody MIP S2); the
+   consent screen says so in advance.
+7. **Authoriser capability.** An authoriser holding only a device key
+   and not the viewing secret MUST refuse a read request with
+   `read_unavailable`.
+
+`read` is total, and this is the dominant residual risk of the standard:
+it delivers the account encryption secret itself, which decrypts the
+whole inbox across every color, current and future, until rotation; no
+schema field bounds it, every read-granted party holds the same secret,
+and issuing or revoking any read grant blinds every other until
+re-sealed. Spend without full disclosure awaits the custody MIP's R9
+successor. Read-only grants are first-class; unshielded balances are
+public and need no capability.
 
 ### 9. GrantRequest and the redirect binding
 
 #### 9.1 The object
 
-One transport-independent `GrantRequest` object, canonical JSON per
-RFC 8785 (JCS), base64url-encoded without padding. `Uint<128>` values
-are decimal strings. Field names follow RFC 6749 where a parameter has
-an OAuth analogue.
+One transport-independent `GrantRequest` object, canonical JSON per RFC
+8785 (JCS), base64url-encoded without padding. `Uint<128>` values are
+decimal strings. Field names follow RFC 6749 where a parameter has an
+OAuth analogue.
 
 ```json
 {
@@ -1108,7 +1034,7 @@ an OAuth analogue.
         "per_call_cap": "1000000",
         "cap": "5000000",
         "max_coin_value": "5000000",
-        "expires_at": 1790000000,
+        "expires_at": 1792600000,
         "recipient": null
       }
     }
@@ -1127,92 +1053,97 @@ an OAuth analogue.
 }
 ```
 
-`recipient`, when present, is `{ "kind": "user" | "zswap" | "contract", "value": "<64 hex>" }`
-mapping to `recipient_kind` `1`, `2`, `3`. `envelope` is present only
-for `ecdsa_secp256k1_sha256`. `grants` carries one or more elements
-against the one grantee key, each with a distinct `slot`: one ceremony,
-one consent screen rendering every element, one device signature per
-record, and the authoriser composes the `N` `issue_grant` calls into one
-transaction (`[CIRCUIT]`) or submits them in sequence, returning
-`grant_id` as an ordered array `[RULING]`.
+`iat` and `exp` are Unix seconds; `bounds.expires_at` is in the ledger's
+block-time unit (section 5.1), a distinct unit. `recipient`, when
+present, is `{ "kind": "user" | "zswap" | "contract", "value": "<64 hex>" }`
+mapping to `recipient_kind` `1`, `2`, and `3`. `grants` carries one or more
+elements for the single grantee key, each with a distinct `slot`: one
+ceremony, one consent screen rendering every element, one device
+signature per record; the authoriser composes the `N` `issue_grant`
+calls into one transaction or submits them in sequence.
 
 | Member | Required | Rule |
 |---|---|---|
 | `v` | MUST | integer `1`; unknown is `unsupported_version` |
 | `chain` | MUST | CAIP-2 `midnight:<reference>` (MIP-0008); a legacy bare network id is accepted and canonicalised |
-| `aud` | MUST | the authoriser origin, exact string match against the authoriser's own origin; mismatch is `invalid_request` |
-| `iat`, `exp` | MUST | Unix seconds; `exp - iat` at most 600; a request outside `[iat, exp]` is `invalid_request` |
-| `client_id` | MUST | normalised RFC 6454 origin, `https` (plain `http` only for `localhost`); `rdns:`, `mais:`, `self:` identifiers are `invalid_request` in the browser binding |
-| `redirect_uri` | MUST in the browser binding; MUST be absent in non-browser bindings | absolute `https` URI whose origin equals `client_id`, no fragment; exact string match on return (RFC 9700 section 4.1.3); loopback exception only for native clients |
-| `account` | MUST when the dApp knows it | contract address hex; when absent the user chooses and the consent screen flags that the request bound no account |
-| `grantee` | MUST | `{scheme, [envelope,] pk}` per section 3; `envelope` `0` or `1` for `ecdsa_secp256k1_sha256` only |
+| `aud` | MUST | the authoriser origin, exact string match |
+| `iat`, `exp` | MUST | `exp - iat` at most 600; outside `[iat, exp]` is `invalid_request` |
+| `client_id` | MUST | normalised per section 4.4; `https` (plain `http` only for `localhost`); `rdns:`, `mais:`, `self:` are `invalid_request` in the browser binding |
+| `redirect_uri` | MUST in the browser binding; MUST be absent otherwise | absolute `https` URI whose origin equals `client_id`, no fragment; exact string match on return (RFC 9700 section 4.1.3); loopback exception only for native clients |
+| `account` | MUST when the dApp knows it | contract address hex; when absent the user chooses and the consent screen says so |
+| `grantee` | MUST | `{scheme, [envelope,] pk}` per section 3; `envelope` for `ecdsa_secp256k1_sha256` only |
 | `grants` | MUST | non-empty array of `{slot, scope, bounds}`; distinct slots; unknown strings are `invalid_scope` |
-| `bounds` | MUST when any withdraw string | `color`, `per_call_cap`, `cap`, `max_coin_value`, `expires_at` (`0` = never, explicit), `recipient` (null or typed) |
-| `read_pk` | MUST when `read` is requested or implied | 32-byte X25519 public key, hex; low-order points and an all-zero shared secret are `invalid_request` |
+| `bounds` | MUST when any withdraw string; MUST be absent otherwise | `color`, `per_call_cap`, `cap`, `max_coin_value`, `expires_at` (`0` = never, explicit), `recipient` (null or typed); a read-only element is issued with the all-zero object and caps of section 5.1 rule 7 |
+| `read_pk` | MUST when `read` is requested or implied | per section 8 item 1 |
 | `state` | MUST | opaque, at least 128 bits of entropy, at most 512 characters, bound to the dApp's browser session, echoed verbatim |
-| `nonce` | MUST | 32 random bytes, hex; one-time: the authoriser MUST reject a `nonce` it has seen within the validity window |
+| `nonce` | MUST | 32 random bytes, hex; one-time within the validity window |
 | `proof` | MUST | possession and origin proof over `request_digest` (section 9.2) |
+
+Encodings of the `proof` members:
+
+| Member | Encoding |
+|---|---|
+| `client_data_json`, `authenticator_data` | base64url of the raw bytes the authenticator returned |
+| `signature` | base64url of the authenticator's ASN.1 DER `ECDSA-Sig-Value`, both `s` forms accepted |
+| `credential_pk` | 128 lowercase hex, affine `x \|\| y`, each coordinate a 32-byte little-endian integer (section 3.4) |
+| `key_signature` | the arm's off-chain form of section 3.4 (`k1` `r \|\| s`, `v1` `R \|\| s`), 128 lowercase hex |
 
 #### 9.2 Request digest and proof rules
 
 `request_digest = H(pad(64, "midnight:account:grant:request:v1") || H(JCS(request without "proof")))`.
 
-Off-chain signatures by a grantee key over a fixed 32-byte digest `d`
-use the arm's own form: `k1` signs `envelope_digest(envelope, d)`; `r1`
-is a WebAuthn assertion with `challenge = d`; `v1` is a key-prefixed
-Schnorr signature `(R, s)` with `c = int_le(H(R || pk || d)) mod r_J`
-and `s = r + c * sk mod r_J`, where `R` and `pk` are in the published
-`JubjubPoint` byte layout (the verifier is not a circuit and needs no
-grinding; a fixed digest cannot be ground) `[CRYPTO]`.
-
 Proof rules in the browser binding:
 
 - **`ecdsa_secp256r1_webauthn` grantee.** `proof.type = "webauthn"`: an
   assertion by the grantee credential with `challenge = request_digest`,
-  requested without extensions. The authoriser verifies the signature
-  under `grantee.pk`, `clientDataJSON.type == "webauthn.get"`,
+  requested without extensions. The authoriser validates `grantee.pk`
+  per section 3.3, verifies the signature under it,
+  `clientDataJSON.type == "webauthn.get"`,
   `clientDataJSON.challenge == base64url(request_digest)`,
   `clientDataJSON.origin == client_id`, and
-  `rpIdHash == H(host(client_id))`, and copies `rpIdHash` into
-  `scope.rp_id_hash`.
+  `rpIdHash == H(host(client_id))`, and takes `rpIdHash` as
+  `rp_id_hash`.
 - **Software grantee** (`schnorr_jubjub`, or `ecdsa_secp256k1_sha256`
   envelope `0`). `proof.type = "webauthn"` by a companion credential
   created on the dApp origin, verified under `proof.credential_pk` with
   the same `clientDataJSON` checks, plus `proof.key_signature`, a
   signature by `grantee.pk` over `request_digest` in the arm's off-chain
   form. The assertion attests the origin and binds the software key
-  through the digest; the key signature proves possession, so the
-  approver never spends an `auth_nonce` on a key the dApp cannot use.
+  through the digest; the key signature proves possession.
 - **Wallet-provider grantee** (`ecdsa_secp256k1_sha256` envelope `1`).
   As the software grantee, with `key_signature` obtained through the
-  connector's `signData` and verified over `envelope_digest(1, request_digest)`;
-  only `midnight:account:read` may be requested.
+  connector's `signData` and verified over
+  `envelope_digest(1, request_digest)`; only `midnight:account:read`
+  may be requested.
 
 Non-browser bindings (agents, `self:` delegates) carry
 `proof.type = "signature"` with `key_signature` only; the identity is
 displayed as operator-asserted or as the owner's own label.
-`proof.type = "signature"` in the browser binding is `invalid_proof`; an
-`rdns:`, `mais:`, or `self:` `client_id` arriving by top-level
-navigation is `invalid_request`.
+`proof.type = "signature"` in the browser binding is `invalid_proof`.
 
-**The binding is a property of the transport** `[RULING]`. An
-authoriser that received the request as a top-level browser navigation
-MUST apply the browser binding regardless of the `client_id` form: the
-possession proof MUST be a WebAuthn assertion made on the dApp origin,
-and `rdns:`, `mais:`, and `self:` clients MUST be rejected. Non-browser
-bindings MUST use a distinct non-redirect delivery (a pasted or scanned
-request object, a local channel), MUST NOT accept a `redirect_uri`, and
-admit key-only proofs because an operator or the owner approves in
-person. Without this rule the requester's choice of an `rdns:`
-`client_id` would select the weaker binding while keeping the redirect,
-reopening both NEAR defects.
+**The binding is a property of the transport.** A request received by
+top-level navigation MUST get the browser binding regardless of the
+`client_id` form: the possession proof MUST be a WebAuthn assertion on
+the dApp origin, and `rdns:`, `mais:`, and `self:` clients MUST be
+rejected with `invalid_request`. Non-browser bindings MUST use a
+non-redirect delivery, MUST NOT accept a `redirect_uri`, and admit
+key-only proofs because an operator or the owner approves in person.
+
+**What the origin proof delivers.** A verified assertion proves that a
+credential registered on the requesting origin vouches for the grantee
+key. It does not prove that the request came from that origin's
+authentic front-end: any registered user of the dApp, or a script
+injected into it, can produce a valid request naming the origin and its
+own key. The consent screen naming the proven origin and the owner's
+roster are the remaining barriers; a dApp MAY publish an allow-list of
+its grantee keys, and `.well-known` client metadata is the recorded
+extension.
 
 #### 9.3 Browser binding: request delivery
 
 Top-level GET navigation to
 `https://<authoriser>/grant#request=<base64url(JCS(GrantRequest))>`.
-The request travels in the fragment, never in the query component
-`[RULING]`.
+The request travels in the fragment, never in the query component.
 
 #### 9.4 Authoriser processing
 
@@ -1228,40 +1159,36 @@ In order:
    `proof`. Reject with an in-place error page (no redirect) if
    `redirect_uri` is not `https`, not same-origin with `client_id`, or
    carries a fragment.
-4. Verify the grantee scheme is in the registry and that the account is
-   capable (`spec_version >= 2`, and the arm present per the
-   authoriser's own record of the account's deployed arms, since
-   verifier keys are not a specified chain read); check `bounds`
-   well-formedness, the implications, and the envelope-1 read-only rule.
-5. Sign the user in with an authoriser credential whose RP ID equals
-   the full authoriser host, never a parent domain; this sign-in
-   assertion yields no signing material.
+4. Verify the scheme is registered and the account is capable
+   (`spec_version >= 2`, and the arm deployed per the authoriser's own
+   record, since verifier keys are not a specified chain read); check
+   `bounds`, the implications, and the envelope-1 read-only rule.
+5. Sign the user in with an authoriser credential whose relying-party
+   (RP) identifier equals the full authoriser host, never a parent
+   domain; this sign-in assertion yields no signing material.
 6. Render the consent screen of section 9.5.
 7. On approval, and only then, perform the authorising ceremony: the
    WebAuthn assertion whose PRF output derives the device key is
    requested with `challenge = challenge_issue_grant_with_<device arm>(...)`,
    so that `clientDataJSON` itself binds the approved scope and the
-   user-verification flag is the consent evidence; derive `grant_id`
-   and the commitments; sign the issue challenge with the derived
-   device key; use that key for exactly the signatures of this ceremony
-   and discard it; prove; submit; wait for inclusion (SHOULD; `pending`
-   is the fallback `[RULING]`); redirect.
+   user-verification flag is the consent evidence; derive `grant_id`,
+   draw `scope_salt`, and compute the commitments; if any element
+   implies `read`, sign and submit `rotate_enc_key` and the re-encrypted
+   inbox entries first, then `issue_grant`, both with the derived device
+   key and both covered by the consent screen's read sentence; use that
+   key for exactly the signatures of this ceremony and discard it;
+   prove; submit; wait for inclusion (SHOULD; `pending` is the
+   fallback); seal the viewing secret if `read`; redirect.
 
 The order matters because the derived device key is signing material
-for any device-gated challenge: a page that derives it before consent
-holds the account's authority while waiting for a DOM click, and a
-script injection or hostile extension turns a connect flow into
-`add_device` or a withdrawal. GR-16 claims only what this construction
-delivers.
+for any device-gated challenge (S18).
 
 The authoriser MUST NOT display or log `state`, MUST set
 `Referrer-Policy: no-referrer`, MUST NOT load third-party resources on
 the consent page, and MUST redirect with status 303, never 307.
 
-**Fees at issuance.** The `issue_grant` transaction is an ordinary
-account operation whose fee follows the custody MIP and the account's
-DUST arrangements; a zero-balance account cannot connect. A conforming
-authoriser MUST surface the fee requirement on the consent screen and
+**Fees.** `issue_grant` is an ordinary account operation paid by the
+account; an authoriser MUST surface the fee on the consent screen and
 MUST return `temporarily_unavailable` rather than `granted` when the
 account cannot fund the call. Sponsorship is out of scope; a conforming
 flow MUST work account-funded.
@@ -1271,26 +1198,27 @@ flow MUST work account-funded.
 Rendered after sign-in and before the authorising ceremony, from the
 exact plaintext scope that will enter the device challenge and from the
 proven `client_id`. No dApp-supplied name, icon, statement, or color
-name is displayed in v1 `[RULING]`. The screen MUST display:
+name is displayed. The screen MUST display:
 
-1. for any element that requests or implies `read`: the sentence that
-   the dApp will be able to see every current and future shielded
-   holding of the account, across all colors, until the encryption key
-   is rotated, that this is not limited by the spend bounds, and that
-   rotate-before-share will be performed;
+1. for any element that requests or implies `read`: that the dApp will
+   be able to see every current and future shielded holding of the
+   account, across all colors, until the encryption key is rotated;
+   that this is not limited by the spend bounds; that
+   rotate-before-share will be performed; and, when other live read
+   grants exist, that they will be re-sealed or will need reconnection;
 2. the authoriser's own origin;
-3. the dApp identity: the proven origin host (IDN shown in punycode when
-   scripts are mixed), or the operator-asserted identifier labelled as
-   such, or the owner's own `self:` label;
+3. the dApp identity: the proven origin host (punycode when scripts are
+   mixed), or the operator-asserted identifier labelled as such, or the
+   owner's own `self:` label;
 4. the account (name and shortened address) and the network; when the
    request bound no `account`, the words that the dApp did not name an
    account and the approver is choosing one;
 5. for each requested element: every requested operation in plain words
    ("withdraw unshielded", "withdraw shielded", "withdraw shielded to a
    contract");
-6. the color as its full hex always, with a registry name beside it only
-   when resolved from the single source this MIP names in its registry
-   entry, and hex only otherwise;
+6. the color as its full hex, and hex only: no color name is displayed,
+   because no on-chain color-name registry exists that the authoriser
+   can verify; a later revision MAY name one;
 7. `per_call_cap`, `cap`, and `max_coin_value` in atomic units with an
    explicit smallest-unit label (no on-chain decimals metadata exists);
    on a re-issue, the tombstone's `spent` as the roster records it;
@@ -1301,8 +1229,8 @@ name is displayed in v1 `[RULING]`. The screen MUST display:
     created on bank.example", "your wallet's key"), and a short
     fingerprint the dApp is instructed to show on its side;
 12. that the connection, its scope bounds, its expiry, and its call
-    count are publicly visible on chain (its color, counterparty, and
-    amounts are not);
+    count are publicly visible on chain (its color, counterparty,
+    amounts, and dApp host are not);
 13. that the transaction is paid by the account;
 14. that the grant can be revoked from any device.
 
@@ -1315,7 +1243,9 @@ verification.
 
 303 to the exact `redirect_uri` with form-encoded parameters in the
 fragment (never the query); the dApp strips the fragment with
-`history.replaceState` on load.
+`history.replaceState` on load. Per-record parameters are repeated once
+per element of `grants`, in the request's `grants` order, so the
+repetitions are index-aligned with the request.
 
 | Parameter | Present | Value |
 |---|---|---|
@@ -1324,21 +1254,29 @@ fragment (never the query); the dApp strips the fragment with
 | `result` | always | `granted`, `pending`, `denied`, `error` |
 | `chain` | granted, pending | canonical CAIP-2 |
 | `account` | granted, pending | contract address hex |
-| `grant_id` | granted, pending | hex, ordered array matching `grants` |
-| `scope_salt` | granted, pending | hex, ordered array; the readability key of each record |
+| `grant_id` | granted, pending; per record | hex |
+| `scope_salt` | granted, pending; per record | hex |
+| `scope` | granted, pending; per record | the approved plaintext scope as a JCS object, base64url: the four flags, `color`, `recipient_kind`, `recipient`, `max_coin_value`, `per_call_cap`, `cap`, `expires_at` |
 | `tx` | pending, optionally granted | transaction identifier |
 | `view` | granted with `read` | GrantViewSeal v1, base64url (section 8) |
 | `error`, `error_description` | error, denied | from the tables below |
 
-No key list, no account list, no bearer artefact, nothing in a query
-component. If `redirect_uri` failed validation the authoriser MUST NOT
-redirect at all.
+The approved scope is returned because the grantee needs
+`recipient_kind`, `recipient`, and `max_coin_value` as commitment
+openings and the approver may have narrowed them; a dApp MUST use the
+returned values and MUST verify that each equals or attenuates its
+request. No key list, no account list, no bearer artefact, nothing in a
+query component; if `redirect_uri` failed validation the authoriser MUST
+NOT redirect at all. In a non-browser binding the authoriser returns the
+same parameter set as a structured object over the channel that carried
+the request, omitting `state`, `iss`, and `redirect_uri`; the grantee
+performs the recomputation and chain read of section 9.7.
 
 Errors rendered in place (never delivered to `redirect_uri`):
 
 | `error` | When |
 |---|---|
-| `invalid_request` | malformed object, missing member, bad encoding, `state` too short, `aud` mismatch, outside `[iat, exp]`, replayed `nonce`, `redirect_uri` invalid or not same-origin with `client_id`, non-browser `client_id` by navigation, low-order `read_pk`, re-seal to a `read_pk` other than the bound one |
+| `invalid_request` | malformed object, missing member, bad encoding, `state` too short, `aud` mismatch, outside `[iat, exp]`, replayed `nonce`, `redirect_uri` invalid or not same-origin with `client_id`, `client_id` matching no production of section 4.4 or non-browser by navigation, invalid `read_pk`, re-seal to a `read_pk` other than the bound one |
 
 Errors delivered to a validated `redirect_uri`:
 
@@ -1347,19 +1285,18 @@ Errors delivered to a validated `redirect_uri`:
 | `unsupported_version` | `v` unknown | |
 | `unsupported_chain` | `chain` not served by this authoriser | |
 | `unsupported_scheme` | scheme not in the registry, or arm not deployed on the account; a withdraw string requested by an envelope-1 grantee | |
-| `invalid_scope` | unknown string, the reserved `signin` string, bounds inconsistent, implication violated, no on-chain effect requested, duplicate `slot` | |
+| `invalid_scope` | unknown string, the reserved `signin` string, bounds inconsistent or present on a read-only element, implication violated, no on-chain effect requested, duplicate `slot` | |
 | `origin_mismatch` | attested `clientDataJSON.origin` differs from `client_id` | |
-| `invalid_proof` | signature, challenge, type, or `rpIdHash` check failed; key not on curve or weak; extension-bearing assertion; `signature` type in the browser binding | |
+| `invalid_proof` | signature, challenge, type, or `rpIdHash` check failed; key not on curve, the identity, or weak; extension-bearing assertion; `signature` type in the browser binding | |
 | `account_not_capable` | account `spec_version < 2` | |
 | `read_unavailable` | this authoriser does not hold the account viewing secret | |
 | `access_denied` | the user declined this request | `Rejected` |
 | `permission_rejected` | the user declined and asked not to be asked again for this `client_id` | `PermissionRejected` |
 | `server_error`, `temporarily_unavailable` | as RFC 6749 section 4.1.2.1; the account cannot fund the issuance | `InternalError` |
 
-**Pending completion.** A dApp that received `result=pending` MUST poll
-chain state for its records and, once they are live, obtain its `view`
-through a silent reconnect (section 9.8), which re-seals to the bound
-`read_pk_hash` after the full read consent screen and no transaction.
+A dApp that received `result=pending` MUST poll chain state for its
+records and, once they are live, obtain its `view` through a silent
+reconnect (section 9.8).
 
 #### 9.7 Exact-match and return-leg rules
 
@@ -1375,19 +1312,20 @@ through a silent reconnect (section 9.8), which re-seals to the bound
   `grants[grant_id]`, `device_epoch`, and `grant_generation` from chain
   state (an indexer query or a replay of the account's contract
   actions); MUST verify `active`, `epoch`, `gen`, that `object_commit`
-  opens under the returned `scope_salt` to the requested color,
-  recipient, and `max_coin_value` (or an attenuation), and that every
-  clear scope field equals or attenuates its request; and only then
-  moves the pending key into use. Redirect parameters are hints.
-- A `grant_id` that does not match the recomputation MUST be treated as
+  opens under the returned `scope_salt` and the returned plaintext object
+  fields, that `rp_commit` opens to its own `rp_id_hash` (r1) or to zero,
+  and that every returned field equals or attenuates its request; and
+  only then moves the pending key into use. Redirect parameters are
+  hints.
+- A `grant_id` or opening that does not match MUST be treated as
   evidence of a compromised authoriser: the dApp MUST NOT use the key
   and MUST prompt the user to revoke from another device.
 - The pending private key SHOULD be non-extractable (WebCrypto or the
-  passkey-gated store), never plain `localStorage`. `scope_salt` and
-  `spent` MUST be persisted by the grantee alongside the key; losing the
-  salt costs the ability to read the record's commitments, and losing
-  `spent` costs the ability to open `spent_commit` until reconstructed
-  from the grantee's own transaction history.
+  passkey-gated store), never plain `localStorage`. Losing `scope_salt`
+  costs the ability to make any further call under the grant, which must
+  then be revoked and re-issued; losing `spent` costs the ability to
+  open `spent_commit` until reconstructed from the grantee's own
+  transaction history.
 
 #### 9.8 Silent reconnect
 
@@ -1397,62 +1335,22 @@ authoriser receiving a request for which the dApp's recomputed
 screen, return `result=granted` with a freshly sealed `view` and no
 transaction, provided `H(read_pk) == scope.read_pk_hash`; a differing
 `read_pk` is `invalid_request`. This is how a dApp recovers its viewing
-material on a new device that holds the same per-origin passkey (and
-therefore the same PRF-derived `read_pk`).
-
-#### 9.9 Sequence
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant B as Browser (user)
-    participant D as dApp origin
-    participant A as Authoriser (consent page)
-    participant K as Authenticators (dApp passkey, authoriser passkey)
-    participant C as Account contract
-    participant I as Indexer / node
-
-    B->>D: open dApp, choose Connect account
-    D->>K: create or use per-connection key; companion or r1 passkey on the dApp origin
-    D->>K: webauthn.get(challenge = request_digest), no extensions
-    K-->>D: assertion (clientDataJSON.origin = dApp origin)
-    D->>B: 303 to A/grant#request=b64url(JCS(GrantRequest))
-    B->>A: GET (top-level; fragment read client-side, then replaceState)
-    A->>A: verify aud, iat/exp, nonce, proof, origin(redirect_uri) == client_id == attested origin, chain, scheme, bounds, spec_version >= 2
-    A->>K: sign-in assertion (rpId = full authoriser host), no signing material
-    A->>B: consent rendered from the plaintext scope and the proven client_id
-    B->>A: approve (possibly narrowed)
-    A->>K: authorising assertion, challenge = challenge_issue_grant (PRF derives the device key)
-    A->>A: grant_id = derive_grant_id_with_<arm>(self, pk, [envelope,] origin_hash, slot); commitments; sign; discard the device key
-    A->>C: issue_grant_with_<device arm>(grant_id, plaintext scope, scope_salt, device auth)
-    C->>C: device seam; commit object and spent; write GrantRecord{epoch, gen, issued_at, nonce = 0, active, scope}; round += 1
-    C-->>A: inclusion
-    A->>A: if read: rotate-before-share done earlier; seal the encryption secret to read_pk
-    A->>B: 303 to redirect_uri#state&iss&result=granted&chain&account&grant_id&scope_salt&view
-    B->>D: fragment delivered on the dApp origin only; replaceState
-    D->>D: check state and iss; recompute grant_id by the byte recipe
-    D->>I: read grants[grant_id], device_epoch, grant_generation
-    I-->>D: record; open object_commit with scope_salt; compare with the request
-    D->>B: signed in (sign-in message signed by the grantee key, verified against chain)
-    D->>C: later: withdraw_shielded_with_grant_<arm>(recipient, color, amount, change_entry, grant auth)
-    C->>C: grant seam: id, active, epoch, gen, expiry, op, coin.color and coin.value against the commitments, caps, recipient, verify over g.nonce, nonce += 1, re-commit spent, round += 1; send; append change_entry
-```
+material on a new device that holds the same per-origin passkey and
+therefore, by section 8 item 1, the same `read_pk`.
 
 ### 10. Sign-in
 
-This MIP defines account-linked, grant-backed sign-in only `[RULING]`.
-A dApp holding a grant knows the account address, because it must to
-call the contract and to read its record. Sign-in is the dApp verifying
-a message signed by the grantee key against the key it registered and
-against chain state. Sign-in-only requests never touch the authoriser or
-the chain: the dApp uses its own per-origin passkey locally. There is no
-identity-only on-chain grant; a read-only grant is not one, because its
-record anchors a real capability the owner can enumerate and revoke.
-Every grant discloses the account address by construction; this is not
-the unlinkable default the sign-in MIP owns, and
-`midnight:account:signin` is reserved for it.
+This MIP defines account-linked, grant-backed sign-in only. A dApp
+holding a grant knows the account address, because it needs that address
+to call the contract and to read its record; sign-in is the dApp
+verifying a message signed by the grantee key against the registered key
+and chain state, and never touches the authoriser or the chain. There is
+no identity-only on-chain grant. Every grant discloses the account
+address by construction; unlinkable sign-in belongs to the sign-in MIP,
+for which `midnight:account:signin` is reserved.
 
-Message layout (fixed line order, `LF` separated, UTF-8):
+Message layout (EIP-4361 shape; fixed line order, `LF` separated,
+UTF-8):
 
 ```
 {domain} wants you to sign in with your Midnight account:
@@ -1461,43 +1359,49 @@ Message layout (fixed line order, `LF` separated, UTF-8):
 URI: {uri}
 Version: 1
 Chain ID: midnight:{reference}
-Nonce: {nonce, at least 8 alphanumeric characters}
+Nonce: {nonce, at least 128 bits of entropy, alphanumeric}
 Issued At: {RFC 3339}
 Expiration Time: {RFC 3339}
 Grant ID: {grant_id hex}
+Incarnation: {issued_at, decimal}
 ```
 
 `signin_digest = H(pad(64, "midnight:account:grant:signin:v1") || H(message))`,
-signed in the arm's off-chain form of section 9.2 (`k1` through its
-envelope, `r1` as a WebAuthn assertion with `challenge = signin_digest`
-on the dApp origin, `v1` key-prefixed Schnorr).
+signed in the arm's off-chain form of section 3.4 (`r1` as a WebAuthn
+assertion with `challenge = signin_digest` on the dApp origin).
 
 Verification by the dApp: the signature is valid under the registered
-`(scheme, [envelope,] pk)`; `domain` equals the dApp's own origin host;
-`Issued At` is within the dApp's tolerance and before `Expiration
-Time`; `Nonce` is unused; and, from chain, `grants[grant_id]` exists,
-`active`, `epoch == device_epoch`, `gen == grant_generation`, and not
-expired. Silent reconnect is a chain read with no redirect. Cross-dApp
-unlinkability of the credential itself follows from WebAuthn RP scoping
-and per-connection keys; cross-dApp collusion links users by account
-address, and the mitigation is multiple accounts, not this MIP.
+`(scheme, [envelope,] pk)`; `domain` equals the dApp's own origin host
+and `URI` is within the dApp's own origin; `Version` is `1`; `Chain ID`
+equals the dApp's expected CAIP-2 identifier; `Issued At` is within the
+dApp's tolerance and before `Expiration Time`; `Nonce` is unused; and,
+from chain, `grants[grant_id]` exists, `active`, `epoch == device_epoch`,
+`gen == grant_generation`, not expired, and `issued_at` equals
+`Incarnation`, so a message signed against one incarnation never
+verifies against a re-issue (GR-6). Cross-dApp collusion links users by account address; the
+mitigation is multiple accounts, not this MIP.
 
 ### 11. Ecosystem carriage
 
 #### 11.1 CAIP-25 carriage
 
-The grant feature strings and their bounds travel in a dedicated member
-of a CAIP-25 session keyed by the MIP-0008 CAIP-2 identifier, with dual
-acceptance of the connector's bare network id on input and
-canonicalisation to CAIP-2:
+The grant feature strings and their bounds travel in the CAIP-25
+`scopedProperties` member, keyed by the MIP-0008 CAIP-2 identifier, with
+the connector's bare network id accepted on input and canonicalised:
 
 ```json
-{ "midnight:mainnet": { "midnight:account:grants": [ { "slot": 0, "scope": ["..."], "bounds": { } } ] } }
+{
+  "scopedProperties": {
+    "midnight:mainnet": {
+      "midnight:account:grants": [ { "slot": 0, "scope": ["..."], "bounds": { } } ]
+    }
+  }
+}
 ```
 
-never in `methods`. A CAIP-25 peer MUST NOT treat a grant feature string
-as invokable. The `accounts` member is illustrative until CAIP-10 for
-Midnight is defined `[DEP]`.
+They never appear in `methods`, and a CAIP-25 peer MUST NOT treat a
+grant feature string as invokable. This MIP defines no `accounts`
+member; CAIP-10 for Midnight is not yet defined.
 
 #### 11.2 Open Wallet Standard mapping
 
@@ -1509,690 +1413,259 @@ asks to pair with:
 |---|---|
 | target contract | the account address (`account`, `kernel.self()`) |
 | circuits | the three operation flags |
-| argument predicates | `color` equality; the recipient pin (`recipient_kind`, `recipient`) |
+| argument predicates | `color` equality; the recipient pin |
 | value per color, per-call bound | `per_call_cap` |
 | value per color, cumulative bound | `cap` |
-| value per color, per-window bound | `window_len`, `window_cap` (reserved in v1; client-side until then) |
+| value per color, per-window bound | `window_len`, `window_cap` (reserved; client-side until enforced) |
 | validity | `expires_at`, `active`, `epoch`, `gen` |
 
 An Open Wallet Standard vaulted key is a first-class grantee through the
 `rdns:` or `mais:` identity in the non-browser binding: the vault signs
-the grant challenge, its policy engine mirrors the scope client-side,
-and the contract enforces it regardless of client behaviour. This MIP
-asks two things of that standard `[DEP]`: a capability flag at the
-handshake meaning "I can present a `GrantRequest` and sign grant
-challenges", and acceptance of the mapping table of section 5.2. The
-connector's scheme strings, its `midnight_signed_message:32:` prefix as
-envelope `1`, its `Rejected` and `PermissionRejected` semantics, and its
-`rdns` identity are reused; MIP-0015's consent vocabulary is aligned
-with informatively `[RULING]`. This MIP defines no injected API, no
-connector method, no client policy language, and no proving or
-submission transport.
+the grant challenge, its policy engine mirrors the scope, and the
+contract enforces it regardless. This MIP asks that standard for a
+handshake capability flag ("I can present a `GrantRequest` and sign
+grant challenges") and acceptance of the mapping table of section 5.2.
 
 #### 11.3 The authoriser role
 
-The authoriser is a role defined by four capabilities: it holds a device
-key of the account, it renders a `GrantRequest`, it drives
-`issue_grant`, and, to serve `read`, it holds the account viewing
-secret. A consent page hosted by an identity provider is one instance;
-it holds no assets and no spend path. Any implementation holding a
-device key can act in the role; a conforming account MUST be
-connectable through a locally run authoriser, self-hosting MUST be
-documented, and a dApp MUST treat an unavailable authoriser as a
-recoverable error carrying no state.
+The authoriser is a role: it holds a device key of the account, renders
+a `GrantRequest`, drives `issue_grant`, and, to serve `read`, holds the
+viewing secret. A consent page hosted by an identity provider is one
+instance; it holds no assets and no spend path. A conforming account
+MUST be connectable through a locally run authoriser, self-hosting MUST
+be documented, and a dApp MUST treat an unavailable authoriser as a
+recoverable error carrying no state. A device key derived under one
+authoriser's RP identifier cannot be derived by another host, so a
+second authoriser needs its own `add_device` and interacts with AUTH-5;
+one device key MUST NOT be enrolled for more than one authoriser host.
 
-Plurality has an enrolment consequence: a device key derived under one
-authoriser's RP ID cannot be derived by another host, so a second
-authoriser needs its own `add_device`, consumes a device slot, changes
-`device_count`, and interacts with AUTH-5. One device key MUST NOT be
-enrolled for more than one authoriser host (RP-scoped derivation forbids
-it). Authoriser substitution is inert: a hostile authoriser cannot
-derive the real one's key.
+### 12. Companion erratum to MIP-0013 section 9
 
-### 12. Invariants
+Three invariants of the authorisation MIP are, as written, falsified by
+any grant twin. This MIP does not reinterpret them; they are read as
+amended by a companion erratum whose acceptance is an acceptance
+criterion and whose wording travels in the erratum pull request: AUTH-1
+admits a grant record whose scope admits the call as an authoriser
+credential beside a device entry; AUTH-2 is scoped to device-authorised
+calls, with the obligation that any other authoriser class define its
+own contract-held freshness element, cover and advance it on every call,
+and never advance `auth_nonce` (GR-5); AUTH-9 is scoped to device
+handles, with a stable per-grant identifier permitted under a stated
+hiding argument (GR-15). Widening "device" to cover grantees is rejected
+(R1). Every conformance item of the authorisation MIP remains
+device-only and passes unchanged on a `spec_version = 2` account; its
+rejection matrix and deposit-independence item gain grant-side
+counterparts in Testing, which do not replace them.
+
+### 13. Invariants
 
 A conforming implementation MUST satisfy all of the following, in
-addition to the custody MIP's INV-1 through INV-8 and, as amended by
-section 13, the authorisation MIP's AUTH-1 through AUTH-10.
+addition to the custody MIP's INV-1 through INV-8, the authorisation
+MIP's AUTH-1 through AUTH-10 as amended by section 12, and the schemes
+MIP's SIG-1 through SIG-5 for the arms it deploys.
 
-- **GR-1 (single seam, closed operation set).** Every grant-authorised
-  operation is verified inside the account contract by the grant seam,
-  which exists only as the grant twins of `withdraw_unshielded`,
-  `withdraw_shielded`, and `withdraw_shielded_to_contract`; no lifecycle,
-  device-management, inbox, or grant-management circuit has a grant
-  twin. (INV-1)
-- **GR-2 (authority disjointness).** Grant keys are looked up only in
-  `grants` under grant tag families; a grant credential cannot satisfy a
-  device seam and a device credential cannot satisfy a grant seam;
-  cross-scheme use fails at identity derivation; an authoriser MUST
-  refuse to issue a grant to a key it knows to be enrolled as a device
-  of the same account, so that `remove_device` and `revoke_grant` each
-  retire what the owner believes they retire. (SIG-1)
-- **GR-3 (contract-maintained identity).** `grant_id` is a
-  deterministic commitment to `(account, arm, key, [envelope,]
-  origin_hash, slot)` recomputed in-circuit at every use; one such
-  tuple has at most one live record, and a key holds at most 256
-  records at one origin, all enumerable by anyone who knows the key and
-  the origin; issuance fails while a live record exists under that id;
-  revocation retires the id; only device-gated circuits create a
-  record, retire a record, or alter a record's scope; a grant twin
-  writes only the freshness and accounting fields of its own record.
-- **GR-4 (full binding).** Every grant challenge covers the account
-  address, the per-operation grant tag, the grantee key, `grant_id`,
-  `issued_at`, every operation argument that varies per call, every
-  consumed witness value, and the record's `nonce`; the commitment
-  openings are bound through `grant_id` and verified by equality
-  against the record. (AUTH-3, AUTH-10, SIG-2; `[CRYPTO]` on the
-  transitive clause)
-- **GR-5 (per-grant single use, owner liveness).** Every grant call
-  binds the record's `nonce` as read from ledger state and advances it,
-  so an identical resubmission of any argument tuple and signature
-  fails; grant calls never read or advance `auth_nonce`. (custody MIP
-  section 4 freshness; companion erratum to AUTH-2)
-- **GR-6 (incarnation isolation).** A signature produced against one
-  issuance of a grant id cannot verify against any other issuance of the
-  same id.
-- **GR-7 (in-circuit scope over consumed values).** Operation flag, the
-  color and value of the coin actually consumed (or the argument the
-  unshielded chip consumes), `per_call_cap`, `cap`, `max_coin_value`,
-  the recipient pin, `expires_at`, `active`, `epoch`, and `gen` are
-  asserted before any custody chip executes; every predicate is
-  evaluated over the value the chip consumes, never over an argument
-  that merely selects it; an out-of-scope call fails at proving or
-  verification, never at application discretion.
-- **GR-8 (contract-derived lifecycle fields).** `epoch`, `gen`,
-  `issued_at`, `object_commit`, and the initial `spent_commit` are
-  written by the contract from ledger state and from the plaintext the
-  approver signed; no argument supplies `epoch`, `gen`, or `issued_at`;
-  no grant can be pre-planted for a future epoch or generation.
-- **GR-9 (kill totality).** After a `device_epoch` bump or a
-  `grant_generation` bump no grant recorded under a previous value
-  authorises anything. (AUTH-6)
-- **GR-10 (chain-verifiable status).** `active`, `epoch`, and `gen` are
-  public state; revocation is effective from the including block; the
-  status of a known record is verifiable from chain state alone; the
-  identity of its grantee is not, and an owner holding only chain state
-  can revoke by id and revoke all but cannot attribute.
-- **GR-11 (no widening).** A record's scope is immutable after issue;
-  modification is revoke then issue under fresh device authorisation
-  whose challenge binds the full plaintext scope; the approver may
-  narrow and never widen a request.
-- **GR-12 (owner-only lifecycle, non-interference).** `issue_grant`,
-  `revoke_grant`, and `revoke_all_grants` are device-gated; a grant
-  call changes no device entry, `device_count`, `auth_nonce`, `enc_key`,
-  or any other grant's record; grants never count toward the
-  last-device rule. (AUTH-5)
-- **GR-13 (round monotonicity).** Issue, revoke, revoke-all, and every
-  grant call strictly increase `round`. (INV-7)
-- **GR-14 (key validity).** Every grantee key is rejected at every use
-  by exactly the per-arm checks of section 3.3 (k1: the point at
-  infinity in either encoding; v1: the identity and the 8-torsion; r1:
-  the schemes MIP's signature-side checks), and the authoriser rejects
-  the same at issuance; on-curve membership is `[CIRCUIT]` and is added
-  to the seam if the runtime does not enforce it. (authorisation MIP S2;
-  erratum 6)
-- **GR-15 (bounded disclosure).** A grant call discloses `grant_id`, the
-  record update, the kernel comparison argument, and the custody chip's
-  disclosures, and never the grantee key, origin, slot, salt, openings,
-  or signature; no grant field records any part of a held coin's
-  description in the clear; the running total is a commitment. (INV-2;
-  grant-side analogue of AUTH-9 per the companion erratum)
-- **GR-16 (consent equals record).** Every plaintext scope field is an
-  argument of `issue_grant` and enters the device challenge through
-  `scope_digest`; the consent surface renders from those fields and from
-  a possession-and-origin-proven request; consent precedes the ceremony
-  that produces signing material; the approver's signature authorises
-  exactly the scope written, and the record's grantee is a commitment
-  the authoriser computed, which the dApp verifies on return.
-- **GR-17 (redirect binding).** The authoriser acts only on a request
-  whose possession proof verifies, whose `aud` names it, whose validity
-  window is current and whose `nonce` is unseen, whose `redirect_uri` is
-  same-origin with the attested `client_id` and matched exactly on
-  return, and whose `state` it echoes verbatim; the binding is chosen
-  by the transport, never by the `client_id` form; it never redirects
-  to a target that failed those checks; the response carries no bearer
-  artefact, key list, or account list; the dApp treats its grant as
-  live only after recomputing `grant_id` and reading the record from
-  chain state. (RFC 9700 sections 2.1, 4.1.3, 4.10; RFC 9207)
-- **GR-18 (read is a capability, and it is total).** `read` is
-  declarative; the ledger does not enforce a read scope; a grant with
-  `read` confers the account's whole viewing capability over current and
-  future shielded holdings until rotation, which is the coarsest scope
-  the standard admits; the viewing secret is delivered sealed to a bound
-  `read_pk` and never in cleartext; rotate-before-share precedes every
-  read issuance; a client honouring a read revocation MUST rotate
-  `enc_key` and re-encrypt; an inbox reader MUST verify each entry's
-  coin against chain data before trusting it. (custody MIP R9, S2,
-  section 6.5)
-
-### 13. Companion erratum to MIP-0013 section 9
-
-This MIP does not reinterpret any invariant of the authorisation MIP's
-section 9 per authoriser class; that MIP's section 4 says an extension
-MUST NOT weaken them. Three invariants are, as written, falsified by any
-grant twin, so this MIP proposes one companion erratum whose acceptance
-by the editors is an acceptance criterion `[RULING]` `[CRYPTO]`:
-
-- **AUTH-1** to read: "Every seam-gated circuit verifies a signature per
-  sections 4 and 5 against an authoriser credential active in the
-  current epoch: a device entry, or a grant record whose scope admits
-  the call, as defined by an instantiating policy standard; no gated
-  circuit proceeds on any other authority."
-- **AUTH-2** to read: "Every device-authorised gated call covers and
-  increments `auth_nonce`. A policy standard defining another authoriser
-  class MUST define its own contract-held freshness element that no
-  other class can advance, MUST cover and advance it on every call, and
-  MUST NOT advance `auth_nonce`."
-- **AUTH-9** to gain the scope clarification: "This invariant governs
-  device handles. A grant identifier is not a device identifier; the
-  account address in a preimage satisfies the cross-account clause; an
-  instantiating policy standard MAY define a stable per-grant
-  identifier, subject to a stated hiding argument." GR-15 is then the
-  grant-side analogue rather than an exception a MIP grants itself.
-
-Widening the authorisation MIP's definition of "device" to cover
-grantees is rejected: it would let a grant count toward `device_count`
-and weaken AUTH-5. The authorisation MIP's conformance tests that are
-device-only under this MIP are its items 1 to 9 as they stand; item 2
-(the rejection matrix) and item 5 (deposit independence) gain grant-side
-counterparts in the Testing section here.
+| Id | Normative statement | Upstream |
+|---|---|---|
+| GR-1 (single seam, closed operation set) | Every grant-authorised operation is verified inside the account contract by the grant seam, which exists only as the grant twins of the three withdraw circuits. | INV-1 |
+| GR-2 (authority disjointness) | Grant keys are looked up only in `grants` under grant tag families; no credential satisfies both a device seam and a grant seam; an authoriser refuses to issue a grant to a key enrolled as a device of the same account. | SIG-1 |
+| GR-3 (contract-maintained identity) | `grant_id` is a deterministic commitment to `(account, arm, key, [envelope,] origin_hash, slot)` recomputed in-circuit at every use; one tuple has at most one live record; a key's records at one origin number at most 256 and are enumerable; only device-gated circuits create, retire, or re-scope a record; a grant twin writes only its own record's `nonce` and `spent_commit`. | |
+| GR-4 (full binding) | Every grant challenge covers the account address, the per-operation tag, the grantee key, `grant_id`, `issued_at`, every operation argument, every consumed witness value, and the record's `nonce`; every private argument is pinned by equality against the record or the ledger. | AUTH-3, AUTH-10, SIG-2, custody S5 |
+| GR-5 (per-grant single use, owner liveness) | Every grant call binds the record's `nonce` as read from state and advances it; identical resubmission fails; grant calls never read or advance `auth_nonce`. | AUTH-2 as amended |
+| GR-6 (incarnation isolation) | Every grant-call challenge and the sign-in message bind `issued_at`, so a signature against one issuance of an id verifies against no other. | |
+| GR-7 (in-circuit scope over consumed values) | Operation flag, the color and value of the coin actually consumed, the caps, the recipient pin, `expires_at`, `active`, `epoch`, `gen`, and `enc_key` equality are asserted before any custody chip executes; an out-of-scope call fails at proving or verification, never at application discretion. | |
+| GR-8 (contract-derived lifecycle fields) | `epoch`, `gen`, `issued_at`, and the commitments are written by the contract from ledger state and the plaintext the approver signed; no grant can be pre-planted for a future epoch or generation. | |
+| GR-9 (kill totality) | After a `device_epoch` or `grant_generation` bump no grant recorded under a previous value authorises anything. | AUTH-6 |
+| GR-10 (chain-verifiable status) | `active`, `epoch`, and `gen` are public state; revocation is effective from the including block; the status of a known record is verifiable from chain alone; the grantee's identity is held in the owner's roster (7.5). | |
+| GR-11 (no widening) | A record's scope is immutable after issue; modification is revoke then issue under fresh device authorisation; the approver may narrow and never widen. | |
+| GR-12 (owner-only lifecycle, non-interference) | The lifecycle circuits are device-gated; a grant call changes no device entry, `device_count`, `auth_nonce`, `enc_key`, or any other grant's record; grants never count toward the last-device rule. | AUTH-5 |
+| GR-13 (round monotonicity) | Issue, revoke, revoke-all, and every grant call strictly increase `round`. | INV-7 |
+| GR-14 (key validity) | Every grantee key is rejected at every use, and at issuance, by exactly the per-arm checks of section 3.3, including the identity key on every arm and SEC 1 validation on `r1`. | authorisation MIP S2 and its erratum 6 on weak device keys |
+| GR-15 (bounded disclosure) | A grant call discloses `grant_id`, the record update, the kernel comparison argument, and the custody chip's disclosures, and never the grantee key, origin, dApp host, slot, salt, openings, or signature; no grant field records any part of a held coin's description in the clear. | INV-2; AUTH-9 as amended |
+| GR-16 (consent equals record) | Every plaintext scope field is an argument of `issue_grant` and enters the device challenge through `scope_digest`; consent renders from those fields and a possession-and-origin-proven request and precedes the ceremony that produces signing material; the dApp verifies the recorded grantee on return. | |
+| GR-17 (redirect binding) | The authoriser acts only on a request whose possession proof shows a credential on the requesting origin, whose `aud` names it, whose window is current and `nonce` unseen, whose `redirect_uri` is same-origin with the attested `client_id` and matched exactly, and whose `state` it echoes; the binding is chosen by the transport; the response carries no bearer artefact or key list; the dApp treats its grant as live only after recomputing `grant_id` and reading the record from chain. | RFC 9700 sections 2.1, 4.1.3, 4.10; RFC 9207 |
+| GR-18 (read is a capability, and it is total) | `read` is declarative and the ledger does not enforce a read scope; a grant with `read` confers the whole viewing capability until rotation; the secret is delivered sealed to a bound `read_pk`; rotate-before-share precedes every read issuance and every rotation re-seals or flags the other live read grants; a read revocation rotates `enc_key`; every inbox reader verifies each entry against chain data. | custody MIP R9, S2, section 6.5 |
 
 ### 14. Versioning
 
-- **Document.** This specification is versioned by its MIP number and
-  revision history; substantive changes after acceptance require a new
-  MIP that lists this one in `Replaces`. It extends the custody MIP and
-  the authorisation MIP and supersedes neither.
+- **Document.** Versioned by its MIP number and revision history;
+  substantive changes after acceptance require a new MIP listing this
+  one in `Replaces`. It extends the two parent MIPs and supersedes
+  neither.
 - **Contract schema.** Grant-capable accounts expose `spec_version = 2`.
-  New cells and structs are a redeploy; twins, lifecycle circuits, pure
-  derivations, and tag families are maintenance updates while the
-  authority is live, and the grant circuits MUST be in the
-  `spec_version = 2` wave plan with retirement after the last wave
-  (section 6.6). Enabling the window bounds later is a circuit revision
-  (`:v2` twins), not a redeploy.
+  New cells and structs are a redeploy (Backwards Compatibility
+  Assessment); twins, lifecycle circuits, pure derivations, and tag
+  families are maintenance updates while the authority is live, under
+  the wave rule of section 6.7. A flattened `GrantRecord` layout, if
+  adopted, takes its own `spec_version`. Enabling the window bounds later
+  is a circuit revision (`:v2` twins), not a redeploy.
 - **Scheme.** A grant scheme is a new tag prefix under the authorisation
   MIP section 10's "policy structure" clause, with `grant` as the
-  policy-structure segment and the arm marker in the position the
-  registry pattern expects; a revision of any construction is a new
-  trailing version segment. Registry status: the JubJub grantee arm
-  Active; `k1` Interim with the schemes MIP's sunset, envelope-1
-  grantees `read`-only; `r1` Active upon `[DEP]`; `schnorr_bip340`
-  registered as pending upstream point operations. No new envelope id.
-- **Tag families**, all to be registered under the MPS-0027 registry
-  (an acceptance criterion):
+  policy-structure segment; a revision of any construction, including
+  the `scope_digest` and `args_digest` fallbacks, is a new trailing
+  version segment. Registry status: `v1` Active; `k1` Interim with the
+  schemes MIP's sunset, envelope-1 grantees `read`-only; `r1` Active
+  upon the schemes MIP receiving a number and the secp256r1 surface
+  shipping; `schnorr_bip340` reserved. The registry entry records the
+  pinned block-time unit and which layout and preimage variant is in
+  force.
+- **Tag families**, all to be registered under the MPS-0027 registry (an
+  acceptance criterion):
 
   | Family | Convention | Members |
   |---|---|---|
   | `midnight:account:grant:id:{v1,k1:v1,r1:v1}` | raw 32-byte pad, tuple element | identity preimage |
-  | `midnight:account:grant:obj:v1`, `midnight:account:grant:spent:v1`, `midnight:account:grant:scope:v1` `[RULING]` | raw 32-byte pad, tuple element | commitments and the scope digest |
-  | `midnight:account:grant:auth:{v1,k1:v1,r1:v1}:<operation>` | hashed from a 64-byte pad (`persistentHash<[Bytes<64>]>`) | per-twin DST; the longest member is 63 of 64 bytes, so the 64-byte width is a normative budget on operation names |
-  | `midnight:account:auth:{v1,k1:v1}:{issue_grant,revoke_grant,revoke_all_grants}` | the existing device family; the `k1` family version is verified against the reference before publication | lifecycle DSTs |
-  | `midnight:account:grant:origin:v1` | raw 32-byte pad prefixed to the bytes hashed (off-chain) | `origin_hash` |
-  | `midnight:account:grant:request:v1` | raw 64-byte pad prefixed to a hash (off-chain) | `request_digest` |
-  | `midnight:account:grant:signin:v1` | raw 64-byte pad prefixed to a hash (off-chain) | sign-in digest |
-  | `midnight:account:grant:view:v1` | ASCII HKDF `info` | GrantViewSeal |
+  | `midnight:account:grant:{obj,spent,rp,scope}:v1` | raw 32-byte pad, tuple element | commitments and the scope digest |
+  | `midnight:account:grant:auth:{v1,k1:v1,r1:v1}:<operation>` | hashed from a 64-byte pad | per-twin DST; the 64-byte width is a normative budget on operation names |
+  | `midnight:account:auth:{v1,k1:v1}:{issue_grant,revoke_grant,revoke_all_grants}` | the existing device family (the `k1` auth family stayed at `:k1:v1` when the device and boot families moved to `:k1:v2`; verified against the reference before publication) | lifecycle DSTs |
+  | `midnight:account:grant:{origin:v1,request:v1,signin:v1}` | raw pad prefix at the width that fits (32, 64, 64), off-chain | `origin_hash`, `request_digest`, `signin_digest` |
+  | `midnight:account:grant:{view,read}:v1` | ASCII HKDF `info` and PRF input | GrantViewSeal; `read_pk` derivation |
 
-  The rule fixing conventions: on-chain tuple elements use raw 32-byte
-  pads (the device-entry convention); per-circuit DSTs are hashed from
-  64-byte pads (the auth convention as amended by the authorisation
-  MIP's first erratum); off-chain digests use a raw pad prefix at the
-  width that fits; HKDF `info` is ASCII.
 - **Containers.** GrantViewSeal carries its own leading version and
-  suite bytes; readers MUST skip unknown values rather than treat them
-  as errors, as the custody MIP requires of InboxEntry.
+  suite bytes; readers MUST skip unknown values rather than treat them as
+  errors, as the custody MIP requires of InboxEntry.
 - **Request.** `v` in the `GrantRequest`; unknown versions fail with
   `unsupported_version`.
 
-### 15. Open items
-
-| Id | Tag | Item | Current default in this text |
-|---|---|---|---|
-| O1 | `[RULING]` | external co-author | named before the PR is opened; the offer in the upstream scoped-grant discussion answered first |
-| O2 | `[RULING]` | Shape B redeploy shared with the erratum-8 device-identity remedy | one `spec_version = 2` bump carrying both |
-| O3 | `[RULING]` `[CRYPTO]` | companion erratum to AUTH-1, AUTH-2, AUTH-9 (section 13) | the three wordings given; widening "device" rejected |
-| O4 | `[RULING]` | dApp-chosen `slot` in the identity; request `nonce` bound only in `request_digest` | adopted |
-| O5 | `[RULING]` | `issued_at` incarnation ordinal in the challenge rather than nonce continuity | adopted; re-issue resets `nonce` and `spent_commit` |
-| O6 | `[RULING]` | wire scheme names (section 3.4) | connector strings where they exist; `schnorr_jubjub`, `ecdsa_secp256r1_webauthn` filed into the registry |
-| O7 | `[RULING]` | binding chosen by transport; key-only proofs excluded from the browser binding | adopted; `.well-known` metadata an optional `[DEP]` extension, not v1 |
-| O8 | `[RULING]` | rotate-before-share on read grants | MUST; SHOULD only if the per-coin cost is judged prohibitive |
-| O9 | `[RULING]` | reserved window columns in v1 | yes (about 48 bytes per grant) |
-| O10 | `[RULING]` | owner recovery of plaintext origin and grantee | client roster MUST, reconciled on every account view; `origin_hint` a MAY with its leak stated |
-| O11 | `[RULING]` | request and response in the fragment, JCS object in one parameter | adopted |
-| O12 | `[RULING]` | no dApp-supplied display strings on consent, including color names | forbidden; hex always; one named registry source MAY add a name |
-| O13 | `[RULING]` | sign-in scope | grant-backed, address-disclosing only; `signin` reserved for the sign-in MIP |
-| O14 | `[RULING]` | one MIP or two | one MIP under MPS-0018; the split offered in the PR body |
-| O15 | `[RULING]` | wait for inclusion before redirecting | SHOULD; `pending` with `tx` as the fallback |
-| O16 | `[RULING]` | tombstone pruning and window enforcement | both deferred to a circuit revision |
-| O17 | `[RULING]` | salted commitments versus clear fields with an INV-2 carve-out erratum | commitments |
-| O18 | `[RULING]` | `max_coin_value` and atomic change backfill; no standalone `append_inbox` twin | adopted; bounded standalone twin is the fallback |
-| O19 | `[RULING]` | envelope-1 grantees restricted to `read` in v1 | restricted |
-| O20 | `[RULING]` | batch issuance in one ceremony | yes; sequential submission if composition fails |
-| O21 | `[RULING]` | `self:` grantee form | admitted in the non-browser binding |
-| O22 | `[RULING]` | device-removal cascade to grants | no contract cascade; client MUST compose `revoke_all_grants` with a compromise removal |
-| O23 | `[RULING]` | MIP-0015 in `Requires` or informative | informative |
-| O24 | `[RULING]` | `scope_digest` tag family (added by this draft) | `midnight:account:grant:scope:v1` |
-| D1 | `[DEP]` | secp256r1 in the Compact language surface (`r1` arm) | `r1` registered, Active upon delivery |
-| D2 | `[DEP]` | secp256k1 point operations upstream (`schnorr_bip340`) | reserved |
-| D3 | `[DEP]` | connector structured-display surface (envelope-1 spend) | envelope-1 `read`-only |
-| D4 | `[DEP]` | WebAuthn PRF availability in target browsers | PRF-derived `read_pk` for browser grantees |
-| D5 | `[DEP]` | Open Wallet Standard handshake capability flag and mapping-table acceptance; CAIP-10 for Midnight | asked; `accounts` member illustrative |
-| C1 | `[CIRCUIT]` | nested struct as a `Map` value | flattened fallback changes no wire form |
-| C2 | `[CIRCUIT]` | `Boolean` in a hash tuple; `scope_digest` arity | flags as single bytes; two-stage fallback |
-| C3 | `[CIRCUIT]` | challenge tuple arity above ten | `args_digest` fallback |
-| C4 | `[CIRCUIT]` | `JubjubPoint` byte layout; integer serialisation in recipes | published with vectors; little-endian at type width |
-| C5 | `[CIRCUIT]` | on-curve membership of witness points | assertion added if the runtime does not enforce it |
-| C6 | `[CIRCUIT]` | on-chain unit of `kernel.blockTimeLessThan` | pinned before Draft leaves; recorded in the registry entry |
-| C7 | `[CIRCUIT]` | precomputability of the change description | bounded standalone twin fallback |
-| C8 | `[CIRCUIT]` | map reset primitive availability | optional hygiene only |
-| C9 | `[CIRCUIT]` | lifecycle bodies compile with guarded lookups; composition of revoke plus issue and of batch issuance in one transaction | conformance items |
-| C10 | `[CIRCUIT]` | every cost and deploy-budget figure of section 6.6 | to be measured |
-| K1 | `[CRYPTO]` | hiding argument for `grant_id` and the salted commitments | per-connection key entropy; public keys stated as linkable |
-| K2 | `[CRYPTO]` | transitive binding of openings through `grant_id` (GR-4) | fallback binds them directly |
-| K3 | `[CRYPTO]` | `issued_at` incarnation argument (GR-6) | every issuance is a distinct credential |
-| K4 | `[CRYPTO]` | companion-passkey binding of a software key; off-chain key-prefixed Schnorr form | as section 9.2 |
-| K5 | `[CRYPTO]` | GrantViewSeal suite, PRF-to-X25519 derivation, low-order rejection | as section 8 |
-| K6 | `[CRYPTO]` | negative statement on fork replay | no cell defeats it |
-
 ## Rationale
 
-**R1. A second authoriser class behind the same seam, not a wider
-"device", not a separate verifier, not a sender witness.** The custody
-MIP's INV-1 admits exactly one gate, so a grant must be a way to
-satisfy `require_authorised()` and not a parallel mechanism. Three
-shapes were available. Widening "device" to cover grantees would make a
-grant count toward `device_count` and weaken AUTH-5, and would put a
-full-authority credential class and a bounded one in the same set. A
-separate verifier contract would need the authenticated caller identity
-MPS-0029 records Compact does not have. Authenticating the grantee by a
-sender witness is the `ownPublicKey()` pattern the custody MIP section
-4 forbids and the pattern the upstream private-mandate proposal uses
-(R13). The remaining shape, a distinct record class verified inline in
-the account by grant twins that call a grant seam chip where device
-twins call the device chip, is what the account-custody prototype
-evidenced on a devnet node for cap, color, tombstone, and epoch
-enforcement, and what all five candidate designs converged on. Its
-price is a doubled twin count for the three spend circuits; merging
-device and grant twins into one circuit was rejected because a circuit
-conditional is a select that evaluates both sides, doubling the cost of
-every call to hide the authoriser class from an observer who can read
-the record anyway.
+**R1. A second authoriser class behind the same seam.** The custody
+MIP's INV-1 admits exactly one gate, so a grant must be a way to satisfy
+`require_authorised()`. Widening "device" would make a grant count
+toward `device_count` and weaken AUTH-5; a separate verifier contract
+would need the caller identity MPS-0029 records Compact lacks; a sender
+witness is the `ownPublicKey()` pattern the custody MIP section 4
+forbids. The remaining shape, a distinct record class verified by grant
+twins calling a grant seam chip where device twins call the device chip,
+is what the account-custody prototype evidenced on a devnet node.
+Merging device and grant twins was rejected: a circuit conditional
+evaluates both sides and would double every call's cost.
 
-**R2. An explicit map with a contract-recomputed identity, not a
-rolling-entry register and not entries in the device set.** The
+**R2. An explicit map with a contract-recomputed identity.** The
 authorisation MIP's erratum 8 was proven on-node: a register keyed by an
 opaque, client-derived commitment cannot enforce "one credential, one
-live record", because a device that enrols a second entry for its own
-key survives revocation. A grant register must not reproduce it. The
-alternatives compared:
+live record". The alternatives:
 
-| Shape | Enumerable by owner | Targeted revocation | Reaches `spec_version = 1` accounts | Erratum 8 | AUTH-9, INV-2 |
-|---|---|---|---|---|---|
-| Rolling single-use entries in a `Set` | no | races an active grantee indefinitely | by maintenance update | avoided | complete |
-| Grant entries in `devices` | no | as devices | by maintenance update | inherited wholesale; drifts `device_count` | as devices |
-| Grantee key stored in the record | yes | yes | no | avoided | publishes a stable grantee pseudonym; breaks the cross-account claim |
-| Contract-maintained grantee set plus `revoke_grantee` | yes | yes | no | avoided | set member dictionary-testable by anyone holding the public key |
-| Explicit `Map<Bytes<32>, GrantRecord>` keyed by a contract-recomputed `grant_id` (this MIP) | yes, by id | yes, instant | no | avoided: one live record per `(key, origin, slot)` is a contract rule | stable per-grant pseudonym hiding in key entropy; no coin material |
+| Shape | Enumerable | Targeted revocation | Erratum 8 | AUTH-9, INV-2 |
+|---|---|---|---|---|
+| Rolling single-use entries in a `Set` | no | races the grantee | avoided | complete |
+| Grant entries in `devices` | no | as devices | inherited; drifts `device_count` | as devices |
+| Grantee key stored in the record | yes | yes | avoided | stable grantee pseudonym |
+| Contract-maintained grantee set | yes | yes | avoided | set member dictionary-testable |
+| `Map` keyed by a contract-recomputed `grant_id` (this MIP) | by id | instant | one live record per `(key, origin, slot)` | per-grant pseudonym hiding in key entropy |
 
-The rolling-set design is the accumulator extension the authorisation
-MIP's S4 already permits and is recorded here as the privacy-preserving
-successor for call count and status, with its cost: the register is not
-enumerable, the shielded-implies-read rule cannot be asserted at issue
-because the entry arrives opaque, and revocation chases a grantee that
-keeps rolling. Contract-written `epoch` and `gen` mean erratum 7's
-pre-planting has no grant analogue. In-circuit derivation of `grant_id`
-inside `issue_grant` was rejected: it costs a device-arm times
-grantee-arm product of issue circuits (four today, six with r1) against
-a deploy budget that is already waved, and it does not remove the
-authoriser's trust position, since during the ceremony the authoriser
-holds the derived device key and could sign any device-gated challenge;
-the testable mitigations (the dApp reproduces the fingerprint and treats
-a `grant_id` mismatch as compromise) are adopted instead.
+The rolling set is the privacy-preserving successor for call count and
+status. Contract-written `epoch` and `gen` mean erratum 7's pre-planting
+of an entry for a future epoch has no grant analogue. In-circuit
+derivation of `grant_id` inside `issue_grant` was rejected: it
+multiplies the issue circuits by the grantee arms, and the authoriser
+holds the derived device key during the ceremony anyway; the dApp's
+recomputation of `grant_id` is the adopted mitigation.
 
-**R3. A bounded `slot`, not a 32-byte request nonce, in the identity.**
-An earlier shape bound a dApp-chosen nonce into `grant_id`. Three
-findings removed it. A dApp-chosen unbounded nonce let one key hold
-arbitrarily many live records the owner could not enumerate or
-attribute, so revoking one left the key operating under the others,
-which is erratum 8 in a new register. With the nonce as the only
-non-public element of the preimage it became a capability secret
-carried in URL fragments and browser history. And the role it served
-for the dApp ("recompute the id of the grant I asked for") is served by
-key, origin, and slot. A one-byte slot keeps several grants per key (a
-multi-color dApp) while making all of a grantee's records enumerable in
-at most 256 lookups; the request nonce survives as a one-time request
-identifier bound only in `request_digest`. The consequence is stated
-plainly: no secret lives in the identity, so grant security rests on
-the grantee signing key alone, and for a publicly known key the
-dictionary test on `(key, origin, account)` is trivially answerable.
+**R6. Salted commitments, not clear fields with an INV-2 carve-out.**
+The custody MIP section 6.1 forbids writing a held coin's color or
+value, in whole or in part, into public state, and a shielded spend's
+amount is not public today. A clear `spent` delta would publish each
+output coin's value, a clear `color` a color the account holds, a clear
+`ZswapCoinPublicKey` pin a counterparty, and an unsalted host hash every
+browser connection, since host names are a small dictionary. A
+successor cannot weaken an invariant, and the commitment design costs
+the seam only the rolling-commitment shape the device seam already pays.
+An "any color" sentinel makes the cap dimensionless; a recipient set is
+not expressible in a struct field.
 
-**R4. A per-grant nonce read from state, not the shared `auth_nonce`
-and not a nonce argument.** The authorisation MIP's R4 chose a dedicated
-`auth_nonce` so that permissionless deposits could not invalidate a
-pending device signature. A grantee that could advance `auth_nonce`
-would reintroduce the same interference against the owner: it could
-race and void the owner's signed-but-unsubmitted authorisations, and a
-threshold device's signing ceremony would be griefable by any connected
-dApp. The record's own `nonce` is the freshness element, and it is read
-from ledger state inside the circuit exactly as the device arms read
-`auth_nonce`. An earlier step list hashed a free caller-supplied nonce
-and advanced a counter nobody compared, so one signature would have
-replayed until the cap was exhausted; a `grant_nonce` argument asserted
-equal to the record would have been equivalent in effect, but a dead
-argument invites exactly the omission that review found, and the
-read-from-state pattern already exists in the reference.
+**R9. Origin by browser attestation.** Browsers send no `Origin` header
+on a top-level GET and `Referer` is suppressed by `no-referrer`. A
+plaintext origin on chain would publish every connection; the record
+holds the origin only inside the `grant_id` preimage beside a
+per-connection key and, for r1, inside a salted commitment. Fetched
+`.well-known` metadata adds a network and cross-origin resource sharing
+(CORS) dependency to consent and is the recorded extension. Passkeys are
+relying-party scoped, so a passkey registered for the dApp is a second
+credential on the dApp origin with a P-256 key, hence `r1` is the
+first-class arm; until secp256r1 ships, a companion passkey attesting
+the origin over a digest that covers a software key is the only
+construction on today's toolchain. A key-only proof with a
+"self-asserted" label was rejected because a user shown it will click
+approve. The authoriser performs the write because a dApp-performed
+write would make the dApp balance fees at connect time, tie the artefact
+to `auth_nonce`, and put a proven transaction in a URL fragment.
 
-**R5. `issued_at` as an incarnation ordinal, not nonce continuity across
-tombstones.** Re-issue over a tombstone raises the question of whether
-an unsubmitted grantee signature at the inherited nonce could verify
-against a re-issue whose scope admits the same arguments. Nonce
-continuity (the re-issue inherits the tombstone's counter) leaves that
-narrow residual; never re-using an id forces a slot change on every
-re-issue; binding a contract-written `issued_at` (the `auth_nonce`
-observed inside `issue_grant`, unique per issuance because `auth_nonce`
-strictly increases on every gated call) closes it at the cost of one
-field the dApp reads alongside `nonce` anyway, and it turns the
-cryptographic claim into "every issuance is a distinct credential",
-which also frees a later revision to prune tombstones without a
-high-water mark. Simplicity dissent is recorded; dApps additionally
-SHOULD choose a fresh slot on re-issue where one is free, which yields a
-new identity and makes the question moot on the normal path.
+**R11. Read as the sealed viewing capability.** A WebAuthn credential
+never performs a key agreement, so a separate X25519 `read_pk`,
+PRF-derived for browser grantees, is the only construction every grantee
+can operate. A per-coin mirror leaves later deposits invisible and hides
+the grantee's own change; it is the direction of the custody MIP's R9
+successor. Proxied reads put an operator on the read path; a sealed blob
+on chain was rejected because silent reconnect delivers the same
+portability at no schema cost. Rotate-before-share is a MUST because the
+blast radius is otherwise the account's whole history.
 
-**R6. Salted commitments for `color`, the recipient pin,
-`max_coin_value`, and `spent`, not clear fields with an INV-2
-carve-out.** The custody MIP section 6.1 forbids writing a held coin's
-color or value, in whole or in part, into public ledger state, and a
-shielded spend's amount is not public today (the disclosures inside the
-shielded withdraw chip feed the send path's commitment arithmetic, not
-the clear transcript). A public `spent` delta would publish the exact
-value of each output coin, a public `color` would name a color the
-account holds shielded, and a public `ZswapCoinPublicKey` pin would
-publish a counterparty the send path hides. The alternative, clear
-fields plus a companion erratum quantifying the leak as color, per-call
-value, cumulative value, and optionally counterparty, is recorded with
-its cost `[RULING]`; it was not taken because the custody MIP's own rule
-does not let a successor weaken an invariant, and because the
-commitment design costs the seam only the rolling-commitment shape the
-device seam already pays (two hashes per call: open and re-commit).
-What the commitment design costs the owner and the grantee is the salt,
-a readability key: losing it costs the ability to read the record's
-commitments, never authority. The observer still learns caps, expiry,
-and call count, which the consent screen says. An "any color" sentinel
-was rejected because it makes the cap dimensionless; a recipient set is
-not expressible in a struct field; a `spent` commitment with a range
-proof and a decremented `remaining` in a rolling entry are recorded as
-alternatives not taken.
+**R13. Positioning.** The upstream private-mandate proposal standardises
+a delegation record of the same shape, but authenticates its agent by a
+sender witness and attaches to an admin-overwritten balance rather than
+custodied assets; it can adopt a grant as its authority object. The dApp
+connector and the Open Wallet Standard are wallet-side and ephemeral;
+this MIP sits above them as the ceremony a user approves once and below
+them as the object their signatures target, and reuses their vocabulary.
+MIP-0015's `deriveSecret` is seed-anchored and a seedless account cannot
+satisfy it.
 
-**R7. `max_coin_value` and an atomic change backfill, not a standalone
-`append_inbox` grant twin.** INV-4 puts the change entry on the spending
-client, which under a grant is the grantee, and the change description
-travels only in the communication commitment. A grantee that never
-backfilled would silently orphan the account's change, bounded only by
-the coin it selected. An earlier shape gave the grantee a gated
-`append_inbox` twin; it wrote unbounded 192-byte entries under a
-no-value scope that neither cap bounds, and the shielded-implies-append
-rule made that authority unrevocable separately from the spend scope.
-With the change entry as an argument of the shielded twins, bound in
-the challenge and appended in the same circuit, the reason for the twin
-is gone; `max_coin_value` bounds the value at risk from the coin the
-grantee selects and puts that number on the consent screen. A garbage
-entry remains possible and is detected by the owner's discovery walk,
-which verifies each candidate against chain data.
-
-**R8. The authoriser performs the write, not the dApp.** A dApp-performed
-on-chain write after the return leg departs from the user brief, makes
-the dApp balance fees and submit a device-proven transaction at connect
-time, ties the artefact's life to `auth_nonce` (any owner call in
-between voids the ceremony), and puts a proven transaction of
-unmeasured size (a bare proof is already 4,064 bytes) in a URL
-fragment. Grant injection is closed by the origin-attested possession
-proof, not by who submits, so the authoriser keeps the write, which is
-the brief verbatim and keeps the dApp integration to "redirect, return,
-read chain". The dApp-performed write is recorded as the alternative
-for origin-blind keys.
-
-**R9. Origin by browser attestation, not by HTTP headers, not by a
-plaintext origin on chain, not by fetched client metadata.** Browsers
-send no `Origin` header on a top-level GET and `Referer` is suppressed
-by the `no-referrer` policy this MIP mandates, so an HTTP-header origin
-binding for software keys is empty. A plaintext origin in the record
-would publish every connection an account has to every observer; the
-record holds a commitment inside a preimage that also contains a
-per-connection key, and this MIP states that chain-side origin
-enforcement does not exist. TLS-fetched `.well-known` client metadata
-would add a network dependency and a CORS requirement to consent and is
-recorded as an optional `[DEP]` extension for browser clients without
-WebAuthn. Because passkeys are RP-scoped, the "passkey registered for
-this dApp" of the user brief is necessarily a second credential on the
-dApp origin, and its key is P-256, so the first-class arm is `r1`;
-until the secp256r1 surface ships, a companion passkey on the dApp
-origin attesting the origin over a digest that covers a software key is
-the only construction on today's toolchain that closes NEAR's
-grant-injection defect for a software key. A key-only proof admitted in
-the browser binding with a "self-asserted" label was rejected because a
-user shown that label will click approve.
-
-**R10. One JCS object in the fragment, not loose query parameters.**
-Loose query strings with "sorted by name, percent-encoded" rules are a
-classic source of signature-verification divergence; RFC 8785 is a
-published canonicalisation. A single `request` parameter is also
-simpler for a developer than fifteen loose parameters plus a
-canonicalisation rule. Fragment transport on both legs keeps `state`,
-`pk`, `grant_id`, `account`, and the sealed viewing secret out of server
-logs and the `Referer` header and is compatible with a static
-authoriser page; it does not keep them out of browser history, session
-restore, profile sync, or an extension with host permissions, so both
-sides strip the fragment on load and Security Considerations name the
-residual. The developer-simplicity dissent for loose parameters is
-recorded.
-
-**R11. Read as the sealed viewing capability, not HPKE to the signing
-key, not a per-coin mirror, not a proxied read.** A WebAuthn credential
-signs and never performs a key agreement, so sealing to the grantee
-signing key is infeasible for the target grantee; a separate X25519
-`read_pk`, PRF-derived for browser grantees, is the only construction
-every grantee can operate. A per-coin mirror (re-encrypting each held
-coin to the grantee) costs a device-gated inbox write per coin, leaves
-later deposits invisible until re-mirrored, and hides the grantee's own
-change from it, so the brief's wallet-like dApp is not served by it; it
-is the direction of the custody MIP's R9 successor and is recorded as
-such. Proxied reads through the authoriser put an operator on the read
-path and are a step toward the authoriser becoming a wallet. A sealed
-blob stored on chain was rejected because silent reconnect to the bound
-`read_pk_hash` delivers the same portability at no schema cost.
-Rotate-before-share is a MUST because the blast radius is otherwise the
-account's whole history, at the cost of one gated call plus one inbox
-entry per held coin. Reusing InboxEntry's version and suite numbers
-literally for the seal was rejected because a different length,
-plaintext, and `info` under the same numbers invites mis-parsing by
-readers that skip on unknown values.
-
-**R12. Grant-backed sign-in, not an identity-only grant, and not a
-VRF.** Verifying liveness against a per-account contract requires
-naming the contract; address-hiding sign-in is a membership proof over
-an accumulator of accounts or an authoriser-signed pairwise pseudonym
-that puts an identity provider on the sign-in path, and both belong to
-the sign-in MIP. An identity-only on-chain grant costs a transaction and
-a tombstone and discloses an address for plain login, so it is
-rejected; a read-only grant is not identity-only, because its record
-anchors a capability. The objection raised against the authorisation
-MIP, that a VRF-based identity should replace signature verification,
-applies here with the same answer: the grantee credentials this MIP
-targets are passkeys and hardware or vaulted signers, which produce
-signatures and nothing else, and the WebAuthn origin attestation that
-closes grant injection is a property of a signature ceremony.
-
-**R13. Positioning against the upstream private-mandate proposal, the
-connector, and MIP-0015.** The private-mandate proposal standardises a
-capability-scoped, value-capped, expiring, revocable delegation record,
-which is the same shape as this grant, but its agent is authenticated by
-a sender witness (the pattern the custody MIP section 4 forbids), its
-payment is bearer by hash, its vault balance is an admin-overwritten
-integer rather than custodied assets, and it attaches to no custody
-seam. This MIP is that record verified behind `require_authorised()`
-over real custody, and the two documents can be reconciled by the
-mandate proposal adopting a grant as its authority object. The dApp
-connector and the Open Wallet Standard are wallet-side, off-chain, and
-ephemeral; this MIP sits above them as the ceremony a user approves
-once and below them as the on-chain object their signatures target, and
-it reuses their vocabulary (scheme strings, the connector prefix as
-envelope `1`, `Rejected` and `PermissionRejected`, `rdns`) rather than
-inventing a parallel namespace. MIP-0015's `deriveSecret` is
-seed-anchored and a seedless account cannot satisfy it; the grantee's
-own per-origin passkey answers the durable-secret need, and MIP-0015's
-consent vocabulary is aligned with informatively rather than imported.
-
-**R14. Connector scheme strings on the wire, not registry short names.**
-Wallets already emit `ecdsa_secp256k1_sha256` and `schnorr_bip340` in
-their `Signature.scheme`, and the reference experiment that validated
-the wallet-key gate asked the registry to adopt them. Two registry
-spellings are proposed for the schemes the connector does not name, with
-one normative mapping table. The dissent for short names with a map to
-connector strings is recorded.
-
-**R15. No `network_id` cell.** A contract address is derived from the
-deploy transaction's content, so two independent deployments already
-differ; addresses collide across networks exactly when the deploy
-content is identical, in which case a constructor argument would be
-identical too and separate nothing. A cell the ledger does not assert
-and a client cannot check against the chain adds nothing a CAIP-2
-string in the client's configuration does not. MIP-0008 is therefore a
-reference, not a requirement; the wire `chain` member stays normative
-for the request, and a state-preserving fork is stated honestly as
-undefeated by any cell.
-
-**R16. One MIP, under MPS-0018.** The grant primitive is the reserved
-extension of two MIPs filed under MPS-0018, and the custody MIP's
-section 2 already names grants in normative language; a fresh problem
-statement would delay this document by an editor cycle and duplicate
-that text. The connection and sign-in flow could be a sibling document;
-the split is offered in the submission if the editors object to dApp
-connection under a libraries-and-tooling problem statement, and the
-unlinkable sign-in mode stays a separate MIP regardless.
-
-**R17. Tombstones kept, lazy expiry, a generation counter for
-revoke-all.** Deletion on revoke removes the enumerability that lets an
-owner reconcile live ids against a roster, and revocation that chases a
-rolling grantee races it; a stable per-grant residue is the price of
-enumerability, and pruning is a revision item. Automatic expiry cleanup
-paid by someone was rejected; in-circuit lazy expiry costs nothing when
-no one calls. The generation counter gives the owner a grant-only kill
-switch the epoch bump (recovery only) does not, without touching
-devices, and carries the safety property so that clearing the map at
-recovery is optional hygiene.
-
-**R18. Envelope-1 grantees read-only.** Stated in section 3.2: a blind
-32-byte signing surface over a challenge whose every element is public
-or attacker-chosen is a signing oracle for any site the user connects
-the same wallet to. Restricting the surface to `read` is the only
-defence available without a secret in the identity preimage, which R3
-deliberately removed; spend waits on a connector surface that renders a
-decoded grant call `[DEP]`.
-
-**R19. No contract cascade from `remove_device` to grants.** A cascade
-would sever every dApp connection on routine device retirement, and a
-removed-but-still-live device calling `revoke_all_grants` is denial of
-service, not theft. The threat model is accepted and carried into a
-client MUST: compose `revoke_all_grants` with a compromise removal,
-because a briefly compromised device can have issued unbounded grants
-to keys it controls. The alternative (`remove_device` bumping
-`grant_generation` internally) is a circuit change with no schema
-change and is `[RULING]`.
-
-**R20. Owner attribution through a client roster, not through
-plaintext on chain.** The user brief says the public key is recorded
-"along with the origin". Recording either in the clear would publish a
-stable grantee pseudonym and every connection of the account. This MIP
-records commitments, and states that an owner holding only chain state
-can revoke by id and revoke all but cannot attribute; a conforming
-client MUST maintain a roster (id, `client_id`, key, `[envelope,]`
-`slot`, `scope_salt`, plaintext scope, re-seals) rebuildable from the
-issuing device and MUST reconcile live ids against it on every account
-view, surfacing any unrecognised live id as possible compromise. An
-optional `origin_hint` sealed under the account encryption secret and
-written at issue is a MAY with its leak stated: every read-granted dApp
-would learn the account's other connections.
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| R3 identity element | one-byte `slot`; request `nonce` bound only in `request_digest` | a 32-byte request nonce in `grant_id` | an unbounded nonce let one key hold records the owner could not enumerate and made the nonce a capability secret in URLs |
+| R4 freshness | the record's `nonce`, read from state | the shared `auth_nonce`; a nonce argument | a grantee advancing `auth_nonce` could void the owner's pending signatures; a dead argument invites the omission of the check |
+| R5 incarnation | contract-written `issued_at` in every challenge | nonce continuity; never reusing an id | closes a pre-revocation signature verifying against a re-issue; every issuance is a distinct credential |
+| R7 change | `max_coin_value`; the change entry as a bound argument appended in the same circuit; `enc_pk == enc_key` | a standalone `append_inbox` twin | the twin wrote unbounded entries under a no-value scope; the equality makes a rotation abort the call rather than orphan change |
+| R10 request transport | one JCS object in the fragment on both legs | loose query parameters | canonical JSON has a published specification; the fragment stays out of logs and `Referer`, not out of history (S19) |
+| R12 sign-in | grant-backed, address-disclosing | an identity-only grant; a verifiable-random-function (VRF) identity | an identity-only grant costs a transaction for plain login; address hiding belongs to the sign-in MIP; the target credentials only sign |
+| R14 wire names | connector spellings plus two registry spellings | registry short names | wallets already emit the connector strings |
+| R15 network | no `network_id` cell; the wire `chain` member | a network cell; MIP-0008 in `Requires` | independent deployments already differ by address; a cell the ledger does not assert separates nothing; the record embeds no network identifier, so MIP-0008 is cited, not required; no cell defeats a state-preserving fork |
+| R16 document shape | one MIP under MPS-0018 | a separate connection MIP | the grant is the reserved extension of two MIPs under MPS-0018; the split is offered if editors object |
+| R17 lifecycle | tombstones kept; lazy expiry; a generation counter; renewal of an expired record is revoke then issue | deletion on revoke; automatic cleanup; an expiry test in `issue_grant` | enumerability needs a residue; a time-dependent `issue_grant` costs a kernel comparison for a transition composition already provides |
+| R18 wallet keys | envelope-1 grantees `read`-only | spend through `signData` | a blind signing surface over a computable challenge is a signing oracle (3.2) |
+| R19 device removal | no contract cascade; the client composes `revoke_all_grants` with a compromise removal | `remove_device` bumping `grant_generation` | a cascade severs every connection on routine retirement |
+| R20 attribution | an owner-side roster (7.5) | key and origin in the clear | either publishes a stable pseudonym and every connection |
 
 ## Path to Active
 
 ### Acceptance Criteria
 
-- [ ] `[RULING]` External co-author named; the offer of a compatible
-      scoped-grant primitive in the upstream discussion answered.
-- [ ] MIP number assigned by an editor; the companion PR appending this
-      MIP to MPS-0018's Recommended MIPs and `MIP:` header merged.
-- [ ] `[RULING]` Editors' acceptance of the companion erratum covering
-      AUTH-1, AUTH-2, and AUTH-9 (section 13).
+- [ ] External co-author named; the offer of a compatible scoped-grant
+      primitive in the upstream discussion answered.
+- [ ] MIP number assigned; the companion PR appending this MIP to
+      MPS-0018's Recommended MIPs merged.
+- [ ] Editors' acceptance of the companion erratum covering AUTH-1,
+      AUTH-2, and AUTH-9 (section 12).
 - [ ] Every tag family of section 14 registered under the MPS-0027
-      registry once it ratifies, including the `scope` family `[RULING]`.
-- [ ] `[CRYPTO]` Independent cryptographer review of: the grant
-      challenge and the `issued_at` incarnation argument; the transitive
-      binding of commitment openings through `grant_id`; the hiding
-      argument for `grant_id` and the salted commitments; the
-      companion-passkey binding of a software key and the off-chain
-      key-prefixed Schnorr form; the GrantViewSeal suite with the
-      low-order rejection and the PRF-to-X25519 derivation; and the
-      negative statement about fork replay; with findings addressed.
-- [ ] `[CIRCUIT]` E1: the grant arm on the reference contract at
-      `spec_version = 2` (`grants`, `grant_generation`, issue, revoke,
-      revoke-all on both device arms, three k256 twins on envelopes `0`
-      and `1`, three jubjub twins), with rows, k, prover-key size, and
-      proving time per twin against the device twins; nested struct or
-      flattened fallback; the absent-key paths of issue and revoke; the
-      tuple arity of the shielded challenges or the `args_digest`
-      fallback; the guarded change append.
-- [ ] `[CIRCUIT]` E2: the negative conformance suite of Testing item 2
-      green on a node, each item ending with the invariants it
-      exercises, including the vacuous-verifier control.
-- [ ] `[CIRCUIT]` E3: the on-chain unit of `kernel.blockTimeLessThan`
-      pinned on a ledger-9 network and recorded in the registry entry;
-      `expires_at` past and future; `0` never expires; a value in the
-      wrong unit as a negative case; boundary behaviour under the
-      transaction validity window.
-- [ ] E4: the redirect ceremony with two distinct origins and two
-      platform passkeys (r1-shaped and companion-passkey proofs), consent
-      before the authorising ceremony, `issue_grant`, return, chain
-      read; a read-only grant; a two-element batch; an account with zero
-      DUST refused with `temporarily_unavailable`; and the attack suite
-      of Testing item 4.
-- [ ] E5: cross-implementation vectors (TypeScript and Rust, the Rust
-      side linking no compiled contract module) for `grant_id` on every
-      arm including the `JubjubPoint` layout, `object_commit`,
-      `spent_commit`, `scope_digest`, every grant challenge,
-      `envelope_digest`, `origin_hash`, `request_digest` over JCS, the
-      sign-in digest, and the sealed viewing secret, bit-identical;
-      `pk` normalisation from SEC 1; negative vectors for weak and
-      low-order keys; published.
-- [ ] E6: deploy budget for the full 30-key (33 with p256)
-      `spec_version = 2` contract against the per-block parameters; the
-      wave plan; hand-built maintenance updates after wave one; authority
-      retirement after the last wave confirmed.
-- [ ] `[CRYPTO]` E7: read handover: a read-only grant first; seal to a
-      PRF-derived X25519 key on the dApp origin; decrypt; the inbox walk
-      from the dApp side with commitment verification;
-      rotate-before-share then confirmation that the delegate cannot
-      read spent history; rotate on revoke then confirmation that the
-      delegate reads no new entries; a low-order `read_pk` refused; a
-      silent-reconnect re-seal to the bound key succeeds and to another
-      key is refused.
-- [ ] E8: an agent grantee: a jubjub grant issued to the reference
-      signer acting as an agent in the non-browser binding, a spend
-      within scope through the jubjub twin, the scope mirrored as an
-      Open Wallet Standard PE-1 policy document; a jubjub grant issued
-      to a `self:` delegate from the owner's own client with no
-      authoriser page.
-- [ ] `[CIRCUIT]` E9: revoke plus issue in one client-built transaction
-      with consecutive use counters; a two-element batch issuance in one
-      transaction; two grant calls under one grant in one transaction
-      with consecutive nonces; atomicity or the documented sequential
-      fallback.
-- [ ] E10: a grantee shielded spend with the change entry appended in
-      the same transaction under the one-hop default; owner and grantee
-      attempting to spend the same coin concurrently (proving failure,
-      no mis-spend); a coin above `max_coin_value` aborts.
-- [ ] `[DEP]` E11: an r1 grantee end to end once the secp256r1 surface
-      ships; an extension-bearing assertion as a negative case. Until
-      then the r1 arm and `schnorr_bip340` are marked pending in the
-      registry.
+      registry once it ratifies.
+- [ ] Independent cryptographer review, findings addressed, of the grant
+      challenge and `issued_at`, the transitive binding of openings, the
+      hiding of `grant_id` and the salted commitments, the
+      companion-passkey binding and the off-chain Schnorr form, the `r1`
+      key validation, GrantViewSeal and the `read_pk` derivation,
+      `signin_digest`, the `envelope_digest` separation, and the
+      fork-replay statement.
+- [ ] E1: the grant arm on the reference contract at `spec_version = 2`
+      (all lifecycle circuits on both device arms; k256 twins on both
+      envelopes; jubjub twins), with rows, k, prover-key size, and
+      proving time per twin; the layout, arity, and change-append
+      fallbacks settled; Testing item 1 green.
+- [ ] E2: Testing item 2 green on a node, each case ending with the
+      invariants it exercises.
+- [ ] E3: the on-chain unit of `kernel.blockTimeLessThan` and the
+      never-expires arm pinned on a ledger-9 network and recorded in the
+      registry entry, with past, future, zero, and wrong-unit cases.
+- [ ] E4: Testing item 4 with two origins and two platform passkeys, a
+      read-only grant, a two-element batch, and a zero-DUST refusal.
+- [ ] E5: the vectors of Testing item 5 published, the Rust side linking
+      no compiled contract module.
+- [ ] E6: the deploy budget and wave plan of Testing item 6.
+- [ ] E7: the read handover of Testing item 7, including the
+      two-delegate re-seal case.
+- [ ] E8, E9, E10: Testing items 8, 9, and 10.
+- [ ] E11: an r1 grantee end to end once the secp256r1 surface ships
+      (Testing item 12); until then the r1 arm and `schnorr_bip340` are
+      marked pending in the registry.
 - [ ] A public reference implementation passing E2 as its conformance
       suite with the E5 vectors published.
 - [ ] A second independent implementation of the grantee side (a wallet
@@ -2200,41 +1673,37 @@ would learn the account's other connections.
       challenges from the byte recipes alone.
 - [ ] Public-testnet deployment of a `spec_version = 2` account with at
       least one grant issued, exercised, and revoked by a third-party
-      dApp.
-- [ ] A dApp not written by the authors completing E4 from the text
-      alone.
-- [ ] `[DEP]` The scope mapping table of section 5.2 accepted by the
-      Open Wallet Standard upstream, or a documented divergence.
+      dApp; a dApp not written by the authors completing E4 from the
+      text alone.
+- [ ] The scope mapping table of section 5.2 accepted by the Open Wallet
+      Standard upstream, or a documented divergence.
 
 ### Implementation Plan
 
-1. Name the external co-author (O1) and settle O2 to O24 with the
+1. Name the external co-author and settle the open items with the
    Foundation and the editors; fold the outcomes into the text.
 2. Extend the reference contract to `spec_version = 2` and run E1, E2,
    E3, E6, E9, and E10; correct any byte recipe the compiled encoding
    contradicts and publish the E5 vectors.
 3. Build a reference authoriser page and a reference dApp against the
    text and run E4 and E7; then E8 with the reference signer as agent.
-4. Commission the cryptographer review; fold findings into the
-   specification before editor numbering if substantive.
+4. Commission the cryptographer review; fold findings in before editor
+   numbering if substantive.
 5. Open the companion PRs: MPS-0018 Recommended MIPs; the authorisation
-   MIP erratum of section 13; the custody MIP R9 wording note.
+   MIP erratum of section 12; the custody MIP R9 wording note; the r1
+   key-validation correction against the schemes MIP.
 6. Register tag families when the MPS-0027 registry lands; file the two
-   registry spellings and the `k1` and `r1` grantee rows into the
-   schemes MIP.
+   registry spellings and the grantee rows into the schemes MIP.
 7. Submit for editor numbering; open a Discussion; raise the origin
-   binding in MIP-0015's open question thread; iterate through community
-   commentary.
+   binding in MIP-0015's open question thread; iterate.
 8. Run E11 when the secp256r1 surface ships and move the r1 arm to
    Active.
 
 ## Backwards Compatibility Assessment
 
 This MIP introduces a new contract standard. It requires no ledger,
-consensus, or node change and no hard fork: every mechanism used
-(in-circuit hashing and curve arithmetic, contract state, witness
-arguments, the kernel block-time comparison, the maintenance-update
-path) exists in the current stable network protocol.
+consensus, or node change and no hard fork; every mechanism used exists
+in the current stable network protocol.
 
 **Schema change: grant support is a redeploy.** `grants`,
 `grant_generation`, and the two structs are new ledger cells and types.
@@ -2245,322 +1714,281 @@ gain grants by maintenance update**; migration is a new account and is
 out of scope. Clients MUST read `spec_version` before requesting a grant
 and MUST report `account_not_capable` otherwise. The redeploy SHOULD be
 shared with the device-identity remedy for the authorisation MIP's
-erratum 8 `[RULING]`, since accounts are not yet deployed at scale.
-Within a `spec_version = 2` account, twins, lifecycle circuits, pure
-derivations, and tag families are maintenance updates while the
-authority is live, and enabling the reserved window bounds later is a
-circuit revision, not a redeploy.
+erratum 8, since accounts are not yet deployed at scale.
 
-**Relation to the custody MIP.** A grant is an "authorisation-policy
-object behind the same seam" (its section 2), and INV-1 to INV-8 hold:
-grants are inside the seam (INV-1); no coin description is stored in
-the clear and the running total is a salted commitment (INV-2); the
-change rule and inbox backfill fall on the grantee and are made atomic
-by the `change_entry` argument (INV-3, INV-4); one-hop remains the
-client default (INV-6); every grant call bumps `round` (INV-7). No new
-InboxEntry version is defined; GrantViewSeal is a new container with
-its own numbering. A companion note to its R9 is raised on the write
-channel the viewing secret opens.
+**Custody MIP.** A grant is an "authorisation-policy object behind the
+same seam" (its section 2). INV-1: grants are inside the seam. INV-2: no
+coin description is stored in the clear and the running total is a
+salted commitment. INV-3 and INV-4: the change rule and inbox backfill
+fall on the grantee and are made atomic by the `change_entry` argument.
+INV-5: a wrong qualified description fails at proving, unchanged for a
+grantee. INV-6: one-hop remains the client default. INV-7: every grant
+call bumps `round`. INV-8: the unshielded mirror is written only by the
+unchanged custody chips. S5 is discharged in section 6.2. GrantViewSeal
+is a new container with its own numbering; a companion note to R9 is
+raised on the write channel the viewing secret opens.
 
-**Relation to the authorisation MIP.** Additive in every existing
-circuit and cell: the device seam, custody chips, and device challenge
-preimages are untouched, so its conformance suite passes unchanged.
-AUTH-3 to AUTH-8 and AUTH-10 hold as written for devices; GR-4, GR-5,
-GR-9, and GR-12 give the grant analogues. AUTH-1, AUTH-2, and AUTH-9 are
-addressed by the companion erratum of section 13, not by
-reinterpretation `[RULING]`. The recovery seam's obligation is
-unchanged; clearing `grants` is optional hygiene. Device keys, wallet
-keys under MIP-0003, and wallets unaware of this standard are
-unaffected; a wallet provider becomes involved only when its key is
-enrolled as an envelope-1 grantee, in which case the connector surface
-it already exposes suffices for `read`.
-
-**Relation to the schemes MIP.** The `k1` and `r1` grantee arms reuse
-its registry, its WebAuthn envelope, and its signature-form policy; two
-registry spellings and a grantee Status per arm are filed into it. The
-`r1` arm is `[DEP]` on the same language surface that MIP is.
+**Authorisation MIP.** Additive in every existing circuit and cell, so
+its conformance suite passes unchanged. AUTH-3 to AUTH-8 and AUTH-10 hold
+as written for devices; GR-4, GR-5, GR-9, and GR-12 give the grant
+analogues; AUTH-1, AUTH-2, and AUTH-9 are read per section 12. Device
+keys, wallet keys under MIP-0003, and wallets unaware of this standard
+are unaffected. The schemes MIP gains two registry spellings, a grantee
+Status per arm, and the r1 key-validation correction.
 
 ## Security Considerations
 
-The dominant residual risk is stated first: **`read` is total.** A
-grant with `read`, which every shielded spend grant implies, delivers
-the account encryption secret, which decrypts every current and future
-shielded holding across all colors until rotation; no schema field
-bounds it; read-granted parties are not isolated from each other; and
-revoking one blinds all until re-consent. The controls are
-rotate-before-share (MUST), sealed delivery to a bound `read_pk`, the
-declarative flag for audit, rotate-and-re-encrypt on revoke (client
-MUST), the disclosure sentence as the first consent item, and the
-custody MIP's R9 successor named as the dependency for spend without
-full disclosure.
+The dominant residual risk is section 8: `read` is total. The controls
+are rotate-before-share with the re-seal obligation, sealed delivery to
+a bound `read_pk`, the declarative flag for audit, rotation on revoke,
+the disclosure sentence as the first consent item, and the custody MIP's
+R9 successor as the named dependency for spend without full disclosure.
 
 **Observability (normative).** A passive observer of the register
 learns, per account, the number of connections ever made (records
 including tombstones), and for each the admitted operations, whether it
 holds `read`, its caps, its expiry, its call count, and its status; from
-a call it learns which grant acted and that the call count advanced. It
-does not learn the grantee key, the origin, the color, the counterparty
-(except a contract recipient, which the send path publishes regardless),
-or any amount. This is within INV-2 (no part of a held coin's
-description in the clear; the caps are the owner's policy, not a coin's
-value) and, per the companion erratum, outside AUTH-9's scope (a grant
-identifier is not a device handle). The consent screen tells the user
-the connection and its bounds are publicly visible. The rejected
-accumulator register is the privacy-preserving successor for call count
-and status, with its revocation race stated in R2.
+a call it learns which grant acted. It does not learn the grantee key,
+the origin, the dApp host, the color, the counterparty (except a
+contract recipient, which the send path publishes regardless), or any
+amount. This is within INV-2 (the caps are the owner's policy, not a
+coin's value) and, per the companion erratum, outside AUTH-9's scope.
+The authoriser is privileged: it knows `scope_salt` for every grant it
+issued and, if it retains it, can open every commitment from public
+state indefinitely, which is why section 4.2 says it SHOULD NOT retain
+the salt.
 
 | | Attack | Mitigation |
 |---|---|---|
-| S1 | Grant injection (login CSRF): the victim approves a URL carrying the attacker's key under the dApp's name | possession proof over `request_digest` by the grantee key; browser-attested `clientDataJSON.origin == client_id` whenever the request arrives by navigation, regardless of `client_id` form; `state` bound to the dApp session; the return-leg recomputation of `grant_id` matches no pending key at the victim's dApp |
-| S2 | Open redirector through an attacker-controlled return URL | `redirect_uri` MUST be `https`, same-origin with the proven `client_id`, exact-string matched; non-browser bindings carry no `redirect_uri`; no navigation to a target that failed validation |
-| S3 | Binding downgrade by choosing an `rdns:` or `self:` `client_id` in a navigation | rejected with `invalid_request`; the binding is a property of the transport |
-| S4 | Mix-up: the response attributed to the wrong authoriser | `iss` in the response compared by string equality; the grant is read from chain state, never from redirect parameters |
-| S5 | Request replay at another authoriser or later | `aud`, `iat`, `exp` covered by `request_digest`; one-time `nonce`; `account` MUST when known and flagged on the consent screen when absent |
-| S6 | Key substitution at issue by a compromised authoriser | the authoriser is trusted for grantee identity exactly as it is trusted to render consent and, during the ceremony, holds the derived device key; the contract accepts an opaque `grant_id` as it accepts an opaque device entry; the mitigations are testable: the dApp MUST reproduce the consent fingerprint and MUST treat a `grant_id` mismatch on return as a compromised authoriser with a prompt to revoke; in-circuit derivation is the rejected alternative (R2) |
-| S7 | Grantee signature replay | the record's `nonce` read in-circuit, covered, and advanced; `grant_id` bound (no cross-grant reuse); `issued_at` bound (no cross-incarnation reuse); identical resubmission is a conformance abort case |
-| S8 | Blind-signing oracle through connector `signData` | envelope-1 grantees admit `read` only; spend `[DEP]` on a structured-display connector surface |
-| S9 | Scope creep by the grantee or upward adjustment by the authoriser | only device-gated circuits write scope; grant twins write only `nonce` and `spent_commit`; attenuation only; modify is revoke plus issue |
-| S10 | Object-scope bypass: declared color in scope, witness coin of another color or of a large value | `coin.color` and `coin.value` are asserted against the commitment and `max_coin_value` before the chip; the `color` argument only selects the witness |
-| S11 | Change orphaning by a grantee (send `C` from a coin of value `V`, never backfill) | `max_coin_value` bounds `V`; the change entry is an argument of the shielded twins appended in the same transaction; the owner's discovery walk verifies entries against chain data |
-| S12 | Revocation escape (the erratum 8 pattern) | contract-recomputed identity from the presented key; the bounded `slot` makes every record of a grantee enumerable; tombstone read at use; `revoke_all_grants` O(1); no grantee can call `issue_grant`; an unrecognised live id in the owner's reconciliation is treated as possible compromise, with `revoke_all_grants` and re-issue as the remedy |
-| S13 | Device compromise not contained by `remove_device` | the owner's client MUST compose `revoke_all_grants` with a compromise removal; a contract-level cascade is `[RULING]` |
-| S14 | Epoch or generation confusion, pre-planting (the erratum 7 pattern) | `epoch`, `gen`, `issued_at` contract-written; both asserted at use |
-| S15 | Weak keys (erratum 6) | the per-arm table of implemented checks; off-curve keys `[CIRCUIT]` with negative vectors |
-| S16 | Origin spoofing through a free parameter | the origin is the browser-attested value in the browser binding; the contract records only a commitment; chain-side origin enforcement does not exist and this MIP says so |
-| S17 | Consent deception by dApp-supplied strings or display units | consent rendered from the exact plaintext scope and the proven `client_id`; no dApp-supplied name, icon, statement, or color name; atomic units with a smallest-unit label; hex color always |
-| S18 | Consent as a DOM event on a page already holding signing material | consent precedes the authorising ceremony; the assertion challenge is the issue challenge; the derived key is used once and discarded; `frame-ancestors 'none'`, top-window check, COOP |
-| S19 | Bearer leakage through URLs, logs, referrers, history | fragment transport on both legs; `no-referrer`; no third-party resources; `history.replaceState` on both legs; the only secret (`view`) is sealed to a validated `read_pk`; `scope_salt` in the fragment is a readability key, not authority; browser history, session restore, profile sync, and extensions with host permissions remain exposure surfaces |
-| S20 | Low-order or malicious `read_pk` makes the seal publicly decryptable | reject the known low-order points; abort on an all-zero shared secret; AAD binds `eph_pk`, `grant_id`, `account` |
-| S21 | Silent reconnect re-delegates the secret to an attacker-chosen key | re-seal only to `read_pk_hash`; full read consent on every re-seal; re-seals recorded in the roster |
-| S22 | Owner liveness griefing by a racing grantee | grant calls never touch `auth_nonce` |
-| S23 | Register or inbox growth as denial of service | only devices create records; a grantee writes at most one 192-byte inbox entry per spend, under a spend it paid for; counters `Uint<32>` or wider; growth bounded by the owner's own issuance |
-| S24 | Cumulative-cap wrap | the sum is compared to `cap` in the widened type before the narrowing cast |
-| S25 | Inbox forgery with the delegated secret (phantom coins) | conforming readers verify each entry's coin against chain data (custody MIP section 6.5, restated as a MUST); forged entries are inert noise; the companion note to R9 |
-| S26 | Cross-account and cross-dApp linkage of a grantee key by a chain observer | the key is never stored; `kernel.self()` in the identity preimage; per-connection keys MUST; publicly known keys (the wallet-provider form) are linkable and this MIP says so |
-| S27 | Dictionary test "is this account connected to origin X" | `origin_hash` is a private argument inside a preimage that also contains a per-connection key; the plaintext origin is never on chain; the test succeeds for a publicly known key, stated |
-| S28 | Sibling-origin assertion against the authoriser's credential | authoriser and dApp RP IDs MUST equal their full hosts; Related Origin Requests excluded |
-| S29 | Address disclosure by "sign-in" | no identity-only grant; sign-in-only never touches the authoriser or chain; every grant discloses the address, stated |
-| S30 | Cross-network replay after a state-preserving fork | no cell defeats it; `kernel.self()` plus the never-reuse-deploy-content client rule separate independent networks; expiry and revocation on the surviving chain are the defence |
-| S31 | Kernel argument disclosure per call | `expires_at` reaches the public transcript; harmless because the record is public |
-| S32 | Maintenance authority above the seam | grant circuits are part of the wave plan and the authority is retired after the last wave; a live authority remains the strongest attacker, as for devices |
-| S33 | Malleated ECDSA twins | both `s` forms accepted; inert because `nonce` advances and signatures are never identifiers (SIG-4) |
-| S34 | Pending private key stored before consent | non-extractable storage SHOULD; unavoidable in kind and documented |
-| S35 | Concurrent coin selection by owner and grantee | proving failure or a fee-wasting race, never a mis-spend (INV-5); a deterministic selection rule recommended |
-| S36 | Fee-payment linkability outside the contract | a dApp paying DUST from an address linked to its web identity links itself to the account; noted, outside the contract's scope |
-| S37 | Authoriser unavailability | a recoverable error carrying no state; any device-key holder can act as authoriser; a local authoriser is documented |
-| S38 | Toolchain hazards | the negative conformance suite includes the vacuous-verifier control the authorisation MIP's S10 mandates; toolchain versions whose hash outputs are stable are pinned |
+| S1 | Grant injection (login CSRF) | possession proof over `request_digest`; browser-attested origin on every navigation; session-bound `state`. Residual (9.2): the proof shows a credential on the origin, not the dApp's front-end; consent and the roster are the remaining barriers |
+| S2 | Open redirector | `redirect_uri` `https`, same-origin with the proven `client_id`, exact match; none in non-browser bindings (9.7) |
+| S3 | Binding downgrade by `client_id` form | the binding is a property of the transport (9.2) |
+| S4 | Mix-up between authorisers | `iss` string equality; the grant is read from chain, never from redirect parameters (9.7) |
+| S5 | Request replay | `aud`, `iat`, `exp` under `request_digest`; one-time `nonce`; `account` MUST when known (9.1) |
+| S6 | Key substitution by a compromised authoriser | the dApp recomputes `grant_id` and the openings and treats a mismatch as compromise (9.7); in-circuit derivation rejected (R2) |
+| S7 | Grantee signature replay | `nonce` read in-circuit and advanced; `grant_id` and `issued_at` bound (6.3) |
+| S8 | Blind-signing oracle through connector `signData` | envelope-1 grantees `read`-only (3.2) |
+| S9 | Scope creep or upward adjustment | only device-gated circuits write scope; attenuation only; modify is revoke plus issue (7.2) |
+| S10 | Object-scope bypass through the witness coin | `coin.color` and `coin.value` asserted before the chip (6.2 step 5) |
+| S11 | Change orphaning, including by a rotation racing a pending call | `max_coin_value`; the change entry appended in the same transaction; `enc_pk == enc_key` (6.2 step 5) |
+| S12 | Revocation escape (the erratum 8 pattern) | contract-recomputed identity; bounded `slot`; tombstone read at use; roster reconciliation (7.5) |
+| S13 | Device compromise not contained by `remove_device` | `revoke_all_grants` composed with a compromise removal (7.3) |
+| S14 | Epoch or generation confusion, pre-planting (erratum 7) | `epoch`, `gen`, `issued_at` contract-written and asserted at use (GR-8) |
+| S15 | Weak or identity keys (erratum 6) | the per-arm table of 3.3, including SEC 1 validation on r1; off-curve negative vectors |
+| S16 | Origin spoofing through a free parameter | the origin is browser-attested; the record holds only commitments; chain-side origin enforcement does not exist |
+| S17 | Consent deception by dApp-supplied strings or units | consent from the exact plaintext scope and the proven `client_id`; no dApp strings; atomic units; hex color (9.5) |
+| S18 | Consent as a Document Object Model (DOM) event on a page holding signing material | consent precedes the ceremony; the assertion challenge is the issue challenge; the derived key is used once; `frame-ancestors 'none'`, top-window check, `Cross-Origin-Opener-Policy` (9.4) |
+| S19 | Leakage through URLs, logs, referrers, history | fragment transport on both legs; `no-referrer`; no third-party resources; `replaceState`; `view` sealed; `scope_salt` confers no authority but is the key to the record's INV-2 protection, and history, session restore, profile sync, and extensions remain exposure surfaces |
+| S20 | Low-order, non-canonical, or malicious `read_pk` | rejected; abort on an all-zero shared secret; the associated data binds `eph_pk`, `grant_id`, `account` (8) |
+| S21 | Silent reconnect to an attacker-chosen key | re-seal only to `read_pk_hash`; full read consent; roster (9.8) |
+| S22 | Owner liveness griefing by a racing grantee | grant calls never touch `auth_nonce` (GR-5) |
+| S23 | Register or inbox growth | only devices create records; one 192-byte entry per paid spend; counters `Uint<32>` or wider |
+| S24 | Cumulative-cap wrap | widened comparison before the narrowing cast (6.2 step 5) |
+| S25 | Inbox forgery with the delegated secret | readers verify each entry's coin against chain data (8 item 4) |
+| S26 | Cross-account linkage of a grantee key or `read_pk` | the key is never stored; `kernel.self()` in the identity; per-connection keys; `read_pk` per account; publicly known keys are linkable, stated |
+| S27 | Dictionary test "is this account connected to origin X" | `origin_hash` only inside a preimage with a per-connection key; the r1 host under a salted commitment; succeeds only for a publicly known key |
+| S28 | Sibling-origin assertion against the authoriser credential | RP identifiers equal their full hosts; Related Origin Requests excluded (9.4, 11.3) |
+| S29 | Address disclosure by sign-in | no identity-only grant; every grant discloses the address, stated (10) |
+| S30 | Cross-network replay after a state-preserving fork | no cell defeats it; `kernel.self()` plus never reusing deploy content; expiry and revocation on the surviving chain (R15) |
+| S31 | Kernel argument disclosure per call | `expires_at` is public anyway |
+| S32 | Maintenance authority above the seam | grant circuits in the wave plan; authority retired after the last wave (6.7) |
+| S33 | Malleated ECDSA twins | both `s` forms accepted; inert because `nonce` advances (SIG-4) |
+| S34 | Pending private key stored before consent | non-extractable storage SHOULD; unavoidable in kind |
+| S35 | Concurrent coin selection | proving failure or a fee-wasting race, never a mis-spend (INV-5) |
+| S36 | Fee-payment linkability | a dApp paying DUST from an address linked to its identity links itself to the account; outside the contract |
+| S37 | Authoriser unavailability | a recoverable error carrying no state; any device-key holder can act as authoriser (11.3) |
+| S38 | Toolchain hazards | the vacuous-verifier control of the authorisation MIP's S10; pinned toolchain versions |
 
 ## Implementation
 
-- **Evidence held.** In-circuit cap, color, tombstone, and epoch
-  enforcement on a devnet node with a bearer grantee (the
-  account-custody prototype's v0 grants: withdraw only, one color,
-  cumulative cap, no expiry, tombstone revoke, epoch-scoped); the k256
-  envelope arm compiled and measured on a ledger-9 network (the
-  wallet-key gate experiment: k=15 and k=16, 31,046 and 32,900 rows,
-  0.5 to 0.8 s); the r1 WebAuthn envelope verified against a real
-  platform assertion (k=16, 36,466 rows, 1.1 to 1.2 s); the wave-deploy
-  and block-limit numbers of the reference implementation; the kernel
-  block-time comparison compiling and executing (its on-chain unit is
-  not held); contract-to-contract composition validated (the
-  cross-contract-calls experiment). Not yet held: any connection
-  protocol on Midnight, origin binding, expiry on node, signature-based
-  grantee authentication in the grant seam, and the cost of grant
-  verification under real signature circuits; these are the
-  experiments of Path to Active.
-- **Reference implementation changes.** The reference contract gains
-  `grants`, `grant_generation`, the two structs, per-arm
-  `derive_grant_id_with_*`, the commitment and scope-digest derivations,
-  `challenge_*_with_grant_*`, the three seam chips, three twins per
-  grantee arm, three lifecycle circuits per device arm, and
-  `spec_version = 2` in the constructor; the k1 branch's
-  `envelope_digest` is reused verbatim. The TypeScript client gains a
-  grant-authorisation branch in its argument builder and the
-  `<operation>_with_grant_<arm>` call shapes; the Rust signer produces
-  bit-identical `grant_id`, commitments, and challenges from the byte
-  recipes alone, which is the R5 discipline of the authorisation MIP
-  carried to grants and the answer to the byte-framing gap raised
-  upstream.
-- **Reference authoriser and dApp.** A static consent page implementing
-  section 9 and a dApp implementing the return leg and sign-in, each
-  runnable locally, are the E4 and E7 artefacts and the basis of the
-  "dApp not written by the authors" criterion.
-- **Companion documents.** The MPS-0018 Recommended MIPs bullet; the
-  authorisation MIP erratum of section 13; the custody MIP R9 note; the
-  schemes MIP registry rows and spellings.
-- This MIP contains no implementation code; the artefacts above are its
-  evidence base, and the reference implementation is an acceptance
-  criterion, to be linked at its public location on submission.
+| Evidence held | What it establishes |
+|---|---|
+| the account-custody prototype's v0 grants on a devnet node (withdraw only, one color, cumulative cap, tombstone revoke, epoch-scoped, bearer grantee) | in-circuit cap, color, tombstone, and epoch enforcement at the seam |
+| the wallet-key gate experiment on a ledger-9 network (k=15 and k=16; 31,046 and 32,900 rows; 0.5 to 0.8 s) | the k256 envelope arm compiled and measured; the connector prefix as envelope `1` |
+| the P-256 in-circuit experiment against a real platform assertion (k=16, 36,466 rows, 1.1 to 1.2 s) | the r1 WebAuthn envelope |
+| the reference implementation's wave deploy and block-limit numbers | the deploy budget rule of section 6.7 |
+| the kernel block-time comparison compiling and executing | lazy expiry is expressible; its unit is not held |
+| the cross-contract-calls experiment | composition in one transaction |
+
+Not yet held: any connection protocol on Midnight, origin binding,
+expiry on node, signature-based grantee authentication in the grant
+seam, and the cost of grant verification under real signature circuits;
+these are the experiments of Path to Active.
+
+The reference contract gains the two cells, the two structs, the pure
+derivations, the three seam chips, three twins per grantee arm, three
+lifecycle circuits per device arm, and `spec_version = 2`; the Rust
+signer produces bit-identical `grant_id`, commitments, and challenges
+from the byte recipes alone. A static consent page implementing section
+9 and a dApp implementing the return leg and sign-in, each runnable
+locally, are the E4 and E7 artefacts. Companion documents: the MPS-0018
+Recommended MIPs bullet, the erratum of section 12, the custody MIP R9
+note, and the schemes MIP registry rows and r1 correction. This MIP
+contains no implementation code; the reference implementation is an
+acceptance criterion.
 
 ## Testing
 
 Conformance is demonstrated by a suite exercising, against a real node,
 the following. Each item names the invariants it exercises.
 
-1. **Grant happy path.** Issue a grant from a device; a grant call with
-   a valid grantee signature within scope executes; the record's `nonce`
-   advances, `spent_commit` re-commits, `round` advances, `auth_nonce`
-   is unchanged (GR-1, GR-5, GR-13; INV-7).
-2. **Rejection matrix.** The same call aborts with no state change
-   under each single fault: out-of-scope operation; over `per_call_cap`;
-   over `cap`; a cumulative wrap attempt; the declared color in scope
-   with a witness coin of another color; a witness coin above
-   `max_coin_value`; wrong recipient under a pin; recipient-kind
-   mismatch; revoked; expired; stale epoch; stale generation; identical
-   argument tuple and signature resubmitted after success; a signature
-   from a prior incarnation against a re-issue; a cross-scheme key; a
+1. **Grant happy path.** Issue from a device; a grant call within scope
+   executes; `nonce` advances, `spent_commit` re-commits, `round`
+   advances, `auth_nonce` is unchanged (GR-1, GR-5, GR-13; INV-7).
+2. **Rejection matrix.** The same call aborts with no state change under
+   each single fault: out-of-scope operation; over `per_call_cap`; over
+   `cap`; a cumulative wrap attempt; a witness coin of another color; a
+   witness coin above `max_coin_value`; wrong recipient under a pin;
+   recipient-kind mismatch; a stale `enc_pk`; revoked; expired; stale
+   epoch; stale generation; identical resubmission after success; a
+   prior-incarnation signature against a re-issue; a cross-scheme key; a
    wrong envelope (k1); the identity, small-order, off-curve, and
-   invalid-curve keys; a grantee calling any device-gated or lifecycle
-   circuit (no ABI exists); re-issue of a live id rejected; issue over
-   an absent id succeeds; revoke of an absent id aborts; revoke one of
-   two slots held by one key, then prove the other still authorises and
-   only that one; `device_count` untouched; and the vacuous-verifier
-   control (GR-2, GR-3, GR-4, GR-5, GR-6, GR-7, GR-9, GR-12, GR-14; the
-   authorisation MIP's S10).
+   invalid-curve keys on every deployed arm; a grantee calling any
+   device-gated or lifecycle circuit; re-issue of a live id rejected;
+   re-issue of an expired but unrevoked id rejected, and revoke plus
+   issue over it in one transaction accepted; issue over an absent id
+   succeeds; revoke of an absent id aborts; a reused `scope_salt` flagged
+   by the harness as non-conforming; revoke one of two slots held by one
+   key, the other still authorises and only that one; `device_count`
+   untouched; the vacuous-verifier control (GR-2, GR-3, GR-4, GR-5, GR-6,
+   GR-7, GR-9, GR-12, GR-14; the authorisation MIP's S10).
 3. **Owner liveness.** A pending owner signature still verifies after a
    grant call; a permissionless deposit between grantee signing and
    submission does not invalidate the grantee's call (GR-5; AUTH-8).
-4. **Redirect attack suite.** Open redirect; crafted-URL injection with a
-   `state` mismatch; `iss` mismatch; `aud` mismatch; expired request;
-   replayed `nonce`; proof failure; `clientDataJSON.origin` mismatch; an
-   `rdns:` `client_id` by navigation refused; an envelope-1 grantee
-   requesting a withdraw refused; a low-order `read_pk` refused; a
-   `grant_id` mismatch on return treated as compromise; a sibling-origin
-   assertion attempt against the authoriser credential; fragment leakage
-   under a logging reverse proxy and in browser history before and after
-   `replaceState` (GR-16, GR-17).
-5. **Cross-implementation vectors.** Every derivation of section 4 and
-   every challenge of section 6.3, `envelope_digest`, `origin_hash`,
-   `request_digest`, the sign-in digest, and GrantViewSeal, bit-identical
-   between the compiled contract, the TypeScript client, and a Rust
-   implementation linking no compiled module; `pk` normalisation from
-   SEC 1; published negative vectors (GR-3, GR-4).
+4. **Redirect attack suite.** Open redirect; injection with a `state`
+   mismatch; `iss`, `aud` mismatch; expired request; replayed `nonce`;
+   proof failure; `clientDataJSON.origin` mismatch; an `rdns:`
+   `client_id` by navigation refused; a `client_id` outside the
+   productions of section 4.4 refused; an r1 proof under the identity
+   key refused; an envelope-1 withdraw refused; a non-canonical or
+   low-order `read_pk` refused; a `grant_id` or opening mismatch on
+   return treated as compromise; a narrowed request whose returned scope
+   opens `object_commit`; a sibling-origin assertion against the
+   authoriser credential; fragment leakage under a logging reverse proxy
+   and in browser history before and after `replaceState` (GR-16,
+   GR-17).
+5. **Cross-implementation vectors.** Every derivation of section 4,
+   including a read-only `object_commit`, `rp_commit` for an r1 and a
+   non-r1 grant, and one recipient projection per kind; every challenge
+   of section 6.3 with the qualified coin written out element by
+   element; `envelope_digest`, `origin_hash`, `request_digest`,
+   `signin_digest`, the `read_pk` derivation, and GrantViewSeal,
+   bit-identical between the compiled contract, the TypeScript client,
+   and a Rust implementation linking no compiled module; `pk`
+   normalisation from SEC 1 and the `v1` wire form; one off-chain
+   signature vector per arm and a high-S vector per ECDSA arm that MUST
+   verify; negative vectors for weak, identity, and low-order keys
+   (GR-3, GR-4, GR-14).
 6. **Deploy budget.** The full `spec_version = 2` roster deployed in
    waves within the per-block parameters; authority retirement after the
    last wave; a `spec_version = 1` account shown unable to gain grants
-   (Backwards Compatibility).
-7. **Read handover.** Read-only grant; seal, decrypt, inbox walk with
-   commitment verification from the dApp side; rotate-before-share hides
-   spent history; rotate on revoke blinds the delegate; re-seal to the
-   bound key succeeds and to another key is refused; a forged inbox
-   entry is quarantined (GR-18).
-8. **Agent and self grantees.** A jubjub grant to the reference signer
-   in the non-browser binding, a spend within scope, the scope mirrored
-   as a PE-1 policy; a `self:` grant issued from the owner's client with
-   no authoriser page (GR-1, GR-17 non-browser clause).
+   (GR-3, GR-13; Backwards Compatibility).
+7. **Read handover.** Read-only grant; seal, decrypt, verify the secret
+   against `enc_key`, inbox walk with commitment verification; rotate-
+   before-share hides spent history; a second read grant issued and the
+   first re-sealed and still reading; rotate on revoke blinds the revoked
+   delegate and the remaining one is re-sealed; re-seal to the bound key
+   succeeds and to another key is refused; a forged inbox entry is
+   quarantined (GR-18).
+8. **Agent and self grantees.** A jubjub grant to the reference signer in
+   the non-browser binding with its structured response, a spend within
+   scope, the scope mirrored as a PE-1 policy; a `self:` grant issued
+   from the owner's client with no authoriser page (GR-1, GR-17).
 9. **Composition.** Revoke plus issue in one transaction; batch issuance
-   in one transaction; two grant calls under one grant in one
-   transaction with consecutive nonces; reordering invalidates
-   (GR-5, GR-11, GR-13).
+   in one transaction; two grant calls under one grant with consecutive
+   nonces; reordering invalidates (GR-5, GR-11, GR-13).
 10. **Change and concurrency.** A grantee shielded spend with the change
-    entry appended in the same transaction under one-hop; owner and
-    grantee selecting the same coin (proving failure, no mis-spend); a
-    coin above `max_coin_value` aborts (GR-7; INV-3, INV-4, INV-5,
-    INV-6).
-11. **Kill totality.** `revoke_all_grants` inerts every record in one
-    call; a recovery epoch bump inerts every record; re-issue under the
-    new generation or epoch succeeds (GR-9).
-12. **r1 grantee.** `[DEP]` End to end once the secp256r1 surface ships;
-    an extension-bearing assertion as a negative case (GR-14).
+    entry appended in the same transaction under one-hop; a
+    `rotate_enc_key` between signing and submission aborts the call with
+    no orphaned change; owner and grantee selecting the same coin
+    (proving failure, no mis-spend); a coin above `max_coin_value` aborts
+    (GR-7; INV-3, INV-4, INV-5, INV-6).
+11. **Kill totality.** `revoke_all_grants` and a recovery epoch bump each
+    inert every record; re-issue under the new generation or epoch
+    succeeds (GR-9).
+12. **r1 grantee.** End to end once the secp256r1 surface ships; an
+    extension-bearing assertion and the identity key as negative cases;
+    `rp_commit` opened at the seam (GR-14, GR-15).
 
 ## References
 
 **Midnight documents**
 
 - [MPS-0018](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0018-asset-custody-model.md):
-  Multi-key Account Custody for Midnight-Native Assets (the parent
-  problem statement).
+  the parent problem statement.
 - [MIP-0012](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0012-native-asset-custody.md):
-  Contract Custody of Midnight-Native Assets (the seam semantics, INV-1
-  to INV-8, the viewing capability, R9).
+  Contract Custody of Midnight-Native Assets (the seam, INV-1 to INV-8,
+  the viewing capability, R9, S5).
 - [MIP-0013](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0013-account-authorisation.md):
   Multi-key Account Authorisation for Custody Contracts (the device
-  seam, AUTH-1 to AUTH-10, section 10 versioning, the reservation of
-  scoped grants); its
+  seam, AUTH-1 to AUTH-10, errata 6 to 8); its
   [discussion](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/244)
-  (the VRF objection answered in R12).
+  (the VRF objection, R12).
 - Signature Schemes for Custody-Account Authorisation (the schemes MIP;
-  local draft, number pending): registry, r1 WebAuthn envelope, k1
-  interim arm, SIG-1 to SIG-5.
+  draft, number pending): registry, r1 WebAuthn envelope, k1 interim
+  arm, SIG-1 to SIG-5.
 - [MIP-0003](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0003-ecdsa-support.md):
   ECDSA support (the connector `signData` `scheme` discriminator).
 - [MIP-0008](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0008-caip-2-network-identifiers.md):
   CAIP-2 network identifiers (the wire `chain` member).
 - [MIP-0015](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0015-wallet-derived-deterministic-secrets.md):
-  Wallet-derived deterministic secrets (consent and error vocabulary,
-  aligned with informatively).
-- [MIP-0007](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0007-name-service-registry-and-resolver.md):
-  Midnight Name Service (contract-owned names; a candidate authoriser
-  discovery record).
+  Wallet-derived deterministic secrets (consent and error vocabulary).
 - [MPS-0003](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0003-caip-support.md):
-  CAIP support (connection framed as a chain-identifier problem).
+  CAIP support.
 - [MPS-0015](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0015-agent-identity.md):
-  Agent identity (agents as a grantee class).
+  Agent identity (the `mais:` grantee identity); the Midnight Agent
+  Identity Standard
+  ([PR #110](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/110)).
 - [MPS-0027](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0027-domain-separation.md):
   Domain Separation for Midnight Hash Constructions (the tag registry).
 - [MPS-0029](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0029-compact-caller-identity.md):
-  Caller identity in Compact circuits (why a separate verifier is not
-  available).
-- Upstream proposals: Private Mandate Tokens
+  Caller identity in Compact circuits.
+- Upstream proposals and discussions: Private Mandate Tokens
   ([PR #251](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/251),
-  R13); Midnight Agent Identity Standard
-  ([PR #110](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/110));
-  Soulbound Credential Primitive
-  ([PR #214](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/214)).
-- Upstream discussions: a ZK-attested scoped-grant primitive offered as
-  prior art ([#223](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/223));
-  platform gaps for cross-implementation proofs, including
+  R13); a ZK-attested scoped-grant primitive offered as prior art
+  ([#223](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/223));
   `persistentHash` byte framing
   ([#260](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/260)).
 - The Midnight dApp connector API specification (scheme strings, the
   `midnight_signed_message:32:` prefix, `Rejected` and
   `PermissionRejected`, `rdns`); the Open Wallet Standard (policy engine
-  PE-1 to PE-7, the Midnight contract-execution specification).
+  PE-1 to PE-7).
 
 **External standards**
 
-- RFC 2119 (key words); RFC 6749 (OAuth 2.0; parameter names, section
-  4.1.2.1 errors); RFC 9700 (OAuth 2.0 Security Best Current Practice;
-  sections 2.1, 4.1.3, 4.2, 4.10); RFC 9207 (`iss` in authorization
-  responses); RFC 8785 (JSON Canonicalization Scheme); RFC 6454 (web
-  origin); RFC 7748 (X25519, contributory behaviour); RFC 5869
-  (HKDF); RFC 9591 (FROST; the v1 threshold arm).
+- RFC 2119; RFC 3986 (unreserved characters); RFC 6749 (OAuth 2.0
+  parameter names, section 4.1.2.1 errors); RFC 9700 (OAuth 2.0
+  Security Best Current Practice, sections 2.1, 4.1.3, 4.2, 4.10); RFC
+  9207 (`iss`); RFC 8785 (JSON Canonicalization Scheme); RFC 6454 (web
+  origin); RFC 7748 (X25519, clamping, contributory behaviour); RFC 5869
+  (HKDF).
 - W3C Web Authentication Level 3 (client data, authenticator data, RP ID
   scoping, the PRF extension, Related Origin Requests).
-- SEC 1 and SEC 2 (point encodings; secp256k1, secp256r1); the Jubjub
-  curve specification (Zcash protocol specification, section 5.4.9.3).
-- CAIP-2, CAIP-10, CAIP-25, CAIP-217 (chain identifiers, account
-  identifiers, session scopes, scope objects).
-- EIP-4361 Sign-In with Ethereum (the sign-in message shape); UCAN
-  (attenuation, explicit `exp: null`); ERC-7715 (the adjustment
-  pitfall); NEAR access keys and wallet login (the redirect flow whose
-  defects section 9 closes).
+- SEC 1 (point encodings and validation); the Jubjub curve specification
+  (Zcash protocol specification, section 5.4.9.3).
+- CAIP-2, CAIP-10, CAIP-25, and CAIP-217 (the scope objects a CAIP-25
+  session carries, section 11.1).
+- EIP-4361 Sign-In with Ethereum (the sign-in message shape,
+  section 10); UCAN (prior art for an explicitly stated never-expiring
+  capability, section 5.1); NEAR access keys and wallet login (the
+  redirect flow whose defects section 9 closes).
 
-**Workspace evidence** (to be linked at public locations on submission)
+**Evidence**
 
-- The account custody reference implementation, `contract/` (MIP-0012
-  and MIP-0013 in one contract with co-resident device arms; the
-  connector-envelope branch with `envelope_digest`).
-- The account-custody prototype, `experiments/account-custody-prototype/`
-  (v0 grants: colour-scoped, value-capped withdraw grants on node).
-- The wallet-key gate experiment, `experiments/bip340-wallet-gate/`
-  (k256 envelope arm costs; the recommendation to adopt connector
-  scheme strings).
-- The P-256 in-circuit experiment, `experiments/p256-in-circuit/` (the
-  WebAuthn envelope against a real platform assertion).
-- The cross-contract-calls experiment, `experiments/cross-contract-calls/`
-  (composition in one transaction).
-- The Schnorr-wallet reference signers, `experiments/redjubjub-wallet/`
-  and `experiments/redjubjub-wallet-rs/` (the client-agnostic signing
-  boundary and the `JubjubPoint` layout the Rust side reproduces).
+- The reference implementation, the account-custody prototype, and the
+  wallet-key gate, P-256, cross-contract-calls, and Schnorr-wallet
+  experiments named in Implementation live in the
+  [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
+  repository; the commit the evidence was taken at is recorded on
+  submission.
 
 ## Acknowledgements
 
-The IOG Advanced Research and Creativity department and the Midnight
-Foundation. The connector specification and MIP-0015 maintainers, for
-the vocabulary this MIP reuses. The team that offered a compatible
-scoped-grant primitive in the upstream discussion, to be named here once
-the offer is answered `[RULING]`.
+The Input Output Group Advanced Research and Creativity department and
+the Midnight Foundation. The connector specification and MIP-0015
+maintainers, for the vocabulary this MIP reuses. The team that offered a
+compatible scoped-grant primitive in the upstream discussion, to be named
+here once the offer is answered.
 
 ## Copyright Waiver
 

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -37,7 +37,7 @@ MPS: MPS-0018
      | O1 | external co-author | named (Hector Bulgarini); the team that offered prior art in upstream discussion #223 is still to be answered and credited in Acknowledgements |
      | O2 | one spec_version = 2 redeploy carrying the grant cells and the device-identity remedy for MIP-0013 erratum 8 | SHOULD, in Backwards Compatibility |
      | O3 | companion erratum to MIP-0013 AUTH-1, AUTH-2, AUTH-9 (section 12); wordings in .planning/grants-mip/erratum-wordings.md, to travel in the erratum PR | acceptance is an acceptance criterion |
-     | O4 | on-chain unit of kernel.blockTimeLessThan, and that the never-expires arm executes | pinned before Draft leaves; recorded in the registry entry |
+     | O4 | on-chain unit of kernel.blockTimeLessThan (the never-expires arm and both comparison directions execute in the local simulator, whose unit is seconds; the node's unit is not pinned) | pinned before Draft leaves; recorded in the registry entry |
      | O5 | tombstone pruning and window enforcement | deferred to a circuit revision |
      | O6 | one MIP or two | one MIP under MPS-0018; the split offered in the PR body |
      | O7 | editor deviation from brief T3: rp_id_hash is committed under scope_salt (rp_commit) rather than stored clear, so the "observer does not learn the origin" claim of brief 5.5 holds for r1 grants | commitment; one extra opening on the p256 seam |
@@ -48,6 +48,7 @@ MPS: MPS-0018
      | O12 | Replaces: none per the brief and the published family | adopted |
      | O13 | Security Considerations rendered as a table where the published family uses bold-titled Sn bullets | table retained; the divergence is offered to the editors |
      | O14 | approved deviation from brief T5: canonical JSON (RFC 8785, JCS) replaced by signing the `request` parameter bytes as received, with the proof carried as a detached `proof` fragment parameter and no canonicalisation step anywhere | adopted (sections 9.1 to 9.4, 9.6, R10, R21) |
+     | O15 | E1 stage one folded: the grant seam compiled and measured on the reference contract at spec_version 2 (k256 grantee arm, unshielded and shielded twins, lifecycle on the k256 device arm, 27 recipe vectors agreed three ways). The brief's section 13 [CIRCUIT] items are settled (struct as Map value, Boolean in a hash tuple, tuple arity above ten, kernel.blockTimeLessThan in an assert, if-guarded lifecycle bodies, the Map reset primitive, cost figures) except three: proving times per twin, the node's unit of block time (O4, E3), and the change-description precomputation on node (6.5) | fifteen corrections applied in the text; the remainder is stage two (Path to Active E1) |
 
      Upstream dependencies: secp256r1 in the Compact language surface (r1
      arm); secp256k1 point operations (schnorr_bip340); a connector
@@ -241,8 +242,9 @@ Out of scope:
 - **Notation.** `H(x)` is SHA-256 of `x`. `pad(N, s)` is the ASCII bytes
   of `s` followed by zero bytes to `N` bytes; `s` longer than `N` is
   invalid. `u8(n)`, `u64(n)`, `u128(n)` serialise `n` little-endian at 1,
-  8, and 16 bytes. `flag(b)` is `0x01` for true and `0x00` for false.
-  `int_le(x)` is the integer whose little-endian encoding is `x`. `||`
+  8, and 16 bytes. `flag(b)` is one byte, `0x01` for true and `0x00`
+  for false, which is the compiled encoding of a `Boolean` tuple
+  element. `int_le(x)` is the integer whose little-endian encoding is `x`. `||`
   is byte concatenation. `base64url(x)` is the RFC 4648 section 5
   encoding of `x` without padding.
 
@@ -268,8 +270,12 @@ needs are stated in full in sections 3.3 and 6.2.
 verifies over `envelope_digest(envelope, h)`, where
 `envelope_digest(0, h) = H(h)` and
 `envelope_digest(1, h) = H("midnight_signed_message:32:" || h)`, the
-27-byte mandatory prefix of the dApp connector's `signData` surface. It
-is absent from the wire form and the identity preimage for `v1` and
+27-byte mandatory prefix of the dApp connector's `signData` surface.
+Because `envelope` also enters `grant_id` (section 4.3), an envelope-1
+grantee has a different `grant_id` and therefore a different challenge
+from an envelope-0 grantee with the same key, origin, and slot; the two
+envelopes are not two wrappings of one challenge `h`. `envelope` is
+absent from the wire form and the identity preimage for `v1` and
 `r1`. No `2 = webauthn` envelope id is filed. The connector's
 `schnorr_bip340` scheme is reserved pending upstream secp256k1 point
 operations.
@@ -297,10 +303,15 @@ Rules:
   attacker-chosen (the shielded twins additionally need only the viewing
   secret, which every read-granted party holds), so any other site the
   same wallet connects to could obtain a valid spend signature by asking
-  the wallet to sign an opaque message. An authoriser MUST return `unsupported_scheme` for any withdraw string
-  requested by an envelope-1 grantee. Spend through envelope `1` waits
-  on a connector surface that displays a decoded grant call with
-  per-call confirmation.
+  the wallet to sign an opaque message. An authoriser MUST return
+  `unsupported_scheme` for any withdraw string requested by an
+  envelope-1 grantee, and the `k1` grant seam enforces the same
+  restriction in-circuit: every `k1` grant twin asserts `envelope == 0`
+  before any other check (section 6.2 step 1), so a record issued to an
+  envelope-1 key admits no spend whatever its flags say. Spend through
+  envelope `1` waits on a connector surface that displays a decoded
+  grant call with per-call confirmation, and on lifting that assert in
+  a circuit revision.
 
 #### 3.3 Key validation
 
@@ -334,28 +345,39 @@ invalid-curve keys.
 | Arm | `pk` | Preimage element |
 |---|---|---|
 | `k1`, `r1` | 128 hex: affine `x \|\| y`, each a 32-byte little-endian integer; SEC 1 inputs (compressed or uncompressed, big-endian) MUST be decompressed and byte-reversed per coordinate before use | `x`, `y` as given |
-| `v1` | 64 hex: the 32-byte `JubjubPoint` encoding in the layout this MIP publishes with its vectors (the type is opaque in Compact; the layout is the one the reference signer reproduces for the device family) | the 32 bytes as given |
+| `v1` | 128 hex: affine `x \|\| y`, each a 32-byte little-endian canonical element of the BLS12-381 scalar field (the JubJub base field); `JubjubPoint` is opaque in Compact with no compression builtin, so the circuit binds the two coordinates, as the device family already does for `pk` and `sig_r` | `x`, `y` as given (64 bytes) |
 
-Wire `scheme` names:
+A wire coordinate at or above the field modulus is not the encoding of
+any point and MUST be rejected, never reduced: the compiled encoding
+writes the canonical residue of each coordinate, so only canonical
+coordinates reproduce the circuit's digest by plain SHA-256, and a
+coordinate of an on-curve point is always canonical.
 
-| Wire `scheme` | Registry arm | `envelope` member | Source |
-|---|---|---|---|
-| `ecdsa_secp256k1_sha256` | `k1` | MUST, `0` or `1` | dApp connector specification |
-| `schnorr_bip340` | reserved | absent | dApp connector specification |
-| `schnorr_jubjub` | `v1` | absent | this MIP, filed into the schemes MIP registry |
-| `ecdsa_secp256r1_webauthn` | `r1` | absent | this MIP, filed into the schemes MIP registry |
+Wire `scheme` names, keyed to the registry arm. The arm, not the wire
+name, selects the DST marker of section 6.3 and the identity tag of
+section 4.3:
+
+| Wire `scheme` | Registry arm | DST marker | `envelope` member | Source |
+|---|---|---|---|---|
+| `ecdsa_secp256k1_sha256` | `k1` | `k1:` | MUST, `0` or `1` | dApp connector specification |
+| `schnorr_bip340` | reserved | none | absent | dApp connector specification |
+| `schnorr_jubjub` | `v1` | empty | absent | this MIP, filed into the schemes MIP registry |
+| `ecdsa_secp256r1_webauthn` | `r1` | `r1:` | absent | this MIP, filed into the schemes MIP registry |
 
 Off-chain signatures by a grantee key over a fixed 32-byte digest `d`
 (`request_digest`, section 9.2; `signin_digest`, section 10). Every
 verifier MUST accept both `s` forms of an ECDSA signature, matching the
 in-circuit policy (SIG-4); a high-S vector per ECDSA arm that MUST verify
-is published with Testing item 5.
+is published with Testing item 5. Some verifier stacks enforce low-S by
+default and refuse a high-S signature as presented; such a verifier MUST
+normalise `s` to the low form before verifying, and the Rust reference
+does so.
 
 | Arm | Signs | Encoding |
 |---|---|---|
 | `k1` | `envelope_digest(envelope, d)` | 128 hex: `r \|\| s`, each a 32-byte little-endian integer |
 | `r1` | a WebAuthn assertion with `challenge = d` on the dApp origin | the authenticator's ASN.1 DER `ECDSA-Sig-Value`, base64url, with `clientDataJSON` and `authenticatorData` beside it |
-| `v1` | key-prefixed Schnorr: `c = int_le(H(R \|\| pk \|\| d)) mod r_J`, `s = r + c * sk mod r_J` | 128 hex: `R \|\| s`, `R` in the `JubjubPoint` layout, `s` a 32-byte little-endian integer below `r_J` |
+| `v1` | key-prefixed Schnorr: `c = int_le(H(R \|\| pk \|\| d)) mod r_J`, `s = r + c * sk mod r_J`, with `R` and `pk` each the 64-byte `x \|\| y` form | 192 hex: `R.x \|\| R.y \|\| s`, `s` a 32-byte little-endian integer below `r_J` |
 
 The `v1` off-chain form differs from the in-circuit form (unprefixed,
 ground challenge); separation rests on the tag and the key prefix, a
@@ -408,9 +430,10 @@ export ledger grant_generation: Uint<32>;  // bumped only by revoke_all_grants
 
 About 277 bytes per grant including the 32-byte map key (`grant_id`);
 one hundred grants are about 28 KB. The record stores no key, no origin,
-and no scheme. A struct as a `Map` value is not yet evidenced; a
-flattened layout, if adopted, changes no wire form or byte recipe but is
-a different ledger schema and takes its own `spec_version` (section 14).
+and no scheme. A struct embedding a struct as a `Map` value compiles,
+and its lookup and insert execute, on the reference toolchain
+(Implementation); the generated client type exposes the record and its
+scope as one nested value.
 
 #### 4.2 Plaintext scope
 
@@ -457,10 +480,18 @@ and a divergence is corrected in the recipe, never in the vectors.
 |---|---|---|
 | `k1` | `pad(32, "midnight:account:grant:id:k1:v1") \|\| self \|\| x \|\| y \|\| u8(envelope) \|\| origin_hash \|\| u8(slot)` | 162 |
 | `r1` | `pad(32, "midnight:account:grant:id:r1:v1") \|\| self \|\| x \|\| y \|\| origin_hash \|\| u8(slot)` | 161 |
-| `v1` | `pad(32, "midnight:account:grant:id:v1") \|\| self \|\| pk \|\| origin_hash \|\| u8(slot)` | 129 |
+| `v1` | `pad(32, "midnight:account:grant:id:v1") \|\| self \|\| x \|\| y \|\| origin_hash \|\| u8(slot)` | 161 |
 
 where `self` is the account's contract address (32 bytes) and the key
-elements are the wire forms of section 3.4. The consequences are GR-3:
+elements are the wire forms of section 3.4 (`x`, `y` on every arm, 64
+bytes; the compiled `k1` preimage is 162 bytes with `envelope` and
+`slot` as single bytes, and the `v1` one 161 bytes over the two
+coordinates of the `JubjubPoint` element, neither coordinate alone
+reproducing it). The `v1` recipe does not reject the JubJub identity
+`(0, 1)`, which has coordinates and yields a well-formed `grant_id`;
+the rejection is section 3.3's `[8]pk != O` guard, which any
+implementation lifting the derivation on its own MUST also apply. The
+consequences are GR-3:
 one tuple has at most one live record, every record of a key at an
 origin is enumerable in at most 256 lookups, and any mismatch of key,
 origin, slot, arm, or envelope fails at the membership assert. No secret
@@ -471,7 +502,11 @@ connected to origin X on account A" is trivially answerable (S27).
 #### 4.4 Origin normalisation and `origin_hash`
 
 `origin_hash = H(pad(32, "midnight:account:grant:origin:v1") || client_id_bytes)`,
-computed off-chain, where `client_id` is normalised exactly:
+computed off-chain, where `client_id_bytes` are the ASCII bytes of the
+normalised `client_id` appended raw, with no length prefix and no
+padding, immediately after the 32-byte tag pad. The tag fills the pad
+exactly, so it is not extensible without a new version. `client_id` is
+normalised exactly:
 
 - browser clients: the lowercase ASCII RFC 6454 serialisation of the
   origin (`https://bank.example`): scheme and host lowercase, default
@@ -512,9 +547,10 @@ conformance item (Testing item 2). `scope_digest` is the single element
 through which the `issue_grant` device challenge binds the whole
 plaintext scope (AUTH-3 by collision resistance); flags enter as single
 bytes. The `scope` tag family is new here and its registration is an
-acceptance criterion. Its seventeen elements exceed the largest
-evidenced tuple arity of ten; if a two-stage hash is needed, the revised
-recipe takes a new trailing tag version before Proposed.
+acceptance criterion. Its seventeen elements compile and hash as the
+raw concatenation, a 277-byte preimage; the other preimages of this
+section are 145 (`object_commit`), 80 (`spent_commit`), and 96
+(`rp_commit`) bytes.
 
 ### 5. Scope semantics
 
@@ -549,10 +585,12 @@ clients SHOULD recommend `max_coin_value == cap` where the owner can
 pre-split coins.
 
 `expires_at` is in the unit of `kernel.blockTimeLessThan` on the target
-ledger, with `0` meaning never, stated explicitly. Neither the node's
-unit nor the never-expires arm is yet evidenced on node; both are pinned
-on a ledger-9 network before this MIP leaves Draft and recorded in the
-registry entry. Clients MUST sanity-check a non-zero `expires_at`
+ledger, with `0` meaning never, stated explicitly. The comparison
+compiles inside the seam and executes in both directions in the local
+circuit simulator, where the never-expires arm never expires and the
+unit is seconds; the node's unit is not yet pinned and is recorded from
+a ledger-9 network before this MIP leaves Draft, in the registry entry
+(E3). Clients MUST sanity-check a non-zero `expires_at`
 against a freshly read block time before signing, and an authoriser
 SHOULD refuse a value already in the past. There is no `network_id`
 cell (R15); the wire `chain` member remains normative for the request.
@@ -637,9 +675,12 @@ coin's `color` and `value`; the unshielded twin tests its `color`
 argument, which is what its chip consumes. A grant twin performs, in
 order:
 
-1. **Key guard.** Per section 3.3: `k256` rejects the point at infinity
-   in either encoding; `jubjub` asserts `[8]pk != O`; `p256` rejects the
-   identity and asserts the coordinates below `p` and on the curve.
+1. **Envelope and key guard.** `k256` first asserts `envelope == 0`
+   (the envelope-1 read-only rule of section 3.2, enforced in-circuit
+   and not left to the authoriser), then, per section 3.3, rejects the
+   point at infinity in either encoding; `jubjub` asserts `[8]pk != O`;
+   `p256` rejects the identity and asserts the coordinates below `p` and
+   on the curve.
 2. **Identity.** `id = derive_grant_id_with_<s>(kernel.self(), pk, [envelope,] origin_hash, slot)`,
    disclosed; assert `grants.member(id)`; `g = grants.lookup(id)`. A
    lookup MUST be dominated by a membership assert, never combined with
@@ -651,18 +692,22 @@ order:
    public transcript, harmless because the record is public).
 4. **Operation.** Assert the twin's own flag.
 5. **Object and bounds.** With `obj_color = coin.color` on the shielded
-   twins and `obj_color = color` on the unshielded twin:
+   twins and `obj_color = color` on the unshielded twin, the predicate
+   set is normative and every predicate is asserted before any custody
+   chip executes (GR-7); the order below is the reference order and is
+   informative, with one exception: the widened sum MUST be tested
+   against `cap` before it is narrowed, so that a wrap attempt fails the
+   cap and never the cast (the two failures are distinct).
    - assert `derive_grant_object_commit(scope_salt, obj_color, recipient_kind, pinned_recipient, max_coin_value) == g.scope.object_commit`;
    - `p256` only: assert `derive_grant_rp_commit(scope_salt, rp_id_hash) == g.scope.rp_commit`;
-   - shielded twins: assert `coin.value <= max_coin_value` and
-     `enc_pk == enc_key`, so a rotation between the grantee's signing
-     and inclusion aborts the call instead of orphaning change;
    - assert `amount <= g.scope.per_call_cap`;
    - assert `derive_grant_spent_commit(scope_salt, spent_prev) == g.spent_commit`;
    - compute `wide = spent_prev + amount` in the widened type; assert
-     `wide <= g.scope.cap`; then narrow to `new_spent: Uint<128>` (the
-     order is normative; the two failures are distinct);
-   - assert `recipient_kind == 0 || (recipient_kind == <this twin's kind> && pinned_recipient == recipient.bytes)`.
+     `wide <= g.scope.cap`; then narrow to `new_spent: Uint<128>`;
+   - assert `recipient_kind == 0 || (recipient_kind == <this twin's kind> && pinned_recipient == recipient.bytes)`;
+   - shielded twins only: assert `coin.value <= max_coin_value` and
+     `enc_pk == enc_key`, so a rotation between the grantee's signing
+     and inclusion aborts the call instead of orphaning change.
 6. **Challenge and verification.** `h = challenge_<operation>_with_grant_<s>(...)`
    over the preimage of section 6.3. `k256`:
    `secp256k1EcdsaVerify(envelope_digest(envelope, h), sig, pk)`, both
@@ -708,15 +753,17 @@ authorisation MIP's amended section 5.1 requires:
 
 `DST = H(pad(64, "midnight:account:grant:auth:<marker>v1:<operation>"))`
 
-with `<marker>` empty for `v1`, `k1:` for `k1`, `r1:` for `r1`, and
-`<operation>` one of `withdraw_unshielded`, `withdraw_shielded`,
+with `<marker>` taken from the registry arm of the table in section 3.4
+and never derived from the wire `scheme` name: empty for `v1`, `k1:`
+for `k1`, `r1:` for `r1`; and `<operation>` one of
+`withdraw_unshielded`, `withdraw_shielded`,
 `withdraw_shielded_to_contract`. The longest member is 63 of 64 bytes;
 the 64-byte width is a normative budget on future operation names.
 
 | Arm | Preimage (in order) |
 |---|---|
 | ECDSA arms (`k1`, `r1`) | `DST \|\| self \|\| x \|\| y \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce)` |
-| JubJub arm (`v1`) | `DST \|\| self \|\| sig_r \|\| pk \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce) \|\| u64(grind_nonce)` |
+| JubJub arm (`v1`) | `DST \|\| self \|\| sig_r \|\| pk \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce) \|\| u64(grind_nonce)`, with `sig_r` and `pk` each the 64-byte `x \|\| y` form of section 3.4 |
 
 `...args` are the operation arguments in declaration order at their
 Compact widths: the unshielded twin's `color`, `u128(amount)`,
@@ -729,11 +776,14 @@ flattened in declaration order: `nonce` (32 bytes), `color` (32 bytes),
 are read from the record inside the circuit. ECDSA preimages exclude
 signature material (SIG-3); the JubJub arm grinds `grind_nonce` until
 the little-endian value of `h` is below the subgroup order (the
-authorisation MIP section 5.2). The shielded ECDSA preimage has thirteen
-elements and the JubJub one fourteen against an evidenced arity of ten;
-if the operation arguments must be pre-hashed into one `args_digest`
-element, the revised recipe takes a new trailing tag version before
-Proposed.
+authorisation MIP section 5.2). The shielded ECDSA challenge has
+thirteen declared tuple members (the `QualifiedShieldedCoinInfo` is one
+member), sixteen encoded elements, and 568 preimage bytes; the
+unshielded one 256 bytes. Both compile and hash as the raw
+concatenation, so no pre-hashing of the operation arguments is needed
+on the ECDSA arms. The JubJub shielded challenge has fourteen members
+and, by the recipe, 640 bytes (the two 64-byte point elements and the
+grinding nonce); it is not yet compiled and is measured in stage two.
 
 #### 6.4 Signing (grantee side)
 
@@ -797,25 +847,51 @@ section 12.
 Over the corresponding device twin a grant twin replaces two
 device-entry hashes with one identity hash and three commitment hashes,
 and adds one map lookup and insert, one widened comparison, one kernel
-comparison, and on shielded twins one inbox insert. Anchors, all to be
-re-measured on the grant twins (E1):
+comparison, and on shielded twins one inbox insert. Measured on the
+reference contract at `spec_version = 2` (E1 stage one, the k256 arms;
+proving times are not yet measured):
 
-| Arm | Measured anchor | Expected grant twin |
-|---|---|---|
-| `k256` | device seam k=15, 31,046 rows (envelope `0`); k=16, 32,900 rows (envelope `1`); 0.5 to 0.8 s | k=16 on either envelope |
-| `p256` | WebAuthn envelope k=16, 36,466 rows, 1.1 to 1.2 s | k=16 |
-| `jubjub` | well below (49 MB against 117 MB prover keys) | the device twin's k, or one above |
+| Circuit | k | Rows | Prover key |
+|---|---|---|---|
+| `withdraw_unshielded_with_k256` (device twin, for comparison) | 16 | 61,003 | 117 MB |
+| `withdraw_shielded_with_k256` (device twin, for comparison) | 17 | 74,587 | 235 MB |
+| `withdraw_unshielded_with_grant_k256` | 17 | 64,352 | 235 MB |
+| `withdraw_shielded_with_grant_k256` | 17 | 91,862 | 235 MB |
+| `issue_grant_with_k256` | 17 | 78,604 | 235 MB |
+| `revoke_grant_with_k256` | 16 | 58,997 | 117 MB |
+| `revoke_all_grants_with_k256` | 16 | 58,771 | 117 MB |
 
-The reference implementation already exports 18 non-pure circuits and
-exceeds the per-block byte and compute budgets, so it deploys in waves;
-a `spec_version = 2` account carries 30 (33 with p256) at about 2,950
-bytes of verifier key each, at least two waves, the later ones hand-built
-maintenance updates. The grant circuits MUST be part of the
-`spec_version = 2` deploy wave plan, and maintenance-authority retirement
-MUST follow the last grant wave: a retired account can never receive a
-future arm's circuits, so an account deployed without the grant circuits
-and then retired can never gain grants and must migrate. Pure circuits
-add no keys.
+The unshielded grant twin costs 3,349 rows more than its device twin
+and crosses to k=17, doubling the prover key; the shielded grant twin
+costs 17,275 rows more and stays at its device twin's k. The envelope
+is not a circuit-shape parameter (both digests are computed on every
+call), so k does not vary by envelope. k is not a pure function of the
+row count (device circuits of 64,924 and 65,404 rows fit k=16 while the
+unshielded grant twin at 64,352 needs k=17), so an implementation
+quotes k and rows as measured and never predicts one from the other.
+The jubjub grant twins, the remaining k256 twin, and the p256 twins are
+unmeasured; the standalone gate anchors recorded in Implementation are
+expectations only for those arms.
+
+Verifier keys depend on the circuit's shape and not on k: 2,745 bytes
+for every k256 circuit and 2,313 for every jubjub circuit (the deposits
+2,121 and 1,353). The reference implementation already exceeds the
+per-block byte and compute budgets with its 18 existing circuits, so it
+deploys in waves; the stage-one roster of 23 circuits carries 57,663
+verifier bytes (43,938 existing, 13,725 grant) against a 50,000-byte
+per-block write limit with about 9,138 bytes of deploy overhead beyond
+the keys, so a one-transaction deploy is refused and **two waves** are
+needed, the same count as today: the first as today (the two deposits
+and the eight k256 circuits, 25,434 verifier bytes), the second one
+hand-built maintenance update carrying the eight jubjub keys (18,504)
+and the five grant keys (13,725). The thirty-circuit roster (33 with
+p256) carries 74,286 verifier bytes and needs **three waves**, two of
+them maintenance updates. The grant circuits MUST be part of the
+`spec_version = 2` deploy wave plan, and maintenance-authority
+retirement MUST follow the last grant wave: a retired account can never
+receive a future arm's circuits, so an account deployed without the
+grant circuits and then retired can never gain grants and must migrate.
+Pure circuits add no keys.
 
 ### 7. Lifecycle
 
@@ -824,7 +900,8 @@ add no keys.
 All three lifecycle circuits are device-gated through the unchanged
 device seam, which advances `auth_nonce` and `round` before the body
 runs; every `Map.lookup` is dominated by a `member` branch (section 6.2
-step 2). The bodies are pending compilation.
+step 2). The bodies compile and execute off-node on the k256 device arm
+(Implementation); the jubjub device arm is stage two of E1.
 
 `issue_grant(grant_id, <plaintext scope>)`:
 
@@ -850,9 +927,13 @@ step 2). The bodies are pending compilation.
 ("unknown grant"); assert `active` ("grant not live"); rewrite the record
 unchanged except `active = false`.
 
-`revoke_all_grants()`: `grant_generation += 1`; optionally clear the map
-for state relief (a reset primitive is not evidenced); the generation
-check carries safety.
+`revoke_all_grants()`: `grant_generation += 1`; then MAY clear the map
+for state relief through the `Map` reset primitive, which the reference
+does (evidenced: the map is empty afterwards). With the reset, records
+are absent and a later grant twin fails at the membership assert
+("unknown grant") rather than at the generation check; tombstones and
+enumerability go with them. The generation check remains the safety for
+an implementation that omits the reset.
 
 The reference contract uses no spread or update syntax, so a conforming
 implementation spells every struct literal out in full.
@@ -866,8 +947,8 @@ implementation spells every struct literal out in full.
 | active or expired | `revoke_grant` | tombstone | `active = false` |
 | active | block time reaches `expires_at` | expired (lazy; record unchanged) | nothing |
 | any | recovery bumps `device_epoch` | inert by epoch | nothing (MAY clear the map) |
-| any | `revoke_all_grants` bumps `grant_generation` | inert by generation | `grant_generation` |
-| tombstone, expired, or inert | grant twin | abort, no state change | nothing |
+| any | `revoke_all_grants` bumps `grant_generation` | inert by generation, or absent where the implementation clears the map (the reference does) | `grant_generation`; MAY clear the map |
+| tombstone, expired, inert, or absent | grant twin | abort, no state change (an absent record fails at the membership assert) | nothing |
 
 Rules: every transition into active is device-gated and carries fresh
 consent over the whole scope; no in-place modification exists;
@@ -1096,7 +1177,7 @@ member rules. It is validated, never hashed or signed:
   "authenticator_data": "<base64url>",
   "signature": "<base64url>",
   "credential_pk": "<128 hex, companion passkey only>",
-  "key_signature": "<128 hex, software and wallet-provider grantees only>"
+  "key_signature": "<128 hex (k1) or 192 hex (v1), software and wallet-provider grantees only>"
 }
 ```
 
@@ -1114,7 +1195,7 @@ Encodings of the `Proof` members:
 | `client_data_json`, `authenticator_data` | base64url of the raw bytes the authenticator returned |
 | `signature` | base64url of the authenticator's ASN.1 DER `ECDSA-Sig-Value`, both `s` forms accepted |
 | `credential_pk` | 128 lowercase hex, affine `x \|\| y`, each coordinate a 32-byte little-endian integer (section 3.4) |
-| `key_signature` | the arm's off-chain form of section 3.4 (`k1` `r \|\| s`, `v1` `R \|\| s`), 128 lowercase hex |
+| `key_signature` | the arm's off-chain form of section 3.4, lowercase hex: `k1` `r \|\| s`, 128 hex; `v1` `R.x \|\| R.y \|\| s`, 192 hex |
 
 #### 9.2 Request digest and proof rules
 
@@ -1558,19 +1639,16 @@ MIP's SIG-1 through SIG-5 for the arms it deploys.
   New cells and structs are a redeploy (Backwards Compatibility
   Assessment); twins, lifecycle circuits, pure derivations, and tag
   families are maintenance updates while the authority is live, under
-  the wave rule of section 6.7. A flattened `GrantRecord` layout, if
-  adopted, takes its own `spec_version`. Enabling the window bounds later
-  is a circuit revision (`:v2` twins), not a redeploy.
+  the wave rule of section 6.7. Enabling the window bounds later is a
+  circuit revision (`:v2` twins), not a redeploy.
 - **Scheme.** A grant scheme is a new tag prefix under the authorisation
   MIP section 10's "policy structure" clause, with `grant` as the
-  policy-structure segment; a revision of any construction, including
-  the `scope_digest` and `args_digest` fallbacks, is a new trailing
-  version segment. Registry status: `v1` Active; `k1` Interim with the
-  schemes MIP's sunset, envelope-1 grantees `read`-only; `r1` Active
-  upon the schemes MIP receiving a number and the secp256r1 surface
-  shipping; `schnorr_bip340` reserved. The registry entry records the
-  pinned block-time unit and which layout and preimage variant is in
-  force.
+  policy-structure segment; a revision of any construction is a new
+  trailing version segment. Registry status: `v1` Active; `k1` Interim
+  with the schemes MIP's sunset, envelope-1 grantees `read`-only; `r1`
+  Active upon the schemes MIP receiving a number and the secp256r1
+  surface shipping; `schnorr_bip340` reserved. The registry entry
+  records the pinned block-time unit.
 - **Tag families**, all to be registered under the MPS-0027 registry (an
   acceptance criterion):
 
@@ -1735,7 +1813,9 @@ signed unit.
       (all lifecycle circuits on both device arms; k256 twins on both
       envelopes; jubjub twins), with rows, k, prover-key size, and
       proving time per twin; the layout, arity, and change-append
-      fallbacks settled; Testing item 1 green.
+      fallbacks settled; Testing item 1 green (stage one complete: k256
+      grantee arm, two twins, lifecycle on the k256 device arm, vectors;
+      stage two lists the remainder).
 - [ ] E2: Testing item 2 green on a node, each case ending with the
       invariants it exercises.
 - [ ] E3: the on-chain unit of `kernel.blockTimeLessThan` and the
@@ -1853,7 +1933,7 @@ the salt.
 | S5 | Request replay | `aud`, `iat`, `exp` under `request_digest`; one-time `nonce`; `account` MUST when known (9.1) |
 | S6 | Key substitution by a compromised authoriser | the dApp recomputes `grant_id` and the openings and treats a mismatch as compromise (9.7); in-circuit derivation rejected (R2) |
 | S7 | Grantee signature replay | `nonce` read in-circuit and advanced; `grant_id` and `issued_at` bound (6.3) |
-| S8 | Blind-signing oracle through connector `signData` | envelope-1 grantees `read`-only (3.2) |
+| S8 | Blind-signing oracle through connector `signData` | envelope-1 grantees `read`-only, refused by the authoriser and asserted in-circuit by every `k1` grant twin (3.2, 6.2 step 1) |
 | S9 | Scope creep or upward adjustment | only device-gated circuits write scope; attenuation only; modify is revoke plus issue (7.2) |
 | S10 | Object-scope bypass through the witness coin | `coin.color` and `coin.value` asserted before the chip (6.2 step 5) |
 | S11 | Change orphaning, including by a rotation racing a pending call | `max_coin_value`; the change entry appended in the same transaction; `enc_pk == enc_key` (6.2 step 5) |
@@ -1895,17 +1975,22 @@ the salt.
 | the reference implementation's wave deploy and block-limit numbers | the deploy budget rule of section 6.7 |
 | the kernel block-time comparison compiling and executing | lazy expiry is expressible; its unit is not held |
 | the cross-contract-calls experiment | composition in one transaction |
+| E1 stage one: the grant seam compiled on the reference contract at `spec_version = 2` (the two cells and structs, the pure derivations, the k256 seam chips, the unshielded and shielded k256 grant twins, and the three lifecycle circuits on the k256 device arm), measured at k=16 to 17, 58,771 to 91,862 rows, 2,745-byte k256 and 2,313-byte jubjub verifier keys, and executed off-node in a circuit simulator (lifecycle, the unshielded twin, its rejection matrix) | the circuit items settled: a struct as a `Map` value, `Boolean` as a one-byte hash element, tuple arities of thirteen and seventeen hashed as the raw concatenation, the kernel block-time comparison inside an assert, the `if`-guarded lifecycle bodies, and the `Map` reset primitive; the byte recipes of sections 4 and 6.3 reproduced two ways from the text alone (a TypeScript recipe and a Rust recipe linking no compiled module) against the compiled circuits, 27 vectors and two pinned signatures; the deploy budget of section 6.7 |
 
 Not yet held: any connection protocol on Midnight, origin binding,
-expiry on node, signature-based grantee authentication in the grant
-seam, and the cost of grant verification under real signature circuits;
-these are the experiments of Path to Active.
+expiry on node, proving times per twin, the on-node matrix, the jubjub
+grantee twins, the remaining k256 twin
+(`withdraw_shielded_to_contract_with_grant_k256`), and the lifecycle
+circuits on the jubjub device arm; these are stage two of E1 and the
+remaining experiments of Path to Active.
 
-The reference contract gains the two cells, the two structs, the pure
-derivations, the three seam chips, three twins per grantee arm, three
-lifecycle circuits per device arm, and `spec_version = 2`; the Rust
-signer produces bit-identical `grant_id`, commitments, and challenges
-from the byte recipes alone. A static consent page implementing section
+At stage one the reference contract carries the two cells, the two
+structs, the pure derivations, the k256 seam chips, two k256 twins,
+three lifecycle circuits on the k256 device arm, and `spec_version = 2`,
+and the Rust signer produces bit-identical `grant_id`, commitments, and
+k1 challenges from the byte recipes alone; stage two completes three
+twins per grantee arm and three lifecycle circuits per device arm. A
+static consent page implementing section
 9 and a dApp implementing the return leg and sign-in, each runnable
 locally, are the E4 and E7 artefacts. Companion documents: the MPS-0018
 Recommended MIPs bullet, the erratum of section 12, the custody MIP R9
@@ -1921,6 +2006,9 @@ the following. Each item names the invariants it exercises.
 1. **Grant happy path.** Issue from a device; a grant call within scope
    executes; `nonce` advances, `spent_commit` re-commits, `round`
    advances, `auth_nonce` is unchanged (GR-1, GR-5, GR-13; INV-7).
+   Status: green off-node for the unshielded k256 twin in the circuit
+   simulator (no proof, no node); the shielded twins and the node run
+   are pending.
 2. **Rejection matrix.** The same call aborts with no state change under
    each single fault: out-of-scope operation; over `per_call_cap`; over
    `cap`; a cumulative wrap attempt; a witness coin of another color; a
@@ -1928,7 +2016,8 @@ the following. Each item names the invariants it exercises.
    recipient-kind mismatch; a stale `enc_pk`; revoked; expired; stale
    epoch; stale generation; identical resubmission after success; a
    prior-incarnation signature against a re-issue; a cross-scheme key; a
-   wrong envelope (k1); the identity, small-order, off-curve, and
+   wrong envelope (k1); an envelope-1 grantee against any withdraw twin
+   refused in-circuit (k1); the identity, small-order, off-curve, and
    invalid-curve keys on every deployed arm; a grantee calling any
    device-gated or lifecycle circuit; re-issue of a live id rejected;
    re-issue of an expired but unrevoked id rejected, and revoke plus
@@ -1970,7 +2059,15 @@ the following. Each item names the invariants it exercises.
    normalisation from SEC 1 and the `v1` wire form; one off-chain
    signature vector per arm and a high-S vector per ECDSA arm that MUST
    verify; negative vectors for weak, identity, and low-order keys
-   (GR-3, GR-4, GR-14).
+   (GR-3, GR-4, GR-14). Status: green offline for every derivation of
+   section 4, the k1 challenges of section 6.3 (unshielded and shielded,
+   with the qualified coin written out) and the three k1 lifecycle
+   challenges, `envelope_digest`, and `origin_hash`, agreed three ways
+   (compiled circuits, TypeScript, Rust) over 27 published vectors with
+   two pinned k1 signatures, the high-S k1 twin included; pending are the
+   v1 and r1 challenges and signature vectors, `request_digest`,
+   `signin_digest`, the `read_pk` derivation, GrantViewSeal, and the
+   negative key vectors.
 6. **Deploy budget.** The full `spec_version = 2` roster deployed in
    waves within the per-block parameters; authority retirement after the
    last wave; a `spec_version = 1` account shown unable to gain grants
@@ -2076,6 +2173,11 @@ the following. Each item names the invariants it exercises.
   [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
   repository; the commit the evidence was taken at is recorded on
   submission.
+- E1 stage one (Implementation): the findings at `contract/GRANTS-E1.md`
+  and the vectors at `contract/src/tests/vectors/grants-e1.json` on the
+  branch `nicolasdp/grants-seam-e1` of the
+  [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
+  repository.
 
 ## Acknowledgements
 

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -47,6 +47,7 @@ MPS: MPS-0018
      | O11 | re-seal obligation toward other live read grants on every rotation | adopted as an authoriser MUST with a roster fallback |
      | O12 | Replaces: none per the brief and the published family | adopted |
      | O13 | Security Considerations rendered as a table where the published family uses bold-titled Sn bullets | table retained; the divergence is offered to the editors |
+     | O14 | approved deviation from brief T5: canonical JSON (RFC 8785, JCS) replaced by signing the `request` parameter bytes as received, with the proof carried as a detached `proof` fragment parameter and no canonicalisation step anywhere | adopted (sections 9.1 to 9.4, 9.6, R10, R21) |
 
      Upstream dependencies: secp256r1 in the Compact language surface (r1
      arm); secp256k1 point operations (schnorr_bip340); a connector
@@ -234,12 +235,16 @@ Out of scope:
 - **Browser binding**: delivery of a `GrantRequest` by top-level
   navigation to an authoriser page. **Non-browser binding**: any other
   delivery (a pasted or scanned object, a local channel).
+- **Proof**: the possession-and-origin proof object that travels beside
+  a `GrantRequest` as a separate parameter and is never part of the
+  signed bytes (section 9.2).
 - **Notation.** `H(x)` is SHA-256 of `x`. `pad(N, s)` is the ASCII bytes
   of `s` followed by zero bytes to `N` bytes; `s` longer than `N` is
   invalid. `u8(n)`, `u64(n)`, `u128(n)` serialise `n` little-endian at 1,
   8, and 16 bytes. `flag(b)` is `0x01` for true and `0x00` for false.
   `int_le(x)` is the integer whose little-endian encoding is `x`. `||`
-  is byte concatenation.
+  is byte concatenation. `base64url(x)` is the RFC 4648 section 5
+  encoding of `x` without padding.
 
 ### 3. Grantee keys and arms
 
@@ -1010,10 +1015,14 @@ public and need no capability.
 
 #### 9.1 The object
 
-One transport-independent `GrantRequest` object, canonical JSON per RFC
-8785 (JCS), base64url-encoded without padding. `Uint<128>` values are
-decimal strings. Field names follow RFC 6749 where a parameter has an
-OAuth analogue.
+One transport-independent `GrantRequest` object, a JSON object in any
+serialisation the dApp chooses, carried as `base64url(UTF-8 JSON)` in a
+`request` parameter. No canonical form exists and none is computed:
+what is signed is the parameter value as transmitted (section 9.2).
+`Uint<128>` values are decimal strings. Field names follow RFC 6749
+where a parameter has an OAuth analogue. The proof of possession is not
+a member of the object; it is a separate `Proof` object carried beside
+it in a `proof` parameter.
 
 ```json
 {
@@ -1042,15 +1051,7 @@ OAuth analogue.
   ],
   "read_pk": "<64 hex X25519>",
   "state": "<base64url, at least 128 bits>",
-  "nonce": "<64 hex, 32 bytes>",
-  "proof": {
-    "type": "webauthn",
-    "client_data_json": "<base64url>",
-    "authenticator_data": "<base64url>",
-    "signature": "<base64url>",
-    "credential_pk": "<hex, companion passkey only>",
-    "key_signature": "<hex, software and wallet-provider grantees only>"
-  }
+  "nonce": "<64 hex, 32 bytes>"
 }
 ```
 
@@ -1078,9 +1079,35 @@ calls into one transaction or submits them in sequence.
 | `read_pk` | MUST when `read` is requested or implied | per section 8 item 1 |
 | `state` | MUST | opaque, at least 128 bits of entropy, at most 512 characters, bound to the dApp's browser session, echoed verbatim |
 | `nonce` | MUST | 32 random bytes, hex; one-time within the validity window |
-| `proof` | MUST | possession and origin proof over `request_digest` (section 9.2) |
 
-Encodings of the `proof` members:
+Every member listed is the complete member set: an object carrying an
+unknown member, a duplicated member, or a member of the wrong JSON type
+is `invalid_request`. Parsing happens after hashing (section 9.4).
+
+**The `Proof` object.** The possession and origin proof over
+`request_digest` (section 9.2), a JSON object carried as
+`base64url(UTF-8 JSON)` in the `proof` parameter, subject to the same
+member rules. It is validated, never hashed or signed:
+
+```json
+{
+  "type": "webauthn",
+  "client_data_json": "<base64url>",
+  "authenticator_data": "<base64url>",
+  "signature": "<base64url>",
+  "credential_pk": "<128 hex, companion passkey only>",
+  "key_signature": "<128 hex, software and wallet-provider grantees only>"
+}
+```
+
+| Member | Required | Rule |
+|---|---|---|
+| `type` | MUST | `webauthn` or `signature`; `signature` in the browser binding is `invalid_proof` |
+| `client_data_json`, `authenticator_data`, `signature` | MUST when `type` is `webauthn`; MUST be absent otherwise | the assertion the authenticator returned, verified per section 9.2 |
+| `credential_pk` | MUST for a software or wallet-provider grantee under `webauthn`; MUST be absent for an `r1` grantee, whose assertion is by `grantee.pk` itself, and under `signature` | the companion passkey |
+| `key_signature` | MUST for every grantee other than `r1`; MUST be absent for `r1` | a signature by `grantee.pk` over `request_digest` in the arm's off-chain form |
+
+Encodings of the `Proof` members:
 
 | Member | Encoding |
 |---|---|
@@ -1091,7 +1118,24 @@ Encodings of the `proof` members:
 
 #### 9.2 Request digest and proof rules
 
-`request_digest = H(pad(64, "midnight:account:grant:request:v1") || H(JCS(request without "proof")))`.
+`request_digest = H(pad(64, "midnight:account:grant:request:v1") || request_param_bytes)`,
+
+where `request_param_bytes` is the ASCII bytes of the `request`
+parameter value exactly as received: the base64url text, not the
+decoded JSON. The dApp signs the very string it places in the URL, and
+an authoriser MUST hash the received parameter value before any
+decoding and MUST NOT re-serialise, re-encode, or otherwise transform it
+first. There is no canonicalisation step: two serialisations of the
+same object are two different requests, and a request whose bytes were
+altered in transit, by whitespace, key order, or percent-encoding,
+fails its proof and nothing else. A base64url value MUST consist of the
+RFC 4648 section 5 alphabet only, without padding, so no
+percent-encoding applies to it and the bytes the dApp wrote are the
+bytes the authoriser receives. The `Proof` object is outside the signed
+bytes; a change to it fails verification without changing
+`request_digest`. In a WebAuthn assertion the challenge is
+`request_digest` itself, so `clientDataJSON.challenge` is the 43-byte
+unpadded `base64url(request_digest)`.
 
 Proof rules in the browser binding:
 
@@ -1121,6 +1165,9 @@ Non-browser bindings (agents, `self:` delegates) carry
 `proof.type = "signature"` with `key_signature` only; the identity is
 displayed as operator-asserted or as the owner's own label.
 `proof.type = "signature"` in the browser binding is `invalid_proof`.
+In every binding the same two strings travel, `request` and `proof`,
+and the signed bytes are the `request` string as transmitted over that
+channel.
 
 **The binding is a property of the transport.** A request received by
 top-level navigation MUST get the browser binding regardless of the
@@ -1143,8 +1190,14 @@ extension.
 #### 9.3 Browser binding: request delivery
 
 Top-level GET navigation to
-`https://<authoriser>/grant#request=<base64url(JCS(GrantRequest))>`.
-The request travels in the fragment, never in the query component.
+`https://<authoriser>/grant#request=<base64url(UTF-8 JSON GrantRequest)>&proof=<base64url(UTF-8 JSON Proof)>`.
+Both travel in the fragment, never in the query component, as two
+form-encoded parameters in either order. The dApp serialises the
+`GrantRequest` once, base64url-encodes that serialisation, signs the
+resulting string (section 9.2), and places that same string in the URL
+unchanged; it MUST NOT re-serialise between signing and navigation.
+Each parameter MUST appear exactly once; a missing or repeated
+`request` or `proof` parameter is `invalid_request`.
 
 #### 9.4 Authoriser processing
 
@@ -1155,20 +1208,27 @@ In order:
    `Content-Security-Policy: frame-ancestors 'none'` and
    `Cross-Origin-Opener-Policy: same-origin`, and checks that it is the
    top window.
-2. Read and strip the fragment with `history.replaceState`.
-3. Verify `v`, `chain`, `aud`, `iat`, `exp`, `nonce` freshness, and
-   `proof`. Reject with an in-place error page (no redirect) if
-   `redirect_uri` is not `https`, not same-origin with `client_id`, or
-   carries a fragment.
-4. Verify the scheme is registered and the account is capable
+2. Read and strip the fragment with `history.replaceState`; take the
+   `request` and `proof` parameter values as received.
+3. Hash, then decode. Compute `request_digest` over the ASCII bytes of
+   the `request` value before any decoding (section 9.2). Then
+   base64url-decode and JSON-parse both values and validate them
+   against the member sets of section 9.1; a value that does not decode
+   or parse, or an object with an unknown, duplicated, or wrongly typed
+   member, is `invalid_request`.
+4. Verify `v`, `chain`, `aud`, `iat`, `exp`, `nonce` freshness, and
+   the `Proof` object against `request_digest`. Reject with an in-place
+   error page (no redirect) if `redirect_uri` is not `https`, not
+   same-origin with `client_id`, or carries a fragment.
+5. Verify the scheme is registered and the account is capable
    (`spec_version >= 2`, and the arm deployed per the authoriser's own
    record, since verifier keys are not a specified chain read); check
    `bounds`, the implications, and the envelope-1 read-only rule.
-5. Sign the user in with an authoriser credential whose relying-party
+6. Sign the user in with an authoriser credential whose relying-party
    (RP) identifier equals the full authoriser host, never a parent
    domain; this sign-in assertion yields no signing material.
-6. Render the consent screen of section 9.5.
-7. On approval, and only then, perform the authorising ceremony: the
+7. Render the consent screen of section 9.5.
+8. On approval, and only then, perform the authorising ceremony: the
    WebAuthn assertion whose PRF output derives the device key is
    requested with `challenge = challenge_issue_grant_with_<device arm>(...)`,
    so that `clientDataJSON` itself binds the approved scope and the
@@ -1257,7 +1317,7 @@ repetitions are index-aligned with the request.
 | `account` | granted, pending | contract address hex |
 | `grant_id` | granted, pending; per record | hex |
 | `scope_salt` | granted, pending; per record | hex |
-| `scope` | granted, pending; per record | the approved plaintext scope as a JCS object, base64url: the four flags, `color`, `recipient_kind`, `recipient`, `max_coin_value`, `per_call_cap`, `cap`, `expires_at` |
+| `scope` | granted, pending; per record | the approved plaintext scope as a JSON object, `base64url(UTF-8 JSON)`, in any serialisation: the four flags, `color`, `recipient_kind`, `recipient`, `max_coin_value`, `per_call_cap`, `cap`, `expires_at`; it is not signed, and the dApp verifies it against chain state (section 9.7) |
 | `tx` | pending, optionally granted | transaction identifier |
 | `view` | granted with `read` | GrantViewSeal v1, base64url (section 8) |
 | `error`, `error_description` | error, denied | from the tables below |
@@ -1271,13 +1331,15 @@ query component; if `redirect_uri` failed validation the authoriser MUST
 NOT redirect at all. In a non-browser binding the authoriser returns the
 same parameter set as a structured object over the channel that carried
 the request, omitting `state`, `iss`, and `redirect_uri`; the grantee
-performs the recomputation and chain read of section 9.7.
+performs the recomputation and chain read of section 9.7. Nothing on
+the return leg is signed, so no serialisation of it is normative;
+authority rests on the chain record.
 
 Errors rendered in place (never delivered to `redirect_uri`):
 
 | `error` | When |
 |---|---|
-| `invalid_request` | malformed object, missing member, bad encoding, `state` too short, `aud` mismatch, outside `[iat, exp]`, replayed `nonce`, `redirect_uri` invalid or not same-origin with `client_id`, `client_id` matching no production of section 4.4 or non-browser by navigation, invalid `read_pk`, re-seal to a `read_pk` other than the bound one |
+| `invalid_request` | a `request` or `proof` parameter missing, repeated, not base64url, or not JSON; an unknown, duplicated, or wrongly typed member; a missing member; `state` too short, `aud` mismatch, outside `[iat, exp]`, replayed `nonce`, `redirect_uri` invalid or not same-origin with `client_id`, `client_id` matching no production of section 4.4 or non-browser by navigation, invalid `read_pk`, re-seal to a `read_pk` other than the bound one |
 
 Errors delivered to a validated `redirect_uri`:
 
@@ -1483,7 +1545,7 @@ MIP's SIG-1 through SIG-5 for the arms it deploys.
 | GR-14 (key validity) | Every grantee key is rejected at every use, and at issuance, by exactly the per-arm checks of section 3.3, including the identity key on every arm and SEC 1 validation on `r1`. | authorisation MIP S2 and its erratum 6 on weak device keys |
 | GR-15 (bounded disclosure) | A grant call discloses `grant_id`, the record update, the kernel comparison argument, and the custody chip's disclosures, and never the grantee key, origin, dApp host, slot, salt, openings, or signature; no grant field records any part of a held coin's description in the clear. | INV-2; AUTH-9 as amended |
 | GR-16 (consent equals record) | Every plaintext scope field is an argument of `issue_grant` and enters the device challenge through `scope_digest`; consent renders from those fields and a possession-and-origin-proven request and precedes the ceremony that produces signing material; the dApp verifies the recorded grantee on return. | |
-| GR-17 (redirect binding) | The authoriser acts only on a request whose possession proof shows a credential on the requesting origin, whose `aud` names it, whose window is current and `nonce` unseen, whose `redirect_uri` is same-origin with the attested `client_id` and matched exactly, and whose `state` it echoes; the binding is chosen by the transport; the response carries no bearer artefact or key list; the dApp treats its grant as live only after recomputing `grant_id` and reading the record from chain. | RFC 9700 sections 2.1, 4.1.3, 4.10; RFC 9207 |
+| GR-17 (redirect binding) | The authoriser acts only on a request whose possession proof, computed over the request bytes as received, shows a credential on the requesting origin, whose `aud` names it, whose window is current and `nonce` unseen, whose `redirect_uri` is same-origin with the attested `client_id` and matched exactly, and whose `state` it echoes; the binding is chosen by the transport; the response carries no bearer artefact or key list; the dApp treats its grant as live only after recomputing `grant_id` and reading the record from chain. | RFC 9700 sections 2.1, 4.1.3, 4.10; RFC 9207 |
 | GR-18 (read is a capability, and it is total) | `read` is declarative and the ledger does not enforce a read scope; a grant with `read` confers the whole viewing capability until rotation; the secret is delivered sealed to a bound `read_pk`; rotate-before-share precedes every read issuance and every rotation re-seals or flags the other live read grants; a read revocation rotates `enc_key`; every inbox reader verifies each entry against chain data. | custody MIP R9, S2, section 6.5 |
 
 ### 14. Versioning
@@ -1611,13 +1673,36 @@ them as the object their signatures target, and reuses their vocabulary.
 MIP-0015's `deriveSecret` is seed-anchored and a seedless account cannot
 satisfy it.
 
+**R21. Signed as received, not a JWS container.** The request object
+has the shape of an OAuth request object (RFC 9101), and the obvious
+container for a signed JSON object is a JWS (RFC 7515). It was rejected
+for three reasons. First, the browser proof is a WebAuthn assertion,
+whose signing input is `authenticatorData || SHA-256(clientDataJSON)`
+with the challenge inside `clientDataJSON`; that is not the JWS signing
+input, so no JOSE library could verify the proof this MIP relies on and
+the container would be a wrapper around a signature it cannot check.
+Second, JOSE registers no algorithm for Schnorr over JubJub, the `v1`
+arm, and none for the connector's prefixed ECDSA envelope. Third, a JWT
+is a bearer token verified by machines at scale, and its known failure
+modes (`alg` confusion, `none`, key-id injection) are costs with no
+matching benefit for a request that a human approves once on a consent
+screen. What was borrowed from JWS is the rule that made it robust:
+sign the transmitted bytes rather than a canonicalised object, so no
+canonicalisation step exists to disagree about; carry the proof
+detached from the payload, as an RFC 7515 detached content signature
+does; and reuse the `aud`, `iat`, `exp`, and `nonce` claim names that
+JWT-family request objects carry (RFC 9101). RFC 8785 canonical JSON
+was the earlier choice; it added a specification every implementer had
+to get byte-exact for no gain once the parameter value itself is the
+signed unit.
+
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
 | R3 identity element | one-byte `slot`; request `nonce` bound only in `request_digest` | a 32-byte request nonce in `grant_id` | an unbounded nonce let one key hold records the owner could not enumerate and made the nonce a capability secret in URLs |
 | R4 freshness | the record's `nonce`, read from state | the shared `auth_nonce`; a nonce argument | a grantee advancing `auth_nonce` could void the owner's pending signatures; a dead argument invites the omission of the check |
 | R5 incarnation | contract-written `issued_at` in every challenge | nonce continuity; never reusing an id | closes a pre-revocation signature verifying against a re-issue; every issuance is a distinct credential |
 | R7 change | `max_coin_value`; the change entry as a bound argument appended in the same circuit; `enc_pk == enc_key` | a standalone `append_inbox` twin | the twin wrote unbounded entries under a no-value scope; the equality makes a rotation abort the call rather than orphan change |
-| R10 request transport | one JCS object in the fragment on both legs | loose query parameters | canonical JSON has a published specification; the fragment stays out of logs and `Referer`, not out of history (S19) |
+| R10 request transport | one base64url JSON object in the fragment on both legs, signed as transmitted, with a detached `proof` parameter | loose query parameters; a canonicalised object; a JWS container (R21) | a single parameter value is the signed unit and needs no canonicalisation; the fragment stays out of logs and `Referer`, not out of history (S19) |
 | R12 sign-in | grant-backed, address-disclosing | an identity-only grant; a verifiable-random-function (VRF) identity | an identity-only grant costs a transaction for plain login; address hiding belongs to the sign-in MIP; the target credentials only sign |
 | R14 wire names | connector spellings plus two registry spellings | registry short names | wallets already emit the connector strings |
 | R15 network | no `network_id` cell; the wire `chain` member | a network cell; MIP-0008 in `Requires` | independent deployments already differ by address; a cell the ledger does not assert separates nothing; the record embeds no network identifier, so MIP-0008 is cited, not required; no cell defeats a state-preserving fork |
@@ -1761,7 +1846,7 @@ the salt.
 
 | | Attack | Mitigation |
 |---|---|---|
-| S1 | Grant injection (login CSRF) | possession proof over `request_digest`; browser-attested origin on every navigation; session-bound `state`. Residual (9.2): the proof shows a credential on the origin, not the dApp's front-end; consent and the roster are the remaining barriers |
+| S1 | Grant injection (login CSRF) | possession proof over `request_digest`, hashed from the `request` bytes as received (9.2); browser-attested origin on every navigation; session-bound `state`. Residual (9.2): the proof shows a credential on the origin, not the dApp's front-end; consent and the roster are the remaining barriers |
 | S2 | Open redirector | `redirect_uri` `https`, same-origin with the proven `client_id`, exact match; none in non-browser bindings (9.7) |
 | S3 | Binding downgrade by `client_id` form | the binding is a property of the transport (9.2) |
 | S4 | Mix-up between authorisers | `iss` string equality; the grant is read from chain, never from redirect parameters (9.7) |
@@ -1860,9 +1945,13 @@ the following. Each item names the invariants it exercises.
    mismatch; `iss`, `aud` mismatch; expired request; replayed `nonce`;
    proof failure; `clientDataJSON.origin` mismatch; an `rdns:`
    `client_id` by navigation refused; a `client_id` outside the
-   productions of section 4.4 refused; an r1 proof under the identity
-   key refused; an envelope-1 withdraw refused; a non-canonical or
-   low-order `read_pk` refused; a `grant_id` or opening mismatch on
+   productions of section 4.4 refused; a `request` value re-serialised
+   in transit (whitespace or key order changed) whose proof therefore
+   fails; a repeated `request` or `proof` parameter refused; an object
+   with an unknown, duplicated, or wrongly typed member refused; a
+   `proof` value altered with `request` unchanged refused; an r1 proof
+   under the identity key refused; an envelope-1 withdraw refused; a
+   non-canonical or low-order `read_pk` refused; a `grant_id` or opening mismatch on
    return treated as compromise; a narrowed request whose returned scope
    opens `object_commit`; a sibling-origin assertion against the
    authoriser credential; fragment leakage under a logging reverse proxy
@@ -1872,8 +1961,10 @@ the following. Each item names the invariants it exercises.
    including a read-only `object_commit`, `rp_commit` for an r1 and a
    non-r1 grant, and one recipient projection per kind; every challenge
    of section 6.3 with the qualified coin written out element by
-   element; `envelope_digest`, `origin_hash`, `request_digest`,
-   `signin_digest`, the `read_pk` derivation, and GrantViewSeal,
+   element; `envelope_digest`, `origin_hash`, `request_digest` over a
+   published `request` parameter string with its decoded object and
+   detached `Proof` beside it, `signin_digest`, the `read_pk`
+   derivation, and GrantViewSeal,
    bit-identical between the compiled contract, the TypeScript client,
    and a Rust implementation linking no compiled module; `pk`
    normalisation from SEC 1 and the `v1` wire form; one off-chain
@@ -1957,12 +2048,15 @@ the following. Each item names the invariants it exercises.
 
 **External standards**
 
-- RFC 2119; RFC 3986 (unreserved characters); RFC 6749 (OAuth 2.0
-  parameter names, section 4.1.2.1 errors); RFC 9700 (OAuth 2.0
-  Security Best Current Practice, sections 2.1, 4.1.3, 4.2, 4.10); RFC
-  9207 (`iss`); RFC 8785 (JSON Canonicalization Scheme); RFC 6454 (web
-  origin); RFC 7748 (X25519, clamping, contributory behaviour); RFC 5869
-  (HKDF).
+- RFC 2119; RFC 3986 (unreserved characters); RFC 4648 (base64url,
+  section 5); RFC 6749 (OAuth 2.0 parameter names, section 4.1.2.1
+  errors); RFC 9700 (OAuth 2.0 Security Best Current Practice, sections
+  2.1, 4.1.3, 4.2, 4.10); RFC 9207 (`iss`); RFC 9101 (OAuth 2.0
+  JWT-Secured Authorization Request, the request-object precedent and
+  the claim names, R21); RFC 7515 (JSON Web Signature, the
+  sign-the-transmitted-bytes and detached-signature precedents, R21);
+  RFC 6454 (web origin); RFC 7748 (X25519, clamping, contributory
+  behaviour); RFC 5869 (HKDF).
 - W3C Web Authentication Level 3 (client data, authenticator data, RP ID
   scoping, the PRF extension, Related Origin Requests).
 - SEC 1 (point encodings and validation); the Jubjub curve specification

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -2247,7 +2247,7 @@ the following. Each item names the invariants it exercises.
 - E3 (Implementation): the findings at `contract/GRANTS-E3.md` and the
   evidence at `contract/evidence/block-time-unit.json` and
   `contract/evidence/block-time-sweep.json` on the branch
-  `nicolasdp/grants-e3-block-time` of the
+  `nicolasdp/grants-seam-e1` of the
   [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
   repository.
 

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -1,0 +1,2573 @@
+---
+MIP: xxxx
+Title: Scoped Grants and dApp Connection for Custody Accounts
+Authors:
+  - Nicolas Di Prima (NicolasDP)
+  - TBD external co-author [RULING]
+Status: Draft
+Category: Standards
+Created: 2026-09-09
+License: Apache-2.0
+Requires: "MIP-0012: Contract Custody of Midnight-Native Assets", "MIP-0013: Multi-key Account Authorisation for Custody Contracts"
+Replaces: N/A
+MPS: MPS-0018
+---
+
+<!--
+ Copyright 2026 Midnight Foundation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- WORKING DRAFT. Open items are tagged inline and collected in
+     Specification section 15: [RULING] = pending a product, policy, or
+     editorial decision; [DEP] = blocked on an upstream Compact, ledger,
+     connector, or browser feature; [CIRCUIT] = pending circuit evidence;
+     [CRYPTO] = pending cryptographer review. Every tag carries the
+     default the text currently adopts. -->
+
+## Table of contents
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification](#specification)
+  - [1. Scope of this document](#1-scope-of-this-document)
+  - [2. Terminology](#2-terminology)
+  - [3. Grantee keys and arms](#3-grantee-keys-and-arms)
+  - [4. Ledger state and grant identity](#4-ledger-state-and-grant-identity)
+  - [5. Scope semantics](#5-scope-semantics)
+  - [6. The grant seam](#6-the-grant-seam)
+  - [7. Lifecycle](#7-lifecycle)
+  - [8. Read-scope delegation](#8-read-scope-delegation)
+  - [9. GrantRequest and the redirect binding](#9-grantrequest-and-the-redirect-binding)
+  - [10. Sign-in](#10-sign-in)
+  - [11. Ecosystem carriage](#11-ecosystem-carriage)
+  - [12. Invariants](#12-invariants)
+  - [13. Companion erratum to MIP-0013 section 9](#13-companion-erratum-to-mip-0013-section-9)
+  - [14. Versioning](#14-versioning)
+  - [15. Open items](#15-open-items)
+- [Rationale](#rationale)
+- [Path to Active](#path-to-active)
+- [Backwards Compatibility Assessment](#backwards-compatibility-assessment)
+- [Security Considerations](#security-considerations)
+- [Implementation](#implementation)
+- [Testing](#testing)
+- [References](#references)
+- [Acknowledgements](#acknowledgements)
+- [Copyright Waiver](#copyright-waiver)
+
+## Abstract
+
+This MIP specifies a second authoriser class behind the authorisation
+seam of MIP-0013, the **scoped grant**, and the ceremony by which a
+third party obtains one. A grant is a contract-maintained record in a
+custody account conforming to MIP-0012 and MIP-0013 that admits one
+grantee key of one registered signature scheme to a bounded subset of
+the account's asset-facing operations: three spend circuits, one token
+color, a per-call cap, a cumulative cap, a bound on the value of any
+coin the grantee may touch, an optional recipient pin, and an optional
+expiry. Scope is enforced in-circuit on every call, and any active
+device can revoke a grant from chain state. A grant may also be
+read-only, in which case the record anchors, enumerates, and revokes an
+otherwise invisible viewing capability.
+
+The record is keyed by a contract-recomputable identity over the
+account address, the grantee key, its origin, and a small slot number,
+so that one credential has at most one live record per slot and every
+record of a grantee is enumerable from public state. Fields that would
+name a held coin's color, a counterparty, or a released value are
+stored as salted commitments, so the custody invariants of MIP-0012
+hold unchanged. Freshness is a per-grant nonce read from the record
+inside the circuit; grant calls never touch the device counter.
+
+The connection flow is the normative redirect binding of one
+transport-independent `GrantRequest` object: a dApp redirects the user
+to an authoriser page carrying its origin and key with a
+browser-attested proof of possession; the user authenticates with the
+account's device passkey, sees exactly the scope the ledger will
+record, approves; the authoriser submits one device-gated `issue_grant`
+call; the user returns to the dApp, which verifies its grant by reading
+chain state and thereafter signs in with the passkey registered for that
+dApp. The same record and seam serve agents and intra-user delegation
+through non-browser bindings. Read access is delivered as the MIP-0012
+viewing capability sealed to a dApp-supplied key, and the MIP states as
+its dominant residual risk that the ledger enforces spend scope and not
+read scope.
+
+## Motivation
+
+MIP-0012 fixes how a custody contract holds and releases value behind
+one abstract seam, `require_authorised()`, and its section 2 names
+"delegated or scoped spending policies (grants, allowances, session
+permissions)" as authorisation-policy objects behind that same seam,
+deferred to a conforming extension. MIP-0013 instantiates the seam with
+device keys and states in its section 4 that "scoped grants are
+permitted extensions that interact only with this seam and MUST NOT
+weaken any invariant of section 9". Its security consideration S7
+records the gap that makes the extension necessary: `add_device` grants
+full authority, so today the only way to let any third party act on an
+account is to make it a device. This document is the reserved
+extension.
+
+Three inadequacies of the current ecosystem motivate the shape chosen.
+
+**There is no bounded authority.** A dApp that wants to show an
+account's holdings, or to move a bounded amount of one token on the
+user's behalf, has today two options on a MIP-0013 account: hold a full
+device key, which is total compromise of asset release if the dApp is
+compromised (MIP-0013 S5), or hold nothing and route every action
+through the owner's own client. Neither is a connection. The
+account-custody prototype demonstrated a colour-scoped, value-capped,
+epoch-bound withdraw grant enforced in-circuit on a devnet node, which
+establishes that bounded authority is expressible at the seam; it did
+not establish origin binding, expiry, signature-based grantee
+authentication, or any connection protocol, which is what a standard
+must supply.
+
+**Connection is not standard, and what exists is the wrong layer.** The
+dApp connector API and the Open Wallet Standard define how a dApp or an
+agent talks to a wallet: session establishment, message signing, and
+client-side policy. Both are wallet-side, off-chain, and ephemeral. The
+Open Wallet Standard's policy design explicitly asks to pair with "an
+account contract that verifies a scoped authorisation in-circuit" and
+states that client-side policy is defence in depth, not the sole gate.
+MPS-0003 frames dApp-to-wallet connection as a chain-identifier problem
+and lists custom connector protocols as the current workaround. MPS-0029
+records that Compact exposes no authenticated caller identity, so a
+separate verifier contract cannot know who called it. None of these
+produces a scoped, revocable, on-chain object that a dApp's signature
+can target; each points at one.
+
+**The redirect pattern is well known and well known to fail.** NEAR's
+access-key login flow is the closest deployed analogue of the user
+brief's connection: a dApp generates a key, redirects to the wallet with
+its public key and return URL, and the wallet adds the key to the
+account. Its documented defects are login CSRF (nothing proves the dApp
+possesses the key it asks to add, and nothing binds the return to the
+requesting session), an open redirector through attacker-controlled
+return URLs, disclosure of the account's whole key list to every dApp,
+and a non-expiring default. OAuth 2.0 and its security best current
+practice have fixed these classes for a decade. A Midnight standard has
+the opportunity to borrow the fixes and to add the one thing OAuth
+cannot: a browser-written origin attestation (the WebAuthn
+`clientDataJSON.origin`) in place of a self-asserted `from` parameter,
+and a chain record in place of an authorization code.
+
+The absence of a standard here has a demonstrated cost in the adjacent
+upstream proposal for private mandate tokens, which standardises a
+capability-scoped, value-capped, expiring, revocable delegation record
+of exactly this shape but authenticates the agent through an
+unconstrained sender witness, which is the `ownPublicKey()` pattern
+MIP-0012 section 4 forbids, and attaches the record to an
+admin-overwritten balance rather than to custodied assets. The safe
+pattern, a grant verified inside the custody seam by a signature over a
+challenge that binds the call, is what this MIP standardises.
+
+## Specification
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described in RFC 2119.
+
+### 1. Scope of this document
+
+This MIP standardises:
+
+1. the **grant record** and its identity in the ledger state of a
+   custody account (section 4) and the semantics of its scope fields
+   (section 5);
+2. the **grant seam**: how a grantee key satisfies `require_authorised()`
+   for exactly three asset-releasing circuits, with scope evaluated
+   in-circuit over the values the custody chip consumes (section 6);
+3. the **lifecycle** circuits and state machine: issue, revoke, revoke
+   all, lazy expiry, and re-issue (section 7);
+4. **read-scope delegation**: how the MIP-0012 viewing capability is
+   sealed to a grantee and recorded declaratively (section 8);
+5. the **`GrantRequest`** object and its normative https redirect
+   binding, including the consent screen, the response, the error
+   vocabulary, and the return-leg verification (section 9);
+6. **account-linked sign-in** backed by a live grant (section 10);
+7. how the grant vocabulary is carried in CAIP-25 sessions and mapped to
+   Open Wallet Standard policy terms (section 11).
+
+`issue_grant` is a device-gated circuit that the owner can call with no
+ceremony from their own client, offline from any authoriser page; a
+conforming account is fully usable with no authoriser in existence. The
+`GrantRequest` object is the interoperable way a third party asks for a
+grant; the redirect is one binding of it. The same record, identity,
+seam, and lifecycle serve intra-user delegation (a user's second device,
+a script, a household member) through the `self:` grantee form, so no
+parallel mechanism exists for it.
+
+Out of scope, with the successor or owner named where one exists:
+
+- a new injected wallet API, connector method, or Open Wallet Standard
+  capability definition (only the object they carry);
+- a client-side policy language (Open Wallet Standard PE-1 owns it);
+- proving and submission transport, fee sponsorship, and remote proving;
+  this MIP says only what the transaction must contain;
+- unlinkable, address-hiding sign-in and any authoriser-signed identity
+  assertion or pairwise pseudonym (the sign-in MIP recommended by the
+  planning register, hereafter "the sign-in MIP");
+- selective-disclosure credential proofs attached to or required by a
+  grant, and non-asset objects (contracts, attestations);
+- per-grantee, hierarchical, or epoch-scoped viewing keys and the
+  per-coin mirror mode (the MIP-0012 R9 successor, the named dependency
+  for spend without full disclosure); proxied reads;
+- chain-agnostic or "all chains" grants: a grant authorises calls on one
+  contract on one chain by construction; a chain-agnostic record class,
+  if needed, lives at the intent layer; a request MAY carry other
+  CAIP-217 scope objects this MIP does not enforce;
+- a general "callable contracts" object; the account contract has no
+  call-forwarding circuit;
+- grant delegation chains; grants are non-delegable;
+- m-of-n device policy, two-of-n revocation of high-value grants,
+  threshold grantee keys beyond what the JubJub arm permits, per-device
+  scheme agility;
+- the device-identity remedy for MIP-0013 erratum 8 itself
+  (recommended to share the schema bump, specified by MIP-0013 errata);
+- the `schnorr_bip340` grantee arm (pending upstream point operations),
+  activation of the r1 arm `[DEP]`, and spend through wallet-provider
+  keys `[DEP]`;
+- window-bounded rate limits (schema reserved; enforcement is a circuit
+  revision), tombstone pruning, automatic expiry cleanup;
+- authoriser discovery beyond a chooser and manual entry;
+- authenticated request objects (`.well-known` client metadata) for
+  browser clients without WebAuthn `[DEP]`, Related Origin Requests, and
+  any passkey shared across the authoriser and dApp origins;
+- merging device and grant twins into one circuit;
+- seed-anchored `deriveSecret` counterparts (MIP-0015); the grantee's
+  own per-origin passkey answers the durable-secret need;
+- migration of `spec_version = 1` accounts, the recovery seam's
+  internals, how the viewing secret reaches a second authoriser device
+  (MIP-0012), agent identity registration, and Zswap user-held coins;
+- address-only disclosure ceremonies with no on-chain effect; the
+  address is public information the user can share.
+
+### 2. Terminology
+
+- **Account**: a custody contract instance conforming to MIP-0012 and
+  MIP-0013 (hereafter "the custody MIP" and "the authorisation MIP").
+- **Device**, **device key**, **device entry**, **epoch**,
+  **`auth_nonce`**: as defined by the authorisation MIP. A grantee is
+  not a device and never counts toward `device_count`.
+- **Grant**: a record in the account's ledger state admitting one
+  grantee key to a bounded subset of operations under stated bounds.
+- **Grantee**: the holder of the grantee key: a browser dApp, a wallet
+  provider, an agent, or the owner acting through a delegate key.
+- **Grantee key**: a `(scheme, pk)` pair drawn from the signature-scheme
+  registry, plus, for the k1 arm only, an envelope id (section 3).
+- **Arm**: the per-scheme circuit family of the registry: `v1` (Schnorr
+  over JubJub), `k1` (ECDSA over secp256k1), `r1` (ECDSA over secp256r1
+  through the WebAuthn envelope).
+- **Origin**: the normalised identity of the grantee (section 4.4): an
+  RFC 6454 web origin for browser clients, or an `rdns:`, `mais:`, or
+  `self:` identifier for non-browser clients.
+- **Grant identity** (`grant_id`): the contract-recomputable hash keying
+  the record (section 4.3).
+- **Slot**: a dApp-chosen byte distinguishing up to 256 records of one
+  key at one origin.
+- **Scope**: the immutable bounds of a grant (section 5); **plaintext
+  scope**: the scope as the approver consents to it, before commitment.
+- **Grant twin**: a gated circuit `<operation>_with_grant_<arm>` that
+  verifies a grant in the position where the device twin verifies a
+  device signature.
+- **Authoriser**: a role, not a service (section 11.3): a party holding
+  a device key of the account that renders a `GrantRequest`, drives
+  `issue_grant`, and, to serve `read`, holds the account viewing secret.
+- **Viewing capability**, **viewing secret**, **inbox**, **coin store**,
+  **color**: as defined by the custody MIP.
+- **Browser binding**: the delivery of a `GrantRequest` by top-level
+  navigation to an authoriser page (section 9). **Non-browser binding**:
+  any other delivery (a pasted or scanned object, a local channel).
+- **`pad(N, s)`**: the ASCII bytes of `s` followed by zero bytes to a
+  total width of `N` bytes. **`H(x)`**: SHA-256 of the byte string `x`.
+
+### 3. Grantee keys and arms
+
+#### 3.1 Registered grantee arms
+
+A grantee key is a `(scheme, pk)` pair from the signature-scheme
+registry of the authorisation MIP's successor scheme document
+(hereafter "the schemes MIP"), plus, for `k1` only, an `envelope` id.
+Three grantee arms are registered by this MIP:
+
+| Arm | Scheme | Envelope | Registry status | Today |
+|---|---|---|---|---|
+| `v1` | Schnorr over JubJub | intrinsic (none) | Active | yes |
+| `k1` | ECDSA over secp256k1 | `0` none, `1` connector prefix | Interim, inherited from the schemes MIP with its sunset | yes |
+| `r1` | ECDSA over secp256r1 through the WebAuthn envelope | intrinsic (WebAuthn message) | Active upon `[DEP]` secp256r1 language surface | no |
+
+`envelope` is the k1 digest selector and nothing else: the k1 arm
+verifies over `envelope_digest(envelope, h)` where
+`envelope_digest(0, h) = H(h)` and
+`envelope_digest(1, h) = H(pad(27, "midnight_signed_message:32:") || h)`,
+the mandatory prefix of the dApp connector's `signData` surface. It is
+absent from the wire form and from the identity preimage for `v1` and
+`r1`, whose digest wrapping is intrinsic to the scheme. No `2 =
+webauthn` envelope id is filed. The `schnorr_bip340` scheme the
+connector also emits is reserved and `[DEP]` on upstream secp256k1
+point operations.
+
+#### 3.2 Grantee forms
+
+Five grantee forms are admitted through one table; none is privileged
+in the schema:
+
+| Form | Arm, envelope | Today | Origin proof at issuance | Scopes admitted | Serves |
+|---|---|---|---|---|---|
+| Per-dApp WebAuthn credential on the dApp origin | `r1` | `[DEP]` | the assertion itself (`clientDataJSON.origin`) | all | browser dApps once secp256r1 ships |
+| Per-connection software key gated by a companion passkey on the dApp origin | `k1` envelope `0`, or `v1` | yes | WebAuthn assertion by the companion passkey over `request_digest`, which covers the software key | all | browser dApps now |
+| Wallet-provider key through the connector `signData` | `k1` envelope `1`; `schnorr_bip340` reserved `[DEP]` | yes | WebAuthn assertion by a companion passkey on the dApp origin, exactly as the software form; `signData` supplies possession only | `read` only in v1 `[RULING]` | "connect my wallet to my account" |
+| Agent or vaulted key (`rdns:`, `mais:` identity) | `v1` or `k1` envelope `0` | yes | operator assertion in the non-browser binding, displayed as such | all | agents, servers |
+| Intra-user delegate (`self:<label>` identity) | `v1` or `k1` envelope `0` | yes | none needed: approved in person on the owner's own device in the non-browser binding | all | a second device, a script, a household member |
+
+Rules:
+
+- Grantee keys MUST be generated per connection: one key per account per
+  origin. A key MUST NOT be reused across accounts or origins.
+- An authoriser MUST refuse to issue a grant to a `pk` it knows to be
+  enrolled as a device key of the same account. The contract cannot
+  check this, since device keys are not stored; the rule is part of
+  GR-2.
+- **Wallet-provider keys are restricted to `read` in v1** `[RULING]`.
+  Connector `signData` under envelope `1` is a blind 32-byte
+  message-signing surface. Once a grant exists for a wallet key, every
+  element of a spend challenge is public or attacker-chosen (the tag,
+  the account address, the wallet key, `grant_id`, `issued_at`, the
+  record's `nonce`, and the operation arguments), so any other site the
+  user connects the same wallet to could compute a valid spend challenge
+  and obtain a signature by asking the wallet to sign a message the user
+  cannot interpret. An authoriser MUST return `unsupported_scheme` for
+  any withdraw string requested by an envelope-1 grantee. Spend through
+  envelope `1` is `[DEP]` on a connector surface that displays a
+  decoded, structured description of a grant call with per-call
+  confirmation.
+
+#### 3.3 Key validation
+
+Key validation is exactly what the following table says and no more,
+performed by the authoriser at issuance and again by the seam at every
+use:
+
+| Arm | Check | Not checked |
+|---|---|---|
+| `k1` | coordinate pair `(0, 0)` rejected in either identity-flag encoding (the point at infinity) | on-curve membership `[CIRCUIT]`; the cofactor is 1, so subgroup membership is vacuous |
+| `v1` | `[8]P != O` (the identity and the whole 8-torsion) | on-curve membership `[CIRCUIT]` |
+| `r1` | `r != 0`, `s != 0`, recomputed point non-identity (schemes MIP section 3.3 item 5) | on-curve membership of the public key `[CIRCUIT]` |
+
+Whether a `Secp256k1Point` or `JubjubPoint` can be constructed off-curve
+from witness data is not evidenced. Before this MIP leaves Draft, the
+seam either gains an on-curve assertion or cites type-level evidence
+that the runtime enforces membership `[CIRCUIT]`; the negative
+conformance suite (Testing item 2) carries off-curve and invalid-curve
+grantee keys beside the identity and small-order ones.
+
+#### 3.4 Wire form of a grantee key
+
+`pk` is 128 lowercase hexadecimal characters encoding the affine
+coordinates `x || y`, each a 32-byte little-endian integer, for every
+curve. Inputs in SEC 1 form (compressed or uncompressed, big-endian)
+MUST be decompressed and byte-reversed per coordinate before use; a
+normalisation vector is published with the conformance vectors (Testing
+item 5). Wire `scheme` names are the connector's spellings where they
+exist and two registry spellings where they do not, mapped to the
+registry markers by one normative table `[RULING]`:
+
+| Wire `scheme` | Registry arm | `envelope` member | Source of the spelling |
+|---|---|---|---|
+| `ecdsa_secp256k1_sha256` | `k1` | MUST, `0` or `1` | dApp connector specification |
+| `schnorr_bip340` | reserved | absent | dApp connector specification; `[DEP]` |
+| `schnorr_jubjub` | `v1` | absent | this MIP, filed into the schemes MIP registry |
+| `ecdsa_secp256r1_webauthn` | `r1` | absent | this MIP, filed into the schemes MIP registry |
+
+### 4. Ledger state and grant identity
+
+#### 4.1 New cells and structs (`spec_version = 2`)
+
+A grant-capable account extends the custody MIP's and the authorisation
+MIP's ledger state with two cells. This is a schema change: the account
+exposes `spec_version = 2` (custody MIP section 8), and a
+`spec_version = 1` account cannot gain grants by maintenance update
+(Backwards Compatibility Assessment). The redeploy SHOULD land together
+with the device-identity remedy for the authorisation MIP's erratum 8
+`[RULING]`.
+
+```compact
+export ledger grants:           Map<Bytes<32>, GrantRecord>;
+// keyed by grant_id (section 4.3)
+
+export ledger grant_generation: Uint<32>;
+// bumped only by revoke_all_grants; every record carries the value
+// at issue and is inert once it differs
+```
+
+`GrantScope` (immutable after issue; 164 bytes of payload):
+
+| Field | Type | Width | Meaning |
+|---|---|---|---|
+| `op_withdraw_unshielded` | `Boolean` | 1 | admits the `withdraw_unshielded` twin |
+| `op_withdraw_shielded` | `Boolean` | 1 | admits the `withdraw_shielded` twin |
+| `op_withdraw_shielded_to_contract` | `Boolean` | 1 | admits the `withdraw_shielded_to_contract` twin |
+| `read` | `Boolean` | 1 | declarative: the viewing capability was delegated (section 8) |
+| `object_commit` | `Bytes<32>` | 32 | salted commitment to `color`, `recipient_kind`, `recipient`, `max_coin_value` (section 4.5) |
+| `per_call_cap` | `Uint<128>` | 16 | `amount <= per_call_cap` on every call; MUST be `<= cap` |
+| `cap` | `Uint<128>` | 16 | `spent + amount <= cap` cumulatively |
+| `expires_at` | `Uint<64>` | 8 | in the unit of `kernel.blockTimeLessThan` on the target ledger `[CIRCUIT]`; `0` means never, explicitly |
+| `rp_id_hash` | `Bytes<32>` | 32 | `r1` grantees only: SHA-256 of the dApp host; zero otherwise |
+| `read_pk_hash` | `Bytes<32>` | 32 | SHA-256 of the delegate's X25519 `read_pk` when `read`; zero otherwise |
+| `window_len` | `Uint<64>` | 8 | reserved; MUST be `0` in v1 `[RULING]` |
+| `window_cap` | `Uint<128>` | 16 | reserved; MUST be `0` in v1 `[RULING]` |
+
+`GrantRecord` (81 bytes plus the scope):
+
+| Field | Type | Width | Written by | Meaning |
+|---|---|---|---|---|
+| `epoch` | `Uint<32>` | 4 | contract, at issue | `device_epoch` observed inside `issue_grant` |
+| `gen` | `Uint<32>` | 4 | contract, at issue | `grant_generation` observed inside `issue_grant` |
+| `issued_at` | `Uint<64>` | 8 | contract, at issue | `auth_nonce` as advanced by the device seam of the issuing call; unique per issuance |
+| `nonce` | `Uint<64>` | 8 | contract, every grant call | per-grant freshness; read into the challenge and advanced by every grant call |
+| `spent_commit` | `Bytes<32>` | 32 | contract, at issue and every grant call | salted commitment to the cumulative value released under this grant (section 4.5) |
+| `window_start` | `Uint<64>` | 8 | reserved | `0` in v1 |
+| `window_spent` | `Uint<128>` | 16 | reserved | `0` in v1 |
+| `active` | `Boolean` | 1 | contract | `false` is a tombstone (revoked) |
+| `scope` | `GrantScope` | 164 | contract, at issue | immutable after issue |
+
+Byte budget: about 277 bytes per grant including the 32-byte key,
+before the ledger's field alignment; one hundred grants, live or
+tombstoned, are about 28 KB of contract state. The record stores no
+key, no origin, and no scheme. `[CIRCUIT]`: a struct embedding a struct
+as a `Map` value is not evidenced (the prototype's map value is a struct
+of scalar fields only); the flattened fallback (the scope fields inlined
+into `GrantRecord`) changes no wire form, no challenge preimage, and no
+byte recipe.
+
+#### 4.2 Plaintext scope
+
+The plaintext scope the approver consents to, and that `issue_grant`
+takes as arguments, is:
+
+| Argument | Type | Rule |
+|---|---|---|
+| the four flags | `Boolean` each | at least one operation flag or `read` MUST be set; shielded flags imply `read` |
+| `color` | `Bytes<32>` | the token color; all-zero is Night |
+| `recipient_kind` | `Uint<8>` | `0` any, `1` `UserAddress`, `2` `ZswapCoinPublicKey`, `3` `ContractAddress` |
+| `recipient` | `Bytes<32>` | the address bytes when `recipient_kind != 0`, else zero |
+| `max_coin_value` | `Uint<128>` | a shielded twin aborts if the consumed coin's value exceeds it; MUST be `>= per_call_cap` when any spend flag is set |
+| `per_call_cap`, `cap`, `expires_at`, `rp_id_hash`, `read_pk_hash`, `window_len`, `window_cap` | as in `GrantScope` | as in `GrantScope` |
+| `scope_salt` | `Bytes<32>` | chosen by the authoriser at issue; a readability key for the record, never an authorisation secret |
+
+The circuit computes `object_commit` and the initial `spent_commit` from
+these; `color`, `recipient`, and `max_coin_value` never appear in ledger
+state in the clear. The salt is bound in the device challenge, delivered
+to the grantee in the response, and kept in the owner's roster.
+
+#### 4.3 Grant identity
+
+`grant_id` is a deterministic commitment recomputed in-circuit from the
+presented key at every use and pre-derived by the authoriser at issue.
+Every preimage in this MIP is defined normatively as a byte
+concatenation of fixed-width elements hashed with SHA-256; the exported
+pure circuits of a conforming contract are one implementation of the
+recipe, not its definition, so a dApp recomputes its `grant_id` with
+plain SHA-256 and no Midnight stack. The recipes rely on the fact that
+Compact's `persistentHash` over a tuple of byte atoms is SHA-256 of
+their raw concatenation. Integer elements are serialised at the width
+of their Compact type, little-endian, as the coordinates are `[CIRCUIT]`
+(the published vectors of Testing item 5 pin the compiled encoding; a
+divergence is corrected in the recipe, never in the vectors).
+
+| Arm | `grant_id` preimage (in order) | Width |
+|---|---|---|
+| `k1` | `pad(32, "midnight:account:grant:id:k1:v1") \|\| self \|\| x \|\| y \|\| u8(envelope) \|\| origin_hash \|\| u8(slot)` | 162 |
+| `r1` | `pad(32, "midnight:account:grant:id:r1:v1") \|\| self \|\| x \|\| y \|\| origin_hash \|\| u8(slot)` | 161 |
+| `v1` | `pad(32, "midnight:account:grant:id:v1") \|\| self \|\| pk_jubjub \|\| origin_hash \|\| u8(slot)` | 129 |
+
+where `self` is the account's own contract address (32 bytes), `x` and
+`y` are the 32-byte little-endian affine coordinates of the grantee key,
+and `pk_jubjub` is the 32-byte encoding of the `JubjubPoint` element in
+the layout this MIP publishes with its vectors `[CIRCUIT]` (the type is
+opaque in Compact, with no evidenced coordinate accessor; the layout is
+the one the reference signer already reproduces for the device family
+without the compiled module). `envelope` is present only in the `k1`
+preimage.
+
+Consequences that are normative:
+
+- one tuple `(account, arm, key, [envelope,] origin, slot)` has at most
+  one live record; issuance fails while a live record exists under that
+  id; revocation retires the id;
+- a key holds at most 256 records at one origin, every one of them
+  enumerable by anyone who knows the key and the origin, in at most 256
+  lookups;
+- an unregistered key, a wrong origin, a wrong slot, a key of another
+  arm, and, on `k1`, a wrong envelope all fail identically at the
+  membership assert, before any signature is examined;
+- no secret lives in the identity preimage; grant security rests on the
+  grantee signing key alone. `[CRYPTO]`: the hiding argument for
+  `grant_id` rests on the entropy of a per-connection key; for a
+  publicly known key (the wallet-provider form) the dictionary test "is
+  key K connected to origin X on account A" is trivially answerable, and
+  this MIP says so (Security Considerations).
+
+#### 4.4 Origin normalisation and `origin_hash`
+
+`origin_hash = H(pad(32, "midnight:account:grant:origin:v1") || client_id_bytes)`,
+computed off-chain, where `client_id` is normalised exactly:
+
+- browser clients: the lowercase ASCII RFC 6454 serialisation of the
+  origin (`https://bank.example`): scheme and host lowercase, default
+  port omitted, non-default port kept, no path, no trailing slash, IDN
+  hosts in punycode;
+- non-browser clients: `rdns:<reverse-dns>`, `mais:<id>`, or
+  `self:<label>`, lowercase.
+
+`origin_hash` is a private argument of every grant twin and of nothing
+else; it never appears in ledger state; it is derived from public
+information and is not a secret. `slot`, `scope_salt`, and `spent_prev`
+are likewise private arguments.
+
+#### 4.5 Commitments and the scope digest
+
+| Derivation | Preimage (in order) | Tag width |
+|---|---|---|
+| `object_commit` | `pad(32, "midnight:account:grant:obj:v1") \|\| scope_salt \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value)` | 32 |
+| `spent_commit` | `pad(32, "midnight:account:grant:spent:v1") \|\| scope_salt \|\| u128(spent)` | 32 |
+| `scope_digest` | `pad(32, "midnight:account:grant:scope:v1") \|\| flag(op_withdraw_unshielded) \|\| flag(op_withdraw_shielded) \|\| flag(op_withdraw_shielded_to_contract) \|\| flag(read) \|\| color \|\| u8(recipient_kind) \|\| recipient \|\| u128(max_coin_value) \|\| u128(per_call_cap) \|\| u128(cap) \|\| u64(expires_at) \|\| rp_id_hash \|\| read_pk_hash \|\| u64(window_len) \|\| u128(window_cap) \|\| scope_salt` | 32 |
+
+`flag(b)` is the single byte `0x01` for true and `0x00` for false, so
+the recipe does not depend on hashing a `Boolean` in-circuit
+`[CIRCUIT]` (inside the pure circuit the flags enter as `Uint<8>` values
+through a select if `Boolean` tuple elements are not supported).
+`scope_digest` is the single element through which the device challenge
+of `issue_grant` binds the whole plaintext scope (AUTH-3 by collision
+resistance), keeping that challenge within the evidenced tuple arity.
+The `scope` tag family is `[RULING]` (added by this document; the
+derivation is named by the design record without a tag). `[CIRCUIT]`:
+the sixteen-element `scope_digest` tuple exceeds the largest evidenced
+arity of ten; the fallback is a two-stage hash, in which case this
+recipe is revised before Proposed.
+
+### 5. Scope semantics
+
+#### 5.1 Axes
+
+A grant realises three axes: the **operation** axis as three Booleans
+and a declarative `read`; the **object** axis as one token color and an
+optional recipient pin, committed; the **quantitative** axis as
+`per_call_cap`, `cap`, `max_coin_value`, and `expires_at`. Rate windows
+are reserved in the schema and not enforced in v1.
+
+Rules asserted at issue:
+
+1. at least one operation flag or `read` MUST be set (no "empty means
+   all");
+2. `op_withdraw_shielded` or `op_withdraw_shielded_to_contract` implies
+   `read` (a grantee must hold the viewing secret to select a coin);
+3. `per_call_cap <= cap`;
+4. any spend flag requires `cap > 0` and `max_coin_value >= per_call_cap`;
+5. `read` requires a non-zero `read_pk_hash`;
+6. `window_len == 0` and `window_cap == 0`.
+
+`max_coin_value` exists because the value at risk from a shielded grant
+is the coin the grantee selects, not the cap: a grantee capped at `C`
+may present a coin of value `V` much greater than `C`, send `C`, and
+never record the change, orphaning `V - C`. The field makes the value at
+risk a number the consent screen displays and the approver narrows.
+Clients SHOULD recommend `max_coin_value == cap` where the owner can
+pre-split coins.
+
+`expires_at` is expressed in the unit of `kernel.blockTimeLessThan` on
+the target ledger, with `0` meaning never, stated explicitly (the UCAN
+`exp: null` convention); a non-expiring grant is a declaration, never an
+omission. `[CIRCUIT]`: the corpus evidences that the comparison compiles
+and executes, not the node's unit; a millisecond clock would make every
+second-denominated grant born expired. The unit is pinned on a ledger-9
+network before this MIP leaves Draft and recorded in the grant scheme's
+registry entry; clients MUST sanity-check a candidate `expires_at`
+against a freshly read block time before signing.
+
+There is no `network_id` cell. A contract address is derived from the
+deploy transaction's content, so two independent deployments already
+have distinct addresses, and `kernel.self()` is bound in every grant
+challenge and inside `grant_id`. Cross-network separation therefore
+rests on `kernel.self()` plus a client obligation never to reuse deploy
+transaction content across networks; a state-preserving fork is not
+defeated by any cell, and expiry and revocation on the surviving chain
+are the defence. The wire `chain` member remains normative for the
+request, where it tells the authoriser which chain to serve.
+
+#### 5.2 Feature strings and the mapping table
+
+Scope travels on the wire as feature strings named after the circuit
+exports. Each maps to exactly one Boolean; the grant string is canonical
+on the wire and the Boolean is canonical in the record:
+
+| Feature string | Record field | Gated twin | Implies | C23 / Open Wallet Standard scope string | Notes |
+|---|---|---|---|---|---|
+| `midnight:account:withdraw_unshielded` | `op_withdraw_unshielded` | `withdraw_unshielded_with_grant_<arm>` | | `midnight:unshielded` | |
+| `midnight:account:withdraw_shielded` | `op_withdraw_shielded` | `withdraw_shielded_with_grant_<arm>` | `read` | `midnight:shielded` | |
+| `midnight:account:withdraw_shielded_to_contract` | `op_withdraw_shielded_to_contract` | `withdraw_shielded_to_contract_with_grant_<arm>` | `read` | `midnight:shielded` | |
+| `midnight:account:read` | `read` | none (section 8) | | `midnight:shielded` (read side) | unshielded balances are public and need no capability |
+| `midnight:account:signin` | none | none | | none | reserved for the sign-in MIP; v1 authorisers MUST refuse it with `invalid_scope` |
+
+The mapping is many-to-one: a coarse connection scope string covers
+several grant strings, so a peer translating in the other direction
+MUST ask for the grant strings it needs rather than infer them. The
+strings travel in a dedicated `midnight:account:grants` member of a
+CAIP-25 session (or in CAIP-25 `scopedProperties`) alongside their
+bounds, never in the CAIP-217 `methods` member, which is reserved for
+JSON-RPC method names; a CAIP-25 peer MUST NOT treat a grant feature
+string as invokable (section 11.1).
+
+A request whose bounds are inconsistent with its strings is rejected as
+the error table of section 9.6 says: a spend string without `color`,
+`cap`, `max_coin_value`, and `expires_at`; `per_call_cap > cap`;
+`max_coin_value < per_call_cap`; a recipient kind that no requested
+operation can honour (`invalid_scope`); a withdraw string from an
+envelope-1 grantee (`unsupported_scheme`).
+
+### 6. The grant seam
+
+#### 6.1 Circuit list
+
+Per grantee arm `s` in `{jubjub, k256}` today and `{p256}` upon `[DEP]`,
+a conforming contract exports exactly three grant twins over the
+unchanged custody chips:
+
+- `withdraw_unshielded_with_grant_<s>(color: Bytes<32>, amount: Uint<128>, recipient: UserAddress, ...grant auth): []`
+- `withdraw_shielded_with_grant_<s>(recipient: ZswapCoinPublicKey, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, ...grant auth): Maybe<ShieldedCoinInfo>`
+- `withdraw_shielded_to_contract_with_grant_<s>(recipient: ContractAddress, color: Bytes<32>, amount: Uint<128>, change_entry: Bytes<192>, ...grant auth): [ShieldedCoinInfo, Maybe<ShieldedCoinInfo>]`
+- exported pure `challenge_<operation>_with_grant_<s>` for each of the three;
+- exported pure `derive_grant_id_with_<s>`.
+
+`...grant auth` trails the operation arguments, in this order:
+
+| Arm | Grant authorising material |
+|---|---|
+| `k256` | `pk: Secp256k1Point, envelope: Uint<8>, origin_hash: Bytes<32>, slot: Uint<8>, scope_salt: Bytes<32>, recipient_kind: Uint<8>, pinned_recipient: Bytes<32>, max_coin_value: Uint<128>, spent_prev: Uint<128>, sig: Secp256k1EcdsaSignature` |
+| `jubjub` | `pk: JubjubPoint, origin_hash: Bytes<32>, slot: Uint<8>, scope_salt: Bytes<32>, recipient_kind: Uint<8>, pinned_recipient: Bytes<32>, max_coin_value: Uint<128>, spent_prev: Uint<128>, sig_r: JubjubPoint, sig_s: Field, grind_nonce: Uint<64>` |
+| `p256` | as `k256` without `envelope` and with the WebAuthn witness set of the schemes MIP section 3.3 in place of `sig` |
+
+There is no nonce argument: the record's `nonce` is read in-circuit.
+The authorising material is witness data and MUST NOT be disclosed by
+the circuit.
+
+Per device arm `a` in `{jubjub, k256}`, device-gated through the
+unchanged device seam:
+
+- `issue_grant_with_<a>(grant_id: Bytes<32>, <plaintext scope fields of section 4.2>, scope_salt: Bytes<32>, ...device auth): []`
+- `revoke_grant_with_<a>(grant_id: Bytes<32>, ...device auth): []`
+- `revoke_all_grants_with_<a>(...device auth): []`
+- exported pure `derive_grant_scope_digest`, `derive_grant_object_commit`, `derive_grant_spent_commit`;
+- exported pure `challenge_issue_grant_with_<a>`, `challenge_revoke_grant_with_<a>`, `challenge_revoke_all_grants_with_<a>` in the existing device tag family (`midnight:account:auth:v1:issue_grant`, `midnight:account:auth:k1:v1:issue_grant`, and so on), where the `issue_grant` challenge's argument list is `[grant_id, scope_digest]`.
+
+No grant twin exists for `rotate_enc_key`, `add_device`, `remove_device`,
+`append_inbox`, `issue_grant`, `revoke_grant`, or `revoke_all_grants`. A
+`spec_version = 2` account therefore carries 30 non-pure circuits (18
+existing, 6 grant twins, 6 lifecycle circuits), 33 with the p256 twins.
+
+#### 6.2 Seam chip, ordered steps
+
+The grant seam is written once per grantee arm as three chips
+(`authenticate_grant`, `check_spend_scope`, `settle_grant`) so the three
+twins share code. Every predicate is evaluated over the value the
+custody chip will consume, never over an argument that merely selects
+it: shielded twins invoke `held_coin(color)` before step 5 and test the
+returned coin's `color` and `value`; the unshielded twin tests its
+`color` argument, which is what its chip consumes. A grant twin
+performs, in order:
+
+1. **Key guard.** Per the table of section 3.3: `k256` rejects the point
+   at infinity in either encoding; `jubjub` asserts `[8]pk != O`; `p256`
+   per the schemes MIP. On-curve membership `[CIRCUIT]`.
+2. **Identity.** `id = derive_grant_id_with_<s>(kernel.self(), pk, [envelope,] origin_hash, slot)`,
+   disclosed; assert `grants.member(id)`; `g = grants.lookup(id)`. A
+   lookup MUST be dominated by a membership assert and never combined
+   with it in one boolean expression, because both operands of a
+   conjunction are evaluated and a lookup of a non-member has no defined
+   value.
+3. **Liveness.** Assert `g.active`; assert `g.epoch == device_epoch`;
+   assert `g.gen == grant_generation`; assert
+   `g.scope.expires_at == 0 || kernel.blockTimeLessThan(g.scope.expires_at)`
+   (a select, both sides evaluated; the comparison argument reaches the
+   public transcript, which is harmless because the record is public).
+4. **Operation.** Assert the twin's own flag (`g.scope.op_<this twin>`),
+   a per-twin constant selection over the three Booleans.
+5. **Object and bounds.** With `obj_color = coin.color` on the shielded
+   twins and `obj_color = color` on the unshielded twin:
+   - assert `derive_grant_object_commit(scope_salt, obj_color, recipient_kind, pinned_recipient, max_coin_value) == g.scope.object_commit`;
+   - shielded twins: assert `coin.value <= max_coin_value`;
+   - assert `amount <= g.scope.per_call_cap`;
+   - assert `derive_grant_spent_commit(scope_salt, spent_prev) == g.spent_commit`;
+   - compute `wide = spent_prev + amount` in the widened type; assert
+     `wide <= g.scope.cap`; then narrow to `new_spent: Uint<128>` (the
+     narrowing cannot fail once the cap assert passed, since `cap` is a
+     `Uint<128>`; the order is normative and the two failures are
+     distinct);
+   - assert `recipient_kind == 0 || (recipient_kind == <this twin's kind> && pinned_recipient == recipient bytes)`.
+6. **Challenge and verification.** `h = challenge_<operation>_with_grant_<s>(...)`
+   over the preimage of section 6.3. `k256`: `secp256k1EcdsaVerify(envelope_digest(envelope, h), sig, pk)`,
+   both `s` forms accepted. `jubjub`: `ecMulGenerator(sig_s) == ecAdd(sig_r, ecMul(pk, h as Field))`
+   with the grinding rule of the authorisation MIP section 5.2. `p256`:
+   the WebAuthn envelope of the schemes MIP section 3.3 with
+   `rpIdHash == g.scope.rp_id_hash`, the user-verified flag set, and an
+   `authenticatorData` of exactly 37 bytes (ED flag clear; the
+   fixed-width envelope cannot verify an extension-bearing assertion).
+7. **Write-back.** `grants.insert(id, g')` where `g'` is `g` with
+   `nonce + 1` and `spent_commit = derive_grant_spent_commit(scope_salt, new_spent)`,
+   spelled out as a full struct literal; then `round += 1`. `auth_nonce`,
+   `devices`, `device_count`, and `enc_key` are neither read nor written.
+
+The custody chip (`do_withdraw_unshielded`, `do_withdraw_shielded`,
+`do_withdraw_shielded_to_contract`) runs unchanged after step 7, as it
+does after the device seam. The shielded twins then, under a disclosed
+statement-level branch on whether the send produced change, append
+`change_entry` through the inbox chip in the same circuit, so the change
+entry is written in the same transaction as the spend, and return the
+chip's result. The signature is not what enforces the object scope
+under a grant, since the grantee signs its own witness choice; that is
+why step 5 tests `coin.color` and `coin.value` directly.
+
+The commitment openings (`scope_salt`, `recipient_kind`,
+`pinned_recipient`, `max_coin_value`, `spent_prev`) are private
+arguments verified by equality against the record and bound
+transitively through `grant_id`, which determines the record, which
+determines the commitments; a substituted opening aborts at the
+commitment assert rather than authorising anything. `[CRYPTO]`: confirm
+that the transitive binding satisfies AUTH-3; the fallback binds the
+openings directly at the cost of tuple arity.
+
+#### 6.3 Challenge preimages
+
+Per-twin domain-separation tag, hashed from a 64-byte pad as the
+authorisation MIP's amended section 5.1 requires:
+
+`DST = H(pad(64, "midnight:account:grant:auth:<marker>v1:<operation>"))`
+
+with `<marker>` empty for `v1`, `k1:` for `k1`, `r1:` for `r1`, and
+`<operation>` one of `withdraw_unshielded`, `withdraw_shielded`,
+`withdraw_shielded_to_contract`. The longest member is 63 of 64 bytes;
+the 64-byte width is a normative budget on future operation names.
+
+| Arm | Preimage (in order) |
+|---|---|
+| ECDSA arms (`k1`, `r1`) | `DST \|\| self \|\| x \|\| y \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce)` |
+| JubJub arm (`v1`) | `DST \|\| self \|\| sig_r \|\| pk \|\| grant_id \|\| u64(issued_at) \|\| ...args \|\| ...witness_values \|\| u64(g.nonce) \|\| u64(grind_nonce)` |
+
+`...args` are the operation arguments that vary per call, in
+declaration order with their Compact types: `color`, `amount`,
+`recipient`, and for the shielded twins `change_entry`.
+`...witness_values` is the qualified coin returned by `held_coin` on
+the shielded twins and empty on the unshielded twin (AUTH-10). `g.nonce`
+and `g.issued_at` are read from the record inside the circuit, exactly
+as the device arms read `auth_nonce`. ECDSA preimages exclude signature
+material (SIG-3) and need no grinding; the JubJub arm grinds
+`grind_nonce` until the little-endian value of `h` is below the subgroup
+order, as the authorisation MIP section 5.2. `k1` verifies over
+`envelope_digest(envelope, h)`; `r1` over the WebAuthn message whose
+`clientDataJSON.challenge` is `h`. `[CIRCUIT]`: the shielded ECDSA
+preimage has twelve elements and the JubJub one fourteen against a
+largest evidenced arity of ten; the fallback pre-hashes the operation
+arguments into one `args_digest` element.
+
+Binding `grant_id` makes one signature unusable across two grants of
+the same key; binding `issued_at` makes one signature unusable across
+two issuances of the same id (GR-6); per-operation tags keep SIG-1;
+malleated ECDSA twins authorise one execution because `nonce` advances
+(SIG-4).
+
+#### 6.4 Grantee private state and coin selection
+
+A grantee spending shielded value maintains a wallet-local coin store
+per the custody MIP section 6.5 (it holds the viewing secret, since
+shielded scopes imply `read`) and reconstructs coin descriptions and
+`mt_index` values from the inbox and chain data before it can prove.
+Owner and grantee, or two grantees, select coins independently with no
+coordination protocol. Clients SHOULD apply a deterministic selection
+rule (the smallest coin of the color that covers `amount`, ties broken
+by `mt_index`). The failure modes are: a proving failure when both
+select the same coin (no transaction exists, INV-5); a fee-wasting race
+when both submit; and the zombie-state class the atomic change backfill
+exists to prevent.
+
+The change description is precomputable before proving because the
+standard library evolves the output coin's nonce deterministically from
+the input coin's `[CIRCUIT]`; the grantee encrypts it to `enc_key` and
+passes it as `change_entry`, bound in the challenge. A garbage entry
+remains possible and is bounded by `max_coin_value` and detected by the
+owner's discovery walk, which recomputes each candidate coin's
+commitment against chain data (custody MIP section 6.5). The fallback,
+if the description proves not precomputable, is a bounded standalone
+append twin (`append_budget` in the scope, `appends` in the record)
+`[RULING]`.
+
+#### 6.5 Disclosure
+
+Disclosed per grant call: `grant_id` (lookup and write-back), the
+rewritten `nonce` and `spent_commit`, the `expires_at` argument of the
+kernel comparison, and what the custody chip already discloses
+(`color`, `amount`, and `recipient` on the unshielded twin, whose
+balances are public; the contract address of a contract-recipient
+output; the change-entry ciphertext on a shielded twin). Not disclosed:
+`pk`, `origin_hash`, `slot`, `scope_salt`, the openings, `spent_prev`,
+the signature, the qualified coin, and on shielded twins `color`,
+`amount`, and a `ZswapCoinPublicKey` recipient, which feed the send
+path's commitments exactly as under a device twin.
+
+The record publishes the operation flags, `read`, `per_call_cap`, `cap`,
+`expires_at`, `rp_id_hash`, `read_pk_hash`, `nonce` (the call count),
+and `active`; it commits to `color`, the recipient pin,
+`max_coin_value`, and `spent`. `grant_id` is a stable per-grant
+pseudonym disclosed on every call: it hides in the entropy of a
+per-connection key, is unequal across accounts because `kernel.self()`
+is in the preimage, and is confined to grant-authorised calls (device
+calls never touch `grants`); for a publicly known key it is trivially
+computable. Its relation to AUTH-9 is settled by the companion erratum
+of section 13 `[CRYPTO]`.
+
+#### 6.6 Cost
+
+Over the corresponding device twin, per arm: the identity hash replaces
+the two device-entry hashes (the `k1` identity preimage is 162 bytes
+against the `k1` device entry's 140; the `v1` identity preimage 129
+against the `v1` device entry's 108), so the net change in hashing is
+minus one hash plus the two commitment openings and one re-commit
+(three hashes over three to six elements, about two SHA-256
+compressions each), one map lookup and one insert of a 245-byte struct,
+one `Uint<128>` addition with the widened comparison, about a dozen
+comparisons, one kernel block-time comparison, and on shielded twins
+one inbox insert of 192 bytes under a disclosed branch. Anchors: the
+k256 device seam at k=15, 31,046 rows (envelope `0`) and k=16, 32,900
+rows (envelope `1`), about 0.5 to 0.8 s; the P-256 WebAuthn envelope at
+k=16, 36,466 rows, 1.1 to 1.2 s; JubJub well below (49 MB against 117 MB
+prover keys). Expected: k256 grant twins at k=16 on either envelope,
+p256 at k=16, jubjub at its device twin's k or one above; all inside the
+browser-provable envelope. `[CIRCUIT]`: all figures to be measured.
+
+Deploy budget, stated as a total: the reference implementation already
+exports 18 non-pure circuits and prices at 53,076 bytes written against
+a 50,000-byte per-block budget and 2.011 s of compute against 2.000 s,
+so it deploys in waves. A `spec_version = 2` account carries 30 non-pure
+circuits (33 with p256) at about 2,950 bytes of verifier key each, about
+88 KB; roughly three waves. Waves after the first are hand-built
+maintenance-update transactions. The grant circuits MUST be part of the
+`spec_version = 2` deploy wave plan, and maintenance-authority
+retirement MUST follow the last grant wave: a retired account can never
+receive a future arm's circuits, so a `spec_version = 2` account
+deployed without the grant circuits and with the authority retired can
+never gain grants and must migrate. Pure circuits add no keys.
+
+### 7. Lifecycle
+
+#### 7.1 Circuit semantics
+
+All three lifecycle circuits are device-gated through the unchanged
+device seam, which advances `auth_nonce` and `round` before the body
+runs. A ledger `Map.lookup` MUST be dominated by a `member` branch or a
+preceding assert (section 6.2 step 2). `[CIRCUIT]`: the bodies below are
+pending compilation; "issue over an absent id" and "revoke an absent id"
+are conformance items.
+
+`issue_grant(grant_id, <plaintext scope>, scope_salt)`:
+
+1. Disclose `grant_id` as `id`.
+2. If `grants.member(id)`: read the old record and assert that it is
+   not live, that is, `!old.active || old.epoch != device_epoch || old.gen != grant_generation`
+   ("grant already active"). Issue over an absent id, a tombstone, or an
+   inert record succeeds.
+3. Assert the issue rules of section 5.1 in order: non-empty scope;
+   shielded implies `read`; `per_call_cap <= cap`; spend requires
+   `cap > 0` and `max_coin_value >= per_call_cap`; `read` requires a
+   non-zero `read_pk_hash`; window fields zero.
+4. Write the whole record: `epoch = device_epoch`,
+   `gen = grant_generation`, `issued_at = auth_nonce` (already advanced
+   by the device seam, so unique per issuance), `nonce = 0`,
+   `spent_commit = derive_grant_spent_commit(scope_salt, 0)`, window
+   fields zero, `active = true`, and the scope with
+   `object_commit = derive_grant_object_commit(scope_salt, color, recipient_kind, recipient, max_coin_value)`
+   and the clear fields disclosed. `color`, `recipient`, and
+   `max_coin_value` are never disclosed; only their commitment is.
+
+`revoke_grant(grant_id)`:
+
+1. Disclose `grant_id`; assert `grants.member(id)` ("unknown grant").
+2. Read the record; assert `active` ("grant not live").
+3. Rewrite the record unchanged except `active = false`.
+
+`revoke_all_grants()`:
+
+1. `grant_generation += 1`.
+2. Optionally clear the map for state relief `[CIRCUIT]` (availability
+   of a reset primitive is not evidenced); the generation check carries
+   safety.
+
+Since the reference contract uses no spread or update syntax, a
+conforming implementation spells every struct literal out in full.
+
+#### 7.2 State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: issue_grant (device)\nepoch = device_epoch, gen = grant_generation,\nissued_at = auth_nonce, nonce = 0, spent_commit = C(0)
+    Active --> Active: grant twin\nnonce += 1, spent_commit = C(spent + amount)
+    Active --> Revoked: revoke_grant (device)\nactive = false
+    Active --> Expired: block time reaches expires_at\n(lazy, no write)
+    Active --> Inert: device_epoch bump (recovery)\nor grant_generation bump (revoke_all_grants)
+    Revoked --> Active: issue_grant (device)\nnew issued_at, nonce = 0, spent_commit = C(0)
+    Expired --> Active: issue_grant (device)\nre-issue with a new expiry
+    Inert --> Active: issue_grant (device)\nunder the new epoch or generation
+    Revoked --> Inert: epoch or generation bump
+    Expired --> Inert: epoch or generation bump
+```
+
+| From | Event | To | Written |
+|---|---|---|---|
+| absent, tombstone, or inert | `issue_grant` | active (epoch `e`, gen `g`, `issued_at` `i`) | whole record |
+| active | grant twin succeeds | active | `nonce + 1`, `spent_commit` |
+| active | `revoke_grant` | tombstone | `active = false` |
+| active | block time reaches `expires_at` | expired (lazy; record unchanged) | nothing |
+| any | recovery bumps `device_epoch` | inert by epoch | nothing (MAY clear the map) |
+| any | `revoke_all_grants` bumps `grant_generation` | inert by generation | `grant_generation` |
+| tombstone, expired, or inert | grant twin | abort, no state change | nothing |
+
+Rules: every transition into Active is device-gated and carries fresh
+consent over the whole scope; no in-place modification exists;
+modification is revoke then issue under fresh consent, composable in one
+transaction `[CIRCUIT]`; Revoked, Expired, and Inert all abort every
+grant twin with no state change; only `revoke_all_grants` and recovery
+are O(1) over the whole register; `remove_device` has no edge in this
+machine. Re-issue over a tombstone is permitted and yields a new
+incarnation with `nonce = 0`, a fresh `spent_commit` to zero, and a
+fresh `issued_at`; dApps SHOULD choose a fresh `slot` on re-issue where
+one is free. Tombstones are kept in v1 for enumerability and audit;
+pruning is a revision item `[RULING]`. Counters are `Uint<32>` or wider
+and owner-driven only. Grants belong to the account, not to the issuing
+device; no `issued_by` is recorded, since it would disclose a stable
+device identifier contrary to AUTH-9.
+
+#### 7.3 Recovery and device removal
+
+The recovery seam of the authorisation MIP section 8 is unchanged in its
+obligation: it bumps `device_epoch`, and the in-circuit equality check
+of section 6.2 step 3 makes every grant inert. Clearing `grants` at
+recovery is state hygiene a recovery circuit MAY perform; safety does
+not depend on it.
+
+Single-device removal does not cascade to grants in the contract
+`[RULING]`. On removing a device for suspected compromise the owner's
+client MUST call `revoke_all_grants` in the same transaction or
+immediately after, because a briefly compromised device can have issued
+grants with `expires_at = 0`, maximum caps, and no recipient pin to keys
+it controls, and the grant seam checks only `active`, `epoch`, and
+`gen`. The alternative, `remove_device_with_<arm>` bumping
+`grant_generation` internally, is a circuit change with no schema change
+and is recorded in Rationale R19 with its cost.
+
+#### 7.4 Composition in one transaction
+
+A grant call MAY be composed with other calls of the same or other
+contracts, including a device call of the same account or another
+account's call. Each grant call consumes exactly one `nonce` increment,
+so `N` composed calls under one grant need `N` consecutive counters and
+`N` signatures; the cumulative cap is enforced per call against the
+record as it stands at that call's execution, so a transaction cannot
+exceed `cap` in aggregate; the per-call cap is per circuit invocation,
+never per transaction; the recipient pin is evaluated per call and
+survives grafting; reordering composed calls invalidates the signatures.
+
+### 8. Read-scope delegation
+
+Read is the custody MIP's viewing capability (its R9), not a circuit.
+The on-chain `read` flag is declarative: it lets the owner enumerate
+from chain state which grants hold the viewing secret, anchors the
+consent wording to a stored field, and lets the shielded-implies-read
+rule be asserted at issue. The ledger enforces spend scope and not read
+scope.
+
+1. **Delegate key.** The request carries `read_pk`, a 32-byte X25519
+   public key. Browser grantees derive the corresponding secret from the
+   WebAuthn PRF output of their per-origin passkey, so the capability is
+   usable only after the user authenticates on the dApp origin; agents
+   use a vault key. The PRF evaluation is a separate `credentials.get`
+   from any grant-call assertion (an assertion requesting an extension
+   sets the ED flag and appends CBOR output, so its `authenticatorData`
+   exceeds the 37 bytes the r1 gate verifies); its output never enters a
+   circuit. `[DEP]` PRF availability in target browsers. The authoriser
+   MUST reject the twelve known low-order X25519 points and MUST abort on
+   an all-zero shared secret (the RFC 7748 contributory check) with
+   `invalid_request`. `read_pk_hash = H(read_pk)` is stored in the
+   scope.
+2. **Rotate before share.** Before issuing any grant with `read = true`
+   the authoriser MUST perform `rotate_enc_key` and re-encrypt live
+   holdings into fresh inbox entries (custody MIP section 6.7), so the
+   delegated secret reads current and future holdings but not spent
+   history `[RULING]`.
+3. **Sealing.** The authoriser seals the 32-byte account encryption
+   secret to `read_pk`: `shared = X25519(eph_sk, read_pk)`;
+   `key = HKDF-SHA256(ikm = shared, salt = empty, info = "midnight:account:grant:view:v1" || grant_id, L = 32)`;
+   AEAD AES-256-GCM with a random 12-byte nonce and associated data
+   `version || suite || eph_pk || grant_id || account`, so that the
+   ephemeral key, the grant, and the account are authenticated in the
+   container. The container, **GrantViewSeal v1**, is 94 bytes with its
+   own version and suite numbering space, distinct from InboxEntry:
+
+   | Offset | Length | Field |
+   |---|---|---|
+   | 0 | 1 | `version` = `0x01` |
+   | 1 | 1 | `suite` = `0x01` (X25519 + HKDF-SHA256 + AES-256-GCM) |
+   | 2 | 32 | ephemeral X25519 public key |
+   | 34 | 12 | AEAD nonce |
+   | 46 | 16 | AEAD tag |
+   | 62 | 32 | ciphertext of the account encryption secret |
+
+   It is delivered base64url in the response fragment as `view`, never
+   written to chain, never in a query component. `[CRYPTO]`: the sealing
+   suite, the PRF-to-X25519 derivation on the dApp side, and the
+   low-order rejection.
+4. **Reading.** The dApp reads by enumerating the account's contract
+   actions and decrypting locally (custody MIP section 6.5), verifying
+   every candidate coin by recomputing its commitment against chain
+   data before treating the entry as authentic and quarantining the
+   rest; no indexer receives the secret. This check is a MUST for every
+   inbox reader: `deposit_shielded` is permissionless and the contract
+   cannot verify the correspondence between a coin and its entry, so a
+   holder of the viewing secret can write plausible but unverifiable
+   entries; a conforming reader treats them as inert noise. This MIP
+   raises a companion note to the custody MIP's R9 that "pure viewing
+   capability" should read "viewing capability plus the ability to write
+   undecryptable or unverifiable noise into the inbox".
+5. **Re-seal.** Any re-seal (silent reconnect, section 9.8) MUST target
+   the key whose hash is `read_pk_hash`; a differing `read_pk` is
+   `invalid_request`. The authoriser MUST record every re-seal in the
+   owner's roster.
+6. **Revocation.** On revocation of any grant with `read = true` the
+   owner's client MUST `rotate_enc_key` and re-encrypt live holdings;
+   the delegate keeps what it already read (custody MIP S2); the consent
+   screen says so in advance.
+7. **Coarseness, stated as the dominant residual risk.** `read` delivers
+   the account encryption secret itself, which decrypts the whole inbox,
+   every color, current and future until rotation. A grant tightly
+   scoped in the spend dimension is therefore unscoped in the disclosure
+   dimension, and no schema field can bound it; every read-granted party
+   holds the same secret, so grants are not isolated from each other
+   (one dApp sees another dApp's activity and the owner's), and revoking
+   one blinds all until re-consent. This is the coarsest scope the
+   standard admits; spend without full disclosure awaits the custody
+   MIP's R9 successor (per-grantee or epoch-scoped viewing keys), which
+   this MIP records as its named successor dependency. The consent
+   screen carries the disclosure sentence as its first item for any
+   request that implies `read`.
+8. **Read-only grants** are in scope and first-class: a dApp that shows
+   balances holds a grant with `read = true` and no operation flag; the
+   record earns its transaction by being the enumerable, revocable
+   anchor of an otherwise invisible capability. Unshielded balances are
+   public and need no capability; every grant discloses the account
+   address, which is all an unshielded read needs.
+9. **Authoriser capability.** Possession of the viewing secret is an
+   independent capability of the authoriser role; an authoriser holding
+   only a device key cannot serve a read request and MUST refuse it with
+   `read_unavailable`. How the secret reaches a second device is the
+   custody MIP's business.
+
+### 9. GrantRequest and the redirect binding
+
+#### 9.1 The object
+
+One transport-independent `GrantRequest` object, canonical JSON per
+RFC 8785 (JCS), base64url-encoded without padding. `Uint<128>` values
+are decimal strings. Field names follow RFC 6749 where a parameter has
+an OAuth analogue.
+
+```json
+{
+  "v": 1,
+  "chain": "midnight:mainnet",
+  "aud": "https://passport.example",
+  "iat": 1790000000,
+  "exp": 1790000600,
+  "client_id": "https://bank.example",
+  "redirect_uri": "https://bank.example/passport/callback",
+  "account": "<64 hex, MUST when known>",
+  "grantee": { "scheme": "ecdsa_secp256k1_sha256", "envelope": 0, "pk": "<128 hex, x_le32 || y_le32>" },
+  "grants": [
+    {
+      "slot": 0,
+      "scope": ["midnight:account:read", "midnight:account:withdraw_shielded"],
+      "bounds": {
+        "color": "<64 hex>",
+        "per_call_cap": "1000000",
+        "cap": "5000000",
+        "max_coin_value": "5000000",
+        "expires_at": 1790000000,
+        "recipient": null
+      }
+    }
+  ],
+  "read_pk": "<64 hex X25519>",
+  "state": "<base64url, at least 128 bits>",
+  "nonce": "<64 hex, 32 bytes>",
+  "proof": {
+    "type": "webauthn",
+    "client_data_json": "<base64url>",
+    "authenticator_data": "<base64url>",
+    "signature": "<base64url>",
+    "credential_pk": "<hex, companion passkey only>",
+    "key_signature": "<hex, software and wallet-provider grantees only>"
+  }
+}
+```
+
+`recipient`, when present, is `{ "kind": "user" | "zswap" | "contract", "value": "<64 hex>" }`
+mapping to `recipient_kind` `1`, `2`, `3`. `envelope` is present only
+for `ecdsa_secp256k1_sha256`. `grants` carries one or more elements
+against the one grantee key, each with a distinct `slot`: one ceremony,
+one consent screen rendering every element, one device signature per
+record, and the authoriser composes the `N` `issue_grant` calls into one
+transaction (`[CIRCUIT]`) or submits them in sequence, returning
+`grant_id` as an ordered array `[RULING]`.
+
+| Member | Required | Rule |
+|---|---|---|
+| `v` | MUST | integer `1`; unknown is `unsupported_version` |
+| `chain` | MUST | CAIP-2 `midnight:<reference>` (MIP-0008); a legacy bare network id is accepted and canonicalised |
+| `aud` | MUST | the authoriser origin, exact string match against the authoriser's own origin; mismatch is `invalid_request` |
+| `iat`, `exp` | MUST | Unix seconds; `exp - iat` at most 600; a request outside `[iat, exp]` is `invalid_request` |
+| `client_id` | MUST | normalised RFC 6454 origin, `https` (plain `http` only for `localhost`); `rdns:`, `mais:`, `self:` identifiers are `invalid_request` in the browser binding |
+| `redirect_uri` | MUST in the browser binding; MUST be absent in non-browser bindings | absolute `https` URI whose origin equals `client_id`, no fragment; exact string match on return (RFC 9700 section 4.1.3); loopback exception only for native clients |
+| `account` | MUST when the dApp knows it | contract address hex; when absent the user chooses and the consent screen flags that the request bound no account |
+| `grantee` | MUST | `{scheme, [envelope,] pk}` per section 3; `envelope` `0` or `1` for `ecdsa_secp256k1_sha256` only |
+| `grants` | MUST | non-empty array of `{slot, scope, bounds}`; distinct slots; unknown strings are `invalid_scope` |
+| `bounds` | MUST when any withdraw string | `color`, `per_call_cap`, `cap`, `max_coin_value`, `expires_at` (`0` = never, explicit), `recipient` (null or typed) |
+| `read_pk` | MUST when `read` is requested or implied | 32-byte X25519 public key, hex; low-order points and an all-zero shared secret are `invalid_request` |
+| `state` | MUST | opaque, at least 128 bits of entropy, at most 512 characters, bound to the dApp's browser session, echoed verbatim |
+| `nonce` | MUST | 32 random bytes, hex; one-time: the authoriser MUST reject a `nonce` it has seen within the validity window |
+| `proof` | MUST | possession and origin proof over `request_digest` (section 9.2) |
+
+#### 9.2 Request digest and proof rules
+
+`request_digest = H(pad(64, "midnight:account:grant:request:v1") || H(JCS(request without "proof")))`.
+
+Off-chain signatures by a grantee key over a fixed 32-byte digest `d`
+use the arm's own form: `k1` signs `envelope_digest(envelope, d)`; `r1`
+is a WebAuthn assertion with `challenge = d`; `v1` is a key-prefixed
+Schnorr signature `(R, s)` with `c = int_le(H(R || pk || d)) mod r_J`
+and `s = r + c * sk mod r_J`, where `R` and `pk` are in the published
+`JubjubPoint` byte layout (the verifier is not a circuit and needs no
+grinding; a fixed digest cannot be ground) `[CRYPTO]`.
+
+Proof rules in the browser binding:
+
+- **`ecdsa_secp256r1_webauthn` grantee.** `proof.type = "webauthn"`: an
+  assertion by the grantee credential with `challenge = request_digest`,
+  requested without extensions. The authoriser verifies the signature
+  under `grantee.pk`, `clientDataJSON.type == "webauthn.get"`,
+  `clientDataJSON.challenge == base64url(request_digest)`,
+  `clientDataJSON.origin == client_id`, and
+  `rpIdHash == H(host(client_id))`, and copies `rpIdHash` into
+  `scope.rp_id_hash`.
+- **Software grantee** (`schnorr_jubjub`, or `ecdsa_secp256k1_sha256`
+  envelope `0`). `proof.type = "webauthn"` by a companion credential
+  created on the dApp origin, verified under `proof.credential_pk` with
+  the same `clientDataJSON` checks, plus `proof.key_signature`, a
+  signature by `grantee.pk` over `request_digest` in the arm's off-chain
+  form. The assertion attests the origin and binds the software key
+  through the digest; the key signature proves possession, so the
+  approver never spends an `auth_nonce` on a key the dApp cannot use.
+- **Wallet-provider grantee** (`ecdsa_secp256k1_sha256` envelope `1`).
+  As the software grantee, with `key_signature` obtained through the
+  connector's `signData` and verified over `envelope_digest(1, request_digest)`;
+  only `midnight:account:read` may be requested.
+
+Non-browser bindings (agents, `self:` delegates) carry
+`proof.type = "signature"` with `key_signature` only; the identity is
+displayed as operator-asserted or as the owner's own label.
+`proof.type = "signature"` in the browser binding is `invalid_proof`; an
+`rdns:`, `mais:`, or `self:` `client_id` arriving by top-level
+navigation is `invalid_request`.
+
+**The binding is a property of the transport** `[RULING]`. An
+authoriser that received the request as a top-level browser navigation
+MUST apply the browser binding regardless of the `client_id` form: the
+possession proof MUST be a WebAuthn assertion made on the dApp origin,
+and `rdns:`, `mais:`, and `self:` clients MUST be rejected. Non-browser
+bindings MUST use a distinct non-redirect delivery (a pasted or scanned
+request object, a local channel), MUST NOT accept a `redirect_uri`, and
+admit key-only proofs because an operator or the owner approves in
+person. Without this rule the requester's choice of an `rdns:`
+`client_id` would select the weaker binding while keeping the redirect,
+reopening both NEAR defects.
+
+#### 9.3 Browser binding: request delivery
+
+Top-level GET navigation to
+`https://<authoriser>/grant#request=<base64url(JCS(GrantRequest))>`.
+The request travels in the fragment, never in the query component
+`[RULING]`.
+
+#### 9.4 Authoriser processing
+
+In order:
+
+1. Verify that the request arrived by top-level navigation in a
+   top-level browsing context: the page sets
+   `Content-Security-Policy: frame-ancestors 'none'` and
+   `Cross-Origin-Opener-Policy: same-origin`, and checks that it is the
+   top window.
+2. Read and strip the fragment with `history.replaceState`.
+3. Verify `v`, `chain`, `aud`, `iat`, `exp`, `nonce` freshness, and
+   `proof`. Reject with an in-place error page (no redirect) if
+   `redirect_uri` is not `https`, not same-origin with `client_id`, or
+   carries a fragment.
+4. Verify the grantee scheme is in the registry and that the account is
+   capable (`spec_version >= 2`, and the arm present per the
+   authoriser's own record of the account's deployed arms, since
+   verifier keys are not a specified chain read); check `bounds`
+   well-formedness, the implications, and the envelope-1 read-only rule.
+5. Sign the user in with an authoriser credential whose RP ID equals
+   the full authoriser host, never a parent domain; this sign-in
+   assertion yields no signing material.
+6. Render the consent screen of section 9.5.
+7. On approval, and only then, perform the authorising ceremony: the
+   WebAuthn assertion whose PRF output derives the device key is
+   requested with `challenge = challenge_issue_grant_with_<device arm>(...)`,
+   so that `clientDataJSON` itself binds the approved scope and the
+   user-verification flag is the consent evidence; derive `grant_id`
+   and the commitments; sign the issue challenge with the derived
+   device key; use that key for exactly the signatures of this ceremony
+   and discard it; prove; submit; wait for inclusion (SHOULD; `pending`
+   is the fallback `[RULING]`); redirect.
+
+The order matters because the derived device key is signing material
+for any device-gated challenge: a page that derives it before consent
+holds the account's authority while waiting for a DOM click, and a
+script injection or hostile extension turns a connect flow into
+`add_device` or a withdrawal. GR-16 claims only what this construction
+delivers.
+
+The authoriser MUST NOT display or log `state`, MUST set
+`Referrer-Policy: no-referrer`, MUST NOT load third-party resources on
+the consent page, and MUST redirect with status 303, never 307.
+
+**Fees at issuance.** The `issue_grant` transaction is an ordinary
+account operation whose fee follows the custody MIP and the account's
+DUST arrangements; a zero-balance account cannot connect. A conforming
+authoriser MUST surface the fee requirement on the consent screen and
+MUST return `temporarily_unavailable` rather than `granted` when the
+account cannot fund the call. Sponsorship is out of scope; a conforming
+flow MUST work account-funded.
+
+#### 9.5 Consent screen
+
+Rendered after sign-in and before the authorising ceremony, from the
+exact plaintext scope that will enter the device challenge and from the
+proven `client_id`. No dApp-supplied name, icon, statement, or color
+name is displayed in v1 `[RULING]`. The screen MUST display:
+
+1. for any element that requests or implies `read`: the sentence that
+   the dApp will be able to see every current and future shielded
+   holding of the account, across all colors, until the encryption key
+   is rotated, that this is not limited by the spend bounds, and that
+   rotate-before-share will be performed;
+2. the authoriser's own origin;
+3. the dApp identity: the proven origin host (IDN shown in punycode when
+   scripts are mixed), or the operator-asserted identifier labelled as
+   such, or the owner's own `self:` label;
+4. the account (name and shortened address) and the network; when the
+   request bound no `account`, the words that the dApp did not name an
+   account and the approver is choosing one;
+5. for each requested element: every requested operation in plain words
+   ("withdraw unshielded", "withdraw shielded", "withdraw shielded to a
+   contract");
+6. the color as its full hex always, with a registry name beside it only
+   when resolved from the single source this MIP names in its registry
+   entry, and hex only otherwise;
+7. `per_call_cap`, `cap`, and `max_coin_value` in atomic units with an
+   explicit smallest-unit label (no on-chain decimals metadata exists);
+   on a re-issue, the tombstone's `spent` as the roster records it;
+8. the recipient pin, or "to any recipient";
+9. `expires_at` as a local date, or the words "never expires";
+10. the implications (a shielded spend implies read);
+11. the grantee key's scheme, envelope in words ("software key", "passkey
+    created on bank.example", "your wallet's key"), and a short
+    fingerprint the dApp is instructed to show on its side;
+12. that the connection, its scope bounds, its expiry, and its call
+    count are publicly visible on chain (its color, counterparty, and
+    amounts are not);
+13. that the transaction is paid by the account;
+14. that the grant can be revoked from any device.
+
+The approver MAY narrow any bound (lower cap, earlier expiry, narrower
+recipient, fewer operations, smaller `max_coin_value`) and MUST NOT
+widen one. The authorising ceremony MUST be performed with user
+verification.
+
+#### 9.6 Response and errors
+
+303 to the exact `redirect_uri` with form-encoded parameters in the
+fragment (never the query); the dApp strips the fragment with
+`history.replaceState` on load.
+
+| Parameter | Present | Value |
+|---|---|---|
+| `state` | always | echoed verbatim |
+| `iss` | always | the authoriser origin, `https` (RFC 9207; compared by simple string equality) |
+| `result` | always | `granted`, `pending`, `denied`, `error` |
+| `chain` | granted, pending | canonical CAIP-2 |
+| `account` | granted, pending | contract address hex |
+| `grant_id` | granted, pending | hex, ordered array matching `grants` |
+| `scope_salt` | granted, pending | hex, ordered array; the readability key of each record |
+| `tx` | pending, optionally granted | transaction identifier |
+| `view` | granted with `read` | GrantViewSeal v1, base64url (section 8) |
+| `error`, `error_description` | error, denied | from the tables below |
+
+No key list, no account list, no bearer artefact, nothing in a query
+component. If `redirect_uri` failed validation the authoriser MUST NOT
+redirect at all.
+
+Errors rendered in place (never delivered to `redirect_uri`):
+
+| `error` | When |
+|---|---|
+| `invalid_request` | malformed object, missing member, bad encoding, `state` too short, `aud` mismatch, outside `[iat, exp]`, replayed `nonce`, `redirect_uri` invalid or not same-origin with `client_id`, non-browser `client_id` by navigation, low-order `read_pk`, re-seal to a `read_pk` other than the bound one |
+
+Errors delivered to a validated `redirect_uri`:
+
+| `error` | When | Connector analogue |
+|---|---|---|
+| `unsupported_version` | `v` unknown | |
+| `unsupported_chain` | `chain` not served by this authoriser | |
+| `unsupported_scheme` | scheme not in the registry, or arm not deployed on the account; a withdraw string requested by an envelope-1 grantee | |
+| `invalid_scope` | unknown string, the reserved `signin` string, bounds inconsistent, implication violated, no on-chain effect requested, duplicate `slot` | |
+| `origin_mismatch` | attested `clientDataJSON.origin` differs from `client_id` | |
+| `invalid_proof` | signature, challenge, type, or `rpIdHash` check failed; key not on curve or weak; extension-bearing assertion; `signature` type in the browser binding | |
+| `account_not_capable` | account `spec_version < 2` | |
+| `read_unavailable` | this authoriser does not hold the account viewing secret | |
+| `access_denied` | the user declined this request | `Rejected` |
+| `permission_rejected` | the user declined and asked not to be asked again for this `client_id` | `PermissionRejected` |
+| `server_error`, `temporarily_unavailable` | as RFC 6749 section 4.1.2.1; the account cannot fund the issuance | `InternalError` |
+
+**Pending completion.** A dApp that received `result=pending` MUST poll
+chain state for its records and, once they are live, obtain its `view`
+through a silent reconnect (section 9.8), which re-seals to the bound
+`read_pk_hash` after the full read consent screen and no transaction.
+
+#### 9.7 Exact-match and return-leg rules
+
+- `redirect_uri` is compared by exact string match; the only exception
+  is the port of a `localhost` loopback URI for native clients
+  (RFC 9700 section 4.1.3).
+- The dApp MUST discard any response whose `state` matches no pending
+  request in the same browser session or whose `iss` differs from the
+  authoriser it navigated to.
+- The dApp MUST recompute each `grant_id` from its pending key,
+  `[envelope,]` normalised `client_id`, and `slot` by the byte recipe of
+  section 4.3 and compare with the returned values; MUST read
+  `grants[grant_id]`, `device_epoch`, and `grant_generation` from chain
+  state (an indexer query or a replay of the account's contract
+  actions); MUST verify `active`, `epoch`, `gen`, that `object_commit`
+  opens under the returned `scope_salt` to the requested color,
+  recipient, and `max_coin_value` (or an attenuation), and that every
+  clear scope field equals or attenuates its request; and only then
+  moves the pending key into use. Redirect parameters are hints.
+- A `grant_id` that does not match the recomputation MUST be treated as
+  evidence of a compromised authoriser: the dApp MUST NOT use the key
+  and MUST prompt the user to revoke from another device.
+- The pending private key SHOULD be non-extractable (WebCrypto or the
+  passkey-gated store), never plain `localStorage`. `scope_salt` and
+  `spent` MUST be persisted by the grantee alongside the key; losing the
+  salt costs the ability to read the record's commitments, and losing
+  `spent` costs the ability to open `spent_commit` until reconstructed
+  from the grantee's own transaction history.
+
+#### 9.8 Silent reconnect
+
+A dApp holding a live grant reads chain state and does not redirect. An
+authoriser receiving a request for which the dApp's recomputed
+`grant_id` is already live MAY, after sign-in and the full read consent
+screen, return `result=granted` with a freshly sealed `view` and no
+transaction, provided `H(read_pk) == scope.read_pk_hash`; a differing
+`read_pk` is `invalid_request`. This is how a dApp recovers its viewing
+material on a new device that holds the same per-origin passkey (and
+therefore the same PRF-derived `read_pk`).
+
+#### 9.9 Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser (user)
+    participant D as dApp origin
+    participant A as Authoriser (consent page)
+    participant K as Authenticators (dApp passkey, authoriser passkey)
+    participant C as Account contract
+    participant I as Indexer / node
+
+    B->>D: open dApp, choose Connect account
+    D->>K: create or use per-connection key; companion or r1 passkey on the dApp origin
+    D->>K: webauthn.get(challenge = request_digest), no extensions
+    K-->>D: assertion (clientDataJSON.origin = dApp origin)
+    D->>B: 303 to A/grant#request=b64url(JCS(GrantRequest))
+    B->>A: GET (top-level; fragment read client-side, then replaceState)
+    A->>A: verify aud, iat/exp, nonce, proof, origin(redirect_uri) == client_id == attested origin, chain, scheme, bounds, spec_version >= 2
+    A->>K: sign-in assertion (rpId = full authoriser host), no signing material
+    A->>B: consent rendered from the plaintext scope and the proven client_id
+    B->>A: approve (possibly narrowed)
+    A->>K: authorising assertion, challenge = challenge_issue_grant (PRF derives the device key)
+    A->>A: grant_id = derive_grant_id_with_<arm>(self, pk, [envelope,] origin_hash, slot); commitments; sign; discard the device key
+    A->>C: issue_grant_with_<device arm>(grant_id, plaintext scope, scope_salt, device auth)
+    C->>C: device seam; commit object and spent; write GrantRecord{epoch, gen, issued_at, nonce = 0, active, scope}; round += 1
+    C-->>A: inclusion
+    A->>A: if read: rotate-before-share done earlier; seal the encryption secret to read_pk
+    A->>B: 303 to redirect_uri#state&iss&result=granted&chain&account&grant_id&scope_salt&view
+    B->>D: fragment delivered on the dApp origin only; replaceState
+    D->>D: check state and iss; recompute grant_id by the byte recipe
+    D->>I: read grants[grant_id], device_epoch, grant_generation
+    I-->>D: record; open object_commit with scope_salt; compare with the request
+    D->>B: signed in (sign-in message signed by the grantee key, verified against chain)
+    D->>C: later: withdraw_shielded_with_grant_<arm>(recipient, color, amount, change_entry, grant auth)
+    C->>C: grant seam: id, active, epoch, gen, expiry, op, coin.color and coin.value against the commitments, caps, recipient, verify over g.nonce, nonce += 1, re-commit spent, round += 1; send; append change_entry
+```
+
+### 10. Sign-in
+
+This MIP defines account-linked, grant-backed sign-in only `[RULING]`.
+A dApp holding a grant knows the account address, because it must to
+call the contract and to read its record. Sign-in is the dApp verifying
+a message signed by the grantee key against the key it registered and
+against chain state. Sign-in-only requests never touch the authoriser or
+the chain: the dApp uses its own per-origin passkey locally. There is no
+identity-only on-chain grant; a read-only grant is not one, because its
+record anchors a real capability the owner can enumerate and revoke.
+Every grant discloses the account address by construction; this is not
+the unlinkable default the sign-in MIP owns, and
+`midnight:account:signin` is reserved for it.
+
+Message layout (fixed line order, `LF` separated, UTF-8):
+
+```
+{domain} wants you to sign in with your Midnight account:
+{account}
+
+URI: {uri}
+Version: 1
+Chain ID: midnight:{reference}
+Nonce: {nonce, at least 8 alphanumeric characters}
+Issued At: {RFC 3339}
+Expiration Time: {RFC 3339}
+Grant ID: {grant_id hex}
+```
+
+`signin_digest = H(pad(64, "midnight:account:grant:signin:v1") || H(message))`,
+signed in the arm's off-chain form of section 9.2 (`k1` through its
+envelope, `r1` as a WebAuthn assertion with `challenge = signin_digest`
+on the dApp origin, `v1` key-prefixed Schnorr).
+
+Verification by the dApp: the signature is valid under the registered
+`(scheme, [envelope,] pk)`; `domain` equals the dApp's own origin host;
+`Issued At` is within the dApp's tolerance and before `Expiration
+Time`; `Nonce` is unused; and, from chain, `grants[grant_id]` exists,
+`active`, `epoch == device_epoch`, `gen == grant_generation`, and not
+expired. Silent reconnect is a chain read with no redirect. Cross-dApp
+unlinkability of the credential itself follows from WebAuthn RP scoping
+and per-connection keys; cross-dApp collusion links users by account
+address, and the mitigation is multiple accounts, not this MIP.
+
+### 11. Ecosystem carriage
+
+#### 11.1 CAIP-25 carriage
+
+The grant feature strings and their bounds travel in a dedicated member
+of a CAIP-25 session keyed by the MIP-0008 CAIP-2 identifier, with dual
+acceptance of the connector's bare network id on input and
+canonicalisation to CAIP-2:
+
+```json
+{ "midnight:mainnet": { "midnight:account:grants": [ { "slot": 0, "scope": ["..."], "bounds": { } } ] } }
+```
+
+never in `methods`. A CAIP-25 peer MUST NOT treat a grant feature string
+as invokable. The `accounts` member is illustrative until CAIP-10 for
+Midnight is defined `[DEP]`.
+
+#### 11.2 Open Wallet Standard mapping
+
+A `GrantRequest` is expressible in Open Wallet Standard PE-1 policy
+terms field by field, and the grant record is the on-chain object PE-5
+asks to pair with:
+
+| PE-1 term | Grant field |
+|---|---|
+| target contract | the account address (`account`, `kernel.self()`) |
+| circuits | the three operation flags |
+| argument predicates | `color` equality; the recipient pin (`recipient_kind`, `recipient`) |
+| value per color, per-call bound | `per_call_cap` |
+| value per color, cumulative bound | `cap` |
+| value per color, per-window bound | `window_len`, `window_cap` (reserved in v1; client-side until then) |
+| validity | `expires_at`, `active`, `epoch`, `gen` |
+
+An Open Wallet Standard vaulted key is a first-class grantee through the
+`rdns:` or `mais:` identity in the non-browser binding: the vault signs
+the grant challenge, its policy engine mirrors the scope client-side,
+and the contract enforces it regardless of client behaviour. This MIP
+asks two things of that standard `[DEP]`: a capability flag at the
+handshake meaning "I can present a `GrantRequest` and sign grant
+challenges", and acceptance of the mapping table of section 5.2. The
+connector's scheme strings, its `midnight_signed_message:32:` prefix as
+envelope `1`, its `Rejected` and `PermissionRejected` semantics, and its
+`rdns` identity are reused; MIP-0015's consent vocabulary is aligned
+with informatively `[RULING]`. This MIP defines no injected API, no
+connector method, no client policy language, and no proving or
+submission transport.
+
+#### 11.3 The authoriser role
+
+The authoriser is a role defined by four capabilities: it holds a device
+key of the account, it renders a `GrantRequest`, it drives
+`issue_grant`, and, to serve `read`, it holds the account viewing
+secret. A consent page hosted by an identity provider is one instance;
+it holds no assets and no spend path. Any implementation holding a
+device key can act in the role; a conforming account MUST be
+connectable through a locally run authoriser, self-hosting MUST be
+documented, and a dApp MUST treat an unavailable authoriser as a
+recoverable error carrying no state.
+
+Plurality has an enrolment consequence: a device key derived under one
+authoriser's RP ID cannot be derived by another host, so a second
+authoriser needs its own `add_device`, consumes a device slot, changes
+`device_count`, and interacts with AUTH-5. One device key MUST NOT be
+enrolled for more than one authoriser host (RP-scoped derivation forbids
+it). Authoriser substitution is inert: a hostile authoriser cannot
+derive the real one's key.
+
+### 12. Invariants
+
+A conforming implementation MUST satisfy all of the following, in
+addition to the custody MIP's INV-1 through INV-8 and, as amended by
+section 13, the authorisation MIP's AUTH-1 through AUTH-10.
+
+- **GR-1 (single seam, closed operation set).** Every grant-authorised
+  operation is verified inside the account contract by the grant seam,
+  which exists only as the grant twins of `withdraw_unshielded`,
+  `withdraw_shielded`, and `withdraw_shielded_to_contract`; no lifecycle,
+  device-management, inbox, or grant-management circuit has a grant
+  twin. (INV-1)
+- **GR-2 (authority disjointness).** Grant keys are looked up only in
+  `grants` under grant tag families; a grant credential cannot satisfy a
+  device seam and a device credential cannot satisfy a grant seam;
+  cross-scheme use fails at identity derivation; an authoriser MUST
+  refuse to issue a grant to a key it knows to be enrolled as a device
+  of the same account, so that `remove_device` and `revoke_grant` each
+  retire what the owner believes they retire. (SIG-1)
+- **GR-3 (contract-maintained identity).** `grant_id` is a
+  deterministic commitment to `(account, arm, key, [envelope,]
+  origin_hash, slot)` recomputed in-circuit at every use; one such
+  tuple has at most one live record, and a key holds at most 256
+  records at one origin, all enumerable by anyone who knows the key and
+  the origin; issuance fails while a live record exists under that id;
+  revocation retires the id; only device-gated circuits create a
+  record, retire a record, or alter a record's scope; a grant twin
+  writes only the freshness and accounting fields of its own record.
+- **GR-4 (full binding).** Every grant challenge covers the account
+  address, the per-operation grant tag, the grantee key, `grant_id`,
+  `issued_at`, every operation argument that varies per call, every
+  consumed witness value, and the record's `nonce`; the commitment
+  openings are bound through `grant_id` and verified by equality
+  against the record. (AUTH-3, AUTH-10, SIG-2; `[CRYPTO]` on the
+  transitive clause)
+- **GR-5 (per-grant single use, owner liveness).** Every grant call
+  binds the record's `nonce` as read from ledger state and advances it,
+  so an identical resubmission of any argument tuple and signature
+  fails; grant calls never read or advance `auth_nonce`. (custody MIP
+  section 4 freshness; companion erratum to AUTH-2)
+- **GR-6 (incarnation isolation).** A signature produced against one
+  issuance of a grant id cannot verify against any other issuance of the
+  same id.
+- **GR-7 (in-circuit scope over consumed values).** Operation flag, the
+  color and value of the coin actually consumed (or the argument the
+  unshielded chip consumes), `per_call_cap`, `cap`, `max_coin_value`,
+  the recipient pin, `expires_at`, `active`, `epoch`, and `gen` are
+  asserted before any custody chip executes; every predicate is
+  evaluated over the value the chip consumes, never over an argument
+  that merely selects it; an out-of-scope call fails at proving or
+  verification, never at application discretion.
+- **GR-8 (contract-derived lifecycle fields).** `epoch`, `gen`,
+  `issued_at`, `object_commit`, and the initial `spent_commit` are
+  written by the contract from ledger state and from the plaintext the
+  approver signed; no argument supplies `epoch`, `gen`, or `issued_at`;
+  no grant can be pre-planted for a future epoch or generation.
+- **GR-9 (kill totality).** After a `device_epoch` bump or a
+  `grant_generation` bump no grant recorded under a previous value
+  authorises anything. (AUTH-6)
+- **GR-10 (chain-verifiable status).** `active`, `epoch`, and `gen` are
+  public state; revocation is effective from the including block; the
+  status of a known record is verifiable from chain state alone; the
+  identity of its grantee is not, and an owner holding only chain state
+  can revoke by id and revoke all but cannot attribute.
+- **GR-11 (no widening).** A record's scope is immutable after issue;
+  modification is revoke then issue under fresh device authorisation
+  whose challenge binds the full plaintext scope; the approver may
+  narrow and never widen a request.
+- **GR-12 (owner-only lifecycle, non-interference).** `issue_grant`,
+  `revoke_grant`, and `revoke_all_grants` are device-gated; a grant
+  call changes no device entry, `device_count`, `auth_nonce`, `enc_key`,
+  or any other grant's record; grants never count toward the
+  last-device rule. (AUTH-5)
+- **GR-13 (round monotonicity).** Issue, revoke, revoke-all, and every
+  grant call strictly increase `round`. (INV-7)
+- **GR-14 (key validity).** Every grantee key is rejected at every use
+  by exactly the per-arm checks of section 3.3 (k1: the point at
+  infinity in either encoding; v1: the identity and the 8-torsion; r1:
+  the schemes MIP's signature-side checks), and the authoriser rejects
+  the same at issuance; on-curve membership is `[CIRCUIT]` and is added
+  to the seam if the runtime does not enforce it. (authorisation MIP S2;
+  erratum 6)
+- **GR-15 (bounded disclosure).** A grant call discloses `grant_id`, the
+  record update, the kernel comparison argument, and the custody chip's
+  disclosures, and never the grantee key, origin, slot, salt, openings,
+  or signature; no grant field records any part of a held coin's
+  description in the clear; the running total is a commitment. (INV-2;
+  grant-side analogue of AUTH-9 per the companion erratum)
+- **GR-16 (consent equals record).** Every plaintext scope field is an
+  argument of `issue_grant` and enters the device challenge through
+  `scope_digest`; the consent surface renders from those fields and from
+  a possession-and-origin-proven request; consent precedes the ceremony
+  that produces signing material; the approver's signature authorises
+  exactly the scope written, and the record's grantee is a commitment
+  the authoriser computed, which the dApp verifies on return.
+- **GR-17 (redirect binding).** The authoriser acts only on a request
+  whose possession proof verifies, whose `aud` names it, whose validity
+  window is current and whose `nonce` is unseen, whose `redirect_uri` is
+  same-origin with the attested `client_id` and matched exactly on
+  return, and whose `state` it echoes verbatim; the binding is chosen
+  by the transport, never by the `client_id` form; it never redirects
+  to a target that failed those checks; the response carries no bearer
+  artefact, key list, or account list; the dApp treats its grant as
+  live only after recomputing `grant_id` and reading the record from
+  chain state. (RFC 9700 sections 2.1, 4.1.3, 4.10; RFC 9207)
+- **GR-18 (read is a capability, and it is total).** `read` is
+  declarative; the ledger does not enforce a read scope; a grant with
+  `read` confers the account's whole viewing capability over current and
+  future shielded holdings until rotation, which is the coarsest scope
+  the standard admits; the viewing secret is delivered sealed to a bound
+  `read_pk` and never in cleartext; rotate-before-share precedes every
+  read issuance; a client honouring a read revocation MUST rotate
+  `enc_key` and re-encrypt; an inbox reader MUST verify each entry's
+  coin against chain data before trusting it. (custody MIP R9, S2,
+  section 6.5)
+
+### 13. Companion erratum to MIP-0013 section 9
+
+This MIP does not reinterpret any invariant of the authorisation MIP's
+section 9 per authoriser class; that MIP's section 4 says an extension
+MUST NOT weaken them. Three invariants are, as written, falsified by any
+grant twin, so this MIP proposes one companion erratum whose acceptance
+by the editors is an acceptance criterion `[RULING]` `[CRYPTO]`:
+
+- **AUTH-1** to read: "Every seam-gated circuit verifies a signature per
+  sections 4 and 5 against an authoriser credential active in the
+  current epoch: a device entry, or a grant record whose scope admits
+  the call, as defined by an instantiating policy standard; no gated
+  circuit proceeds on any other authority."
+- **AUTH-2** to read: "Every device-authorised gated call covers and
+  increments `auth_nonce`. A policy standard defining another authoriser
+  class MUST define its own contract-held freshness element that no
+  other class can advance, MUST cover and advance it on every call, and
+  MUST NOT advance `auth_nonce`."
+- **AUTH-9** to gain the scope clarification: "This invariant governs
+  device handles. A grant identifier is not a device identifier; the
+  account address in a preimage satisfies the cross-account clause; an
+  instantiating policy standard MAY define a stable per-grant
+  identifier, subject to a stated hiding argument." GR-15 is then the
+  grant-side analogue rather than an exception a MIP grants itself.
+
+Widening the authorisation MIP's definition of "device" to cover
+grantees is rejected: it would let a grant count toward `device_count`
+and weaken AUTH-5. The authorisation MIP's conformance tests that are
+device-only under this MIP are its items 1 to 9 as they stand; item 2
+(the rejection matrix) and item 5 (deposit independence) gain grant-side
+counterparts in the Testing section here.
+
+### 14. Versioning
+
+- **Document.** This specification is versioned by its MIP number and
+  revision history; substantive changes after acceptance require a new
+  MIP that lists this one in `Replaces`. It extends the custody MIP and
+  the authorisation MIP and supersedes neither.
+- **Contract schema.** Grant-capable accounts expose `spec_version = 2`.
+  New cells and structs are a redeploy; twins, lifecycle circuits, pure
+  derivations, and tag families are maintenance updates while the
+  authority is live, and the grant circuits MUST be in the
+  `spec_version = 2` wave plan with retirement after the last wave
+  (section 6.6). Enabling the window bounds later is a circuit revision
+  (`:v2` twins), not a redeploy.
+- **Scheme.** A grant scheme is a new tag prefix under the authorisation
+  MIP section 10's "policy structure" clause, with `grant` as the
+  policy-structure segment and the arm marker in the position the
+  registry pattern expects; a revision of any construction is a new
+  trailing version segment. Registry status: the JubJub grantee arm
+  Active; `k1` Interim with the schemes MIP's sunset, envelope-1
+  grantees `read`-only; `r1` Active upon `[DEP]`; `schnorr_bip340`
+  registered as pending upstream point operations. No new envelope id.
+- **Tag families**, all to be registered under the MPS-0027 registry
+  (an acceptance criterion):
+
+  | Family | Convention | Members |
+  |---|---|---|
+  | `midnight:account:grant:id:{v1,k1:v1,r1:v1}` | raw 32-byte pad, tuple element | identity preimage |
+  | `midnight:account:grant:obj:v1`, `midnight:account:grant:spent:v1`, `midnight:account:grant:scope:v1` `[RULING]` | raw 32-byte pad, tuple element | commitments and the scope digest |
+  | `midnight:account:grant:auth:{v1,k1:v1,r1:v1}:<operation>` | hashed from a 64-byte pad (`persistentHash<[Bytes<64>]>`) | per-twin DST; the longest member is 63 of 64 bytes, so the 64-byte width is a normative budget on operation names |
+  | `midnight:account:auth:{v1,k1:v1}:{issue_grant,revoke_grant,revoke_all_grants}` | the existing device family; the `k1` family version is verified against the reference before publication | lifecycle DSTs |
+  | `midnight:account:grant:origin:v1` | raw 32-byte pad prefixed to the bytes hashed (off-chain) | `origin_hash` |
+  | `midnight:account:grant:request:v1` | raw 64-byte pad prefixed to a hash (off-chain) | `request_digest` |
+  | `midnight:account:grant:signin:v1` | raw 64-byte pad prefixed to a hash (off-chain) | sign-in digest |
+  | `midnight:account:grant:view:v1` | ASCII HKDF `info` | GrantViewSeal |
+
+  The rule fixing conventions: on-chain tuple elements use raw 32-byte
+  pads (the device-entry convention); per-circuit DSTs are hashed from
+  64-byte pads (the auth convention as amended by the authorisation
+  MIP's first erratum); off-chain digests use a raw pad prefix at the
+  width that fits; HKDF `info` is ASCII.
+- **Containers.** GrantViewSeal carries its own leading version and
+  suite bytes; readers MUST skip unknown values rather than treat them
+  as errors, as the custody MIP requires of InboxEntry.
+- **Request.** `v` in the `GrantRequest`; unknown versions fail with
+  `unsupported_version`.
+
+### 15. Open items
+
+| Id | Tag | Item | Current default in this text |
+|---|---|---|---|
+| O1 | `[RULING]` | external co-author | named before the PR is opened; the offer in the upstream scoped-grant discussion answered first |
+| O2 | `[RULING]` | Shape B redeploy shared with the erratum-8 device-identity remedy | one `spec_version = 2` bump carrying both |
+| O3 | `[RULING]` `[CRYPTO]` | companion erratum to AUTH-1, AUTH-2, AUTH-9 (section 13) | the three wordings given; widening "device" rejected |
+| O4 | `[RULING]` | dApp-chosen `slot` in the identity; request `nonce` bound only in `request_digest` | adopted |
+| O5 | `[RULING]` | `issued_at` incarnation ordinal in the challenge rather than nonce continuity | adopted; re-issue resets `nonce` and `spent_commit` |
+| O6 | `[RULING]` | wire scheme names (section 3.4) | connector strings where they exist; `schnorr_jubjub`, `ecdsa_secp256r1_webauthn` filed into the registry |
+| O7 | `[RULING]` | binding chosen by transport; key-only proofs excluded from the browser binding | adopted; `.well-known` metadata an optional `[DEP]` extension, not v1 |
+| O8 | `[RULING]` | rotate-before-share on read grants | MUST; SHOULD only if the per-coin cost is judged prohibitive |
+| O9 | `[RULING]` | reserved window columns in v1 | yes (about 48 bytes per grant) |
+| O10 | `[RULING]` | owner recovery of plaintext origin and grantee | client roster MUST, reconciled on every account view; `origin_hint` a MAY with its leak stated |
+| O11 | `[RULING]` | request and response in the fragment, JCS object in one parameter | adopted |
+| O12 | `[RULING]` | no dApp-supplied display strings on consent, including color names | forbidden; hex always; one named registry source MAY add a name |
+| O13 | `[RULING]` | sign-in scope | grant-backed, address-disclosing only; `signin` reserved for the sign-in MIP |
+| O14 | `[RULING]` | one MIP or two | one MIP under MPS-0018; the split offered in the PR body |
+| O15 | `[RULING]` | wait for inclusion before redirecting | SHOULD; `pending` with `tx` as the fallback |
+| O16 | `[RULING]` | tombstone pruning and window enforcement | both deferred to a circuit revision |
+| O17 | `[RULING]` | salted commitments versus clear fields with an INV-2 carve-out erratum | commitments |
+| O18 | `[RULING]` | `max_coin_value` and atomic change backfill; no standalone `append_inbox` twin | adopted; bounded standalone twin is the fallback |
+| O19 | `[RULING]` | envelope-1 grantees restricted to `read` in v1 | restricted |
+| O20 | `[RULING]` | batch issuance in one ceremony | yes; sequential submission if composition fails |
+| O21 | `[RULING]` | `self:` grantee form | admitted in the non-browser binding |
+| O22 | `[RULING]` | device-removal cascade to grants | no contract cascade; client MUST compose `revoke_all_grants` with a compromise removal |
+| O23 | `[RULING]` | MIP-0015 in `Requires` or informative | informative |
+| O24 | `[RULING]` | `scope_digest` tag family (added by this draft) | `midnight:account:grant:scope:v1` |
+| D1 | `[DEP]` | secp256r1 in the Compact language surface (`r1` arm) | `r1` registered, Active upon delivery |
+| D2 | `[DEP]` | secp256k1 point operations upstream (`schnorr_bip340`) | reserved |
+| D3 | `[DEP]` | connector structured-display surface (envelope-1 spend) | envelope-1 `read`-only |
+| D4 | `[DEP]` | WebAuthn PRF availability in target browsers | PRF-derived `read_pk` for browser grantees |
+| D5 | `[DEP]` | Open Wallet Standard handshake capability flag and mapping-table acceptance; CAIP-10 for Midnight | asked; `accounts` member illustrative |
+| C1 | `[CIRCUIT]` | nested struct as a `Map` value | flattened fallback changes no wire form |
+| C2 | `[CIRCUIT]` | `Boolean` in a hash tuple; `scope_digest` arity | flags as single bytes; two-stage fallback |
+| C3 | `[CIRCUIT]` | challenge tuple arity above ten | `args_digest` fallback |
+| C4 | `[CIRCUIT]` | `JubjubPoint` byte layout; integer serialisation in recipes | published with vectors; little-endian at type width |
+| C5 | `[CIRCUIT]` | on-curve membership of witness points | assertion added if the runtime does not enforce it |
+| C6 | `[CIRCUIT]` | on-chain unit of `kernel.blockTimeLessThan` | pinned before Draft leaves; recorded in the registry entry |
+| C7 | `[CIRCUIT]` | precomputability of the change description | bounded standalone twin fallback |
+| C8 | `[CIRCUIT]` | map reset primitive availability | optional hygiene only |
+| C9 | `[CIRCUIT]` | lifecycle bodies compile with guarded lookups; composition of revoke plus issue and of batch issuance in one transaction | conformance items |
+| C10 | `[CIRCUIT]` | every cost and deploy-budget figure of section 6.6 | to be measured |
+| K1 | `[CRYPTO]` | hiding argument for `grant_id` and the salted commitments | per-connection key entropy; public keys stated as linkable |
+| K2 | `[CRYPTO]` | transitive binding of openings through `grant_id` (GR-4) | fallback binds them directly |
+| K3 | `[CRYPTO]` | `issued_at` incarnation argument (GR-6) | every issuance is a distinct credential |
+| K4 | `[CRYPTO]` | companion-passkey binding of a software key; off-chain key-prefixed Schnorr form | as section 9.2 |
+| K5 | `[CRYPTO]` | GrantViewSeal suite, PRF-to-X25519 derivation, low-order rejection | as section 8 |
+| K6 | `[CRYPTO]` | negative statement on fork replay | no cell defeats it |
+
+## Rationale
+
+**R1. A second authoriser class behind the same seam, not a wider
+"device", not a separate verifier, not a sender witness.** The custody
+MIP's INV-1 admits exactly one gate, so a grant must be a way to
+satisfy `require_authorised()` and not a parallel mechanism. Three
+shapes were available. Widening "device" to cover grantees would make a
+grant count toward `device_count` and weaken AUTH-5, and would put a
+full-authority credential class and a bounded one in the same set. A
+separate verifier contract would need the authenticated caller identity
+MPS-0029 records Compact does not have. Authenticating the grantee by a
+sender witness is the `ownPublicKey()` pattern the custody MIP section
+4 forbids and the pattern the upstream private-mandate proposal uses
+(R13). The remaining shape, a distinct record class verified inline in
+the account by grant twins that call a grant seam chip where device
+twins call the device chip, is what the account-custody prototype
+evidenced on a devnet node for cap, color, tombstone, and epoch
+enforcement, and what all five candidate designs converged on. Its
+price is a doubled twin count for the three spend circuits; merging
+device and grant twins into one circuit was rejected because a circuit
+conditional is a select that evaluates both sides, doubling the cost of
+every call to hide the authoriser class from an observer who can read
+the record anyway.
+
+**R2. An explicit map with a contract-recomputed identity, not a
+rolling-entry register and not entries in the device set.** The
+authorisation MIP's erratum 8 was proven on-node: a register keyed by an
+opaque, client-derived commitment cannot enforce "one credential, one
+live record", because a device that enrols a second entry for its own
+key survives revocation. A grant register must not reproduce it. The
+alternatives compared:
+
+| Shape | Enumerable by owner | Targeted revocation | Reaches `spec_version = 1` accounts | Erratum 8 | AUTH-9, INV-2 |
+|---|---|---|---|---|---|
+| Rolling single-use entries in a `Set` | no | races an active grantee indefinitely | by maintenance update | avoided | complete |
+| Grant entries in `devices` | no | as devices | by maintenance update | inherited wholesale; drifts `device_count` | as devices |
+| Grantee key stored in the record | yes | yes | no | avoided | publishes a stable grantee pseudonym; breaks the cross-account claim |
+| Contract-maintained grantee set plus `revoke_grantee` | yes | yes | no | avoided | set member dictionary-testable by anyone holding the public key |
+| Explicit `Map<Bytes<32>, GrantRecord>` keyed by a contract-recomputed `grant_id` (this MIP) | yes, by id | yes, instant | no | avoided: one live record per `(key, origin, slot)` is a contract rule | stable per-grant pseudonym hiding in key entropy; no coin material |
+
+The rolling-set design is the accumulator extension the authorisation
+MIP's S4 already permits and is recorded here as the privacy-preserving
+successor for call count and status, with its cost: the register is not
+enumerable, the shielded-implies-read rule cannot be asserted at issue
+because the entry arrives opaque, and revocation chases a grantee that
+keeps rolling. Contract-written `epoch` and `gen` mean erratum 7's
+pre-planting has no grant analogue. In-circuit derivation of `grant_id`
+inside `issue_grant` was rejected: it costs a device-arm times
+grantee-arm product of issue circuits (four today, six with r1) against
+a deploy budget that is already waved, and it does not remove the
+authoriser's trust position, since during the ceremony the authoriser
+holds the derived device key and could sign any device-gated challenge;
+the testable mitigations (the dApp reproduces the fingerprint and treats
+a `grant_id` mismatch as compromise) are adopted instead.
+
+**R3. A bounded `slot`, not a 32-byte request nonce, in the identity.**
+An earlier shape bound a dApp-chosen nonce into `grant_id`. Three
+findings removed it. A dApp-chosen unbounded nonce let one key hold
+arbitrarily many live records the owner could not enumerate or
+attribute, so revoking one left the key operating under the others,
+which is erratum 8 in a new register. With the nonce as the only
+non-public element of the preimage it became a capability secret
+carried in URL fragments and browser history. And the role it served
+for the dApp ("recompute the id of the grant I asked for") is served by
+key, origin, and slot. A one-byte slot keeps several grants per key (a
+multi-color dApp) while making all of a grantee's records enumerable in
+at most 256 lookups; the request nonce survives as a one-time request
+identifier bound only in `request_digest`. The consequence is stated
+plainly: no secret lives in the identity, so grant security rests on
+the grantee signing key alone, and for a publicly known key the
+dictionary test on `(key, origin, account)` is trivially answerable.
+
+**R4. A per-grant nonce read from state, not the shared `auth_nonce`
+and not a nonce argument.** The authorisation MIP's R4 chose a dedicated
+`auth_nonce` so that permissionless deposits could not invalidate a
+pending device signature. A grantee that could advance `auth_nonce`
+would reintroduce the same interference against the owner: it could
+race and void the owner's signed-but-unsubmitted authorisations, and a
+threshold device's signing ceremony would be griefable by any connected
+dApp. The record's own `nonce` is the freshness element, and it is read
+from ledger state inside the circuit exactly as the device arms read
+`auth_nonce`. An earlier step list hashed a free caller-supplied nonce
+and advanced a counter nobody compared, so one signature would have
+replayed until the cap was exhausted; a `grant_nonce` argument asserted
+equal to the record would have been equivalent in effect, but a dead
+argument invites exactly the omission that review found, and the
+read-from-state pattern already exists in the reference.
+
+**R5. `issued_at` as an incarnation ordinal, not nonce continuity across
+tombstones.** Re-issue over a tombstone raises the question of whether
+an unsubmitted grantee signature at the inherited nonce could verify
+against a re-issue whose scope admits the same arguments. Nonce
+continuity (the re-issue inherits the tombstone's counter) leaves that
+narrow residual; never re-using an id forces a slot change on every
+re-issue; binding a contract-written `issued_at` (the `auth_nonce`
+observed inside `issue_grant`, unique per issuance because `auth_nonce`
+strictly increases on every gated call) closes it at the cost of one
+field the dApp reads alongside `nonce` anyway, and it turns the
+cryptographic claim into "every issuance is a distinct credential",
+which also frees a later revision to prune tombstones without a
+high-water mark. Simplicity dissent is recorded; dApps additionally
+SHOULD choose a fresh slot on re-issue where one is free, which yields a
+new identity and makes the question moot on the normal path.
+
+**R6. Salted commitments for `color`, the recipient pin,
+`max_coin_value`, and `spent`, not clear fields with an INV-2
+carve-out.** The custody MIP section 6.1 forbids writing a held coin's
+color or value, in whole or in part, into public ledger state, and a
+shielded spend's amount is not public today (the disclosures inside the
+shielded withdraw chip feed the send path's commitment arithmetic, not
+the clear transcript). A public `spent` delta would publish the exact
+value of each output coin, a public `color` would name a color the
+account holds shielded, and a public `ZswapCoinPublicKey` pin would
+publish a counterparty the send path hides. The alternative, clear
+fields plus a companion erratum quantifying the leak as color, per-call
+value, cumulative value, and optionally counterparty, is recorded with
+its cost `[RULING]`; it was not taken because the custody MIP's own rule
+does not let a successor weaken an invariant, and because the
+commitment design costs the seam only the rolling-commitment shape the
+device seam already pays (two hashes per call: open and re-commit).
+What the commitment design costs the owner and the grantee is the salt,
+a readability key: losing it costs the ability to read the record's
+commitments, never authority. The observer still learns caps, expiry,
+and call count, which the consent screen says. An "any color" sentinel
+was rejected because it makes the cap dimensionless; a recipient set is
+not expressible in a struct field; a `spent` commitment with a range
+proof and a decremented `remaining` in a rolling entry are recorded as
+alternatives not taken.
+
+**R7. `max_coin_value` and an atomic change backfill, not a standalone
+`append_inbox` grant twin.** INV-4 puts the change entry on the spending
+client, which under a grant is the grantee, and the change description
+travels only in the communication commitment. A grantee that never
+backfilled would silently orphan the account's change, bounded only by
+the coin it selected. An earlier shape gave the grantee a gated
+`append_inbox` twin; it wrote unbounded 192-byte entries under a
+no-value scope that neither cap bounds, and the shielded-implies-append
+rule made that authority unrevocable separately from the spend scope.
+With the change entry as an argument of the shielded twins, bound in
+the challenge and appended in the same circuit, the reason for the twin
+is gone; `max_coin_value` bounds the value at risk from the coin the
+grantee selects and puts that number on the consent screen. A garbage
+entry remains possible and is detected by the owner's discovery walk,
+which verifies each candidate against chain data.
+
+**R8. The authoriser performs the write, not the dApp.** A dApp-performed
+on-chain write after the return leg departs from the user brief, makes
+the dApp balance fees and submit a device-proven transaction at connect
+time, ties the artefact's life to `auth_nonce` (any owner call in
+between voids the ceremony), and puts a proven transaction of
+unmeasured size (a bare proof is already 4,064 bytes) in a URL
+fragment. Grant injection is closed by the origin-attested possession
+proof, not by who submits, so the authoriser keeps the write, which is
+the brief verbatim and keeps the dApp integration to "redirect, return,
+read chain". The dApp-performed write is recorded as the alternative
+for origin-blind keys.
+
+**R9. Origin by browser attestation, not by HTTP headers, not by a
+plaintext origin on chain, not by fetched client metadata.** Browsers
+send no `Origin` header on a top-level GET and `Referer` is suppressed
+by the `no-referrer` policy this MIP mandates, so an HTTP-header origin
+binding for software keys is empty. A plaintext origin in the record
+would publish every connection an account has to every observer; the
+record holds a commitment inside a preimage that also contains a
+per-connection key, and this MIP states that chain-side origin
+enforcement does not exist. TLS-fetched `.well-known` client metadata
+would add a network dependency and a CORS requirement to consent and is
+recorded as an optional `[DEP]` extension for browser clients without
+WebAuthn. Because passkeys are RP-scoped, the "passkey registered for
+this dApp" of the user brief is necessarily a second credential on the
+dApp origin, and its key is P-256, so the first-class arm is `r1`;
+until the secp256r1 surface ships, a companion passkey on the dApp
+origin attesting the origin over a digest that covers a software key is
+the only construction on today's toolchain that closes NEAR's
+grant-injection defect for a software key. A key-only proof admitted in
+the browser binding with a "self-asserted" label was rejected because a
+user shown that label will click approve.
+
+**R10. One JCS object in the fragment, not loose query parameters.**
+Loose query strings with "sorted by name, percent-encoded" rules are a
+classic source of signature-verification divergence; RFC 8785 is a
+published canonicalisation. A single `request` parameter is also
+simpler for a developer than fifteen loose parameters plus a
+canonicalisation rule. Fragment transport on both legs keeps `state`,
+`pk`, `grant_id`, `account`, and the sealed viewing secret out of server
+logs and the `Referer` header and is compatible with a static
+authoriser page; it does not keep them out of browser history, session
+restore, profile sync, or an extension with host permissions, so both
+sides strip the fragment on load and Security Considerations name the
+residual. The developer-simplicity dissent for loose parameters is
+recorded.
+
+**R11. Read as the sealed viewing capability, not HPKE to the signing
+key, not a per-coin mirror, not a proxied read.** A WebAuthn credential
+signs and never performs a key agreement, so sealing to the grantee
+signing key is infeasible for the target grantee; a separate X25519
+`read_pk`, PRF-derived for browser grantees, is the only construction
+every grantee can operate. A per-coin mirror (re-encrypting each held
+coin to the grantee) costs a device-gated inbox write per coin, leaves
+later deposits invisible until re-mirrored, and hides the grantee's own
+change from it, so the brief's wallet-like dApp is not served by it; it
+is the direction of the custody MIP's R9 successor and is recorded as
+such. Proxied reads through the authoriser put an operator on the read
+path and are a step toward the authoriser becoming a wallet. A sealed
+blob stored on chain was rejected because silent reconnect to the bound
+`read_pk_hash` delivers the same portability at no schema cost.
+Rotate-before-share is a MUST because the blast radius is otherwise the
+account's whole history, at the cost of one gated call plus one inbox
+entry per held coin. Reusing InboxEntry's version and suite numbers
+literally for the seal was rejected because a different length,
+plaintext, and `info` under the same numbers invites mis-parsing by
+readers that skip on unknown values.
+
+**R12. Grant-backed sign-in, not an identity-only grant, and not a
+VRF.** Verifying liveness against a per-account contract requires
+naming the contract; address-hiding sign-in is a membership proof over
+an accumulator of accounts or an authoriser-signed pairwise pseudonym
+that puts an identity provider on the sign-in path, and both belong to
+the sign-in MIP. An identity-only on-chain grant costs a transaction and
+a tombstone and discloses an address for plain login, so it is
+rejected; a read-only grant is not identity-only, because its record
+anchors a capability. The objection raised against the authorisation
+MIP, that a VRF-based identity should replace signature verification,
+applies here with the same answer: the grantee credentials this MIP
+targets are passkeys and hardware or vaulted signers, which produce
+signatures and nothing else, and the WebAuthn origin attestation that
+closes grant injection is a property of a signature ceremony.
+
+**R13. Positioning against the upstream private-mandate proposal, the
+connector, and MIP-0015.** The private-mandate proposal standardises a
+capability-scoped, value-capped, expiring, revocable delegation record,
+which is the same shape as this grant, but its agent is authenticated by
+a sender witness (the pattern the custody MIP section 4 forbids), its
+payment is bearer by hash, its vault balance is an admin-overwritten
+integer rather than custodied assets, and it attaches to no custody
+seam. This MIP is that record verified behind `require_authorised()`
+over real custody, and the two documents can be reconciled by the
+mandate proposal adopting a grant as its authority object. The dApp
+connector and the Open Wallet Standard are wallet-side, off-chain, and
+ephemeral; this MIP sits above them as the ceremony a user approves
+once and below them as the on-chain object their signatures target, and
+it reuses their vocabulary (scheme strings, the connector prefix as
+envelope `1`, `Rejected` and `PermissionRejected`, `rdns`) rather than
+inventing a parallel namespace. MIP-0015's `deriveSecret` is
+seed-anchored and a seedless account cannot satisfy it; the grantee's
+own per-origin passkey answers the durable-secret need, and MIP-0015's
+consent vocabulary is aligned with informatively rather than imported.
+
+**R14. Connector scheme strings on the wire, not registry short names.**
+Wallets already emit `ecdsa_secp256k1_sha256` and `schnorr_bip340` in
+their `Signature.scheme`, and the reference experiment that validated
+the wallet-key gate asked the registry to adopt them. Two registry
+spellings are proposed for the schemes the connector does not name, with
+one normative mapping table. The dissent for short names with a map to
+connector strings is recorded.
+
+**R15. No `network_id` cell.** A contract address is derived from the
+deploy transaction's content, so two independent deployments already
+differ; addresses collide across networks exactly when the deploy
+content is identical, in which case a constructor argument would be
+identical too and separate nothing. A cell the ledger does not assert
+and a client cannot check against the chain adds nothing a CAIP-2
+string in the client's configuration does not. MIP-0008 is therefore a
+reference, not a requirement; the wire `chain` member stays normative
+for the request, and a state-preserving fork is stated honestly as
+undefeated by any cell.
+
+**R16. One MIP, under MPS-0018.** The grant primitive is the reserved
+extension of two MIPs filed under MPS-0018, and the custody MIP's
+section 2 already names grants in normative language; a fresh problem
+statement would delay this document by an editor cycle and duplicate
+that text. The connection and sign-in flow could be a sibling document;
+the split is offered in the submission if the editors object to dApp
+connection under a libraries-and-tooling problem statement, and the
+unlinkable sign-in mode stays a separate MIP regardless.
+
+**R17. Tombstones kept, lazy expiry, a generation counter for
+revoke-all.** Deletion on revoke removes the enumerability that lets an
+owner reconcile live ids against a roster, and revocation that chases a
+rolling grantee races it; a stable per-grant residue is the price of
+enumerability, and pruning is a revision item. Automatic expiry cleanup
+paid by someone was rejected; in-circuit lazy expiry costs nothing when
+no one calls. The generation counter gives the owner a grant-only kill
+switch the epoch bump (recovery only) does not, without touching
+devices, and carries the safety property so that clearing the map at
+recovery is optional hygiene.
+
+**R18. Envelope-1 grantees read-only.** Stated in section 3.2: a blind
+32-byte signing surface over a challenge whose every element is public
+or attacker-chosen is a signing oracle for any site the user connects
+the same wallet to. Restricting the surface to `read` is the only
+defence available without a secret in the identity preimage, which R3
+deliberately removed; spend waits on a connector surface that renders a
+decoded grant call `[DEP]`.
+
+**R19. No contract cascade from `remove_device` to grants.** A cascade
+would sever every dApp connection on routine device retirement, and a
+removed-but-still-live device calling `revoke_all_grants` is denial of
+service, not theft. The threat model is accepted and carried into a
+client MUST: compose `revoke_all_grants` with a compromise removal,
+because a briefly compromised device can have issued unbounded grants
+to keys it controls. The alternative (`remove_device` bumping
+`grant_generation` internally) is a circuit change with no schema
+change and is `[RULING]`.
+
+**R20. Owner attribution through a client roster, not through
+plaintext on chain.** The user brief says the public key is recorded
+"along with the origin". Recording either in the clear would publish a
+stable grantee pseudonym and every connection of the account. This MIP
+records commitments, and states that an owner holding only chain state
+can revoke by id and revoke all but cannot attribute; a conforming
+client MUST maintain a roster (id, `client_id`, key, `[envelope,]`
+`slot`, `scope_salt`, plaintext scope, re-seals) rebuildable from the
+issuing device and MUST reconcile live ids against it on every account
+view, surfacing any unrecognised live id as possible compromise. An
+optional `origin_hint` sealed under the account encryption secret and
+written at issue is a MAY with its leak stated: every read-granted dApp
+would learn the account's other connections.
+
+## Path to Active
+
+### Acceptance Criteria
+
+- [ ] `[RULING]` External co-author named; the offer of a compatible
+      scoped-grant primitive in the upstream discussion answered.
+- [ ] MIP number assigned by an editor; the companion PR appending this
+      MIP to MPS-0018's Recommended MIPs and `MIP:` header merged.
+- [ ] `[RULING]` Editors' acceptance of the companion erratum covering
+      AUTH-1, AUTH-2, and AUTH-9 (section 13).
+- [ ] Every tag family of section 14 registered under the MPS-0027
+      registry once it ratifies, including the `scope` family `[RULING]`.
+- [ ] `[CRYPTO]` Independent cryptographer review of: the grant
+      challenge and the `issued_at` incarnation argument; the transitive
+      binding of commitment openings through `grant_id`; the hiding
+      argument for `grant_id` and the salted commitments; the
+      companion-passkey binding of a software key and the off-chain
+      key-prefixed Schnorr form; the GrantViewSeal suite with the
+      low-order rejection and the PRF-to-X25519 derivation; and the
+      negative statement about fork replay; with findings addressed.
+- [ ] `[CIRCUIT]` E1: the grant arm on the reference contract at
+      `spec_version = 2` (`grants`, `grant_generation`, issue, revoke,
+      revoke-all on both device arms, three k256 twins on envelopes `0`
+      and `1`, three jubjub twins), with rows, k, prover-key size, and
+      proving time per twin against the device twins; nested struct or
+      flattened fallback; the absent-key paths of issue and revoke; the
+      tuple arity of the shielded challenges or the `args_digest`
+      fallback; the guarded change append.
+- [ ] `[CIRCUIT]` E2: the negative conformance suite of Testing item 2
+      green on a node, each item ending with the invariants it
+      exercises, including the vacuous-verifier control.
+- [ ] `[CIRCUIT]` E3: the on-chain unit of `kernel.blockTimeLessThan`
+      pinned on a ledger-9 network and recorded in the registry entry;
+      `expires_at` past and future; `0` never expires; a value in the
+      wrong unit as a negative case; boundary behaviour under the
+      transaction validity window.
+- [ ] E4: the redirect ceremony with two distinct origins and two
+      platform passkeys (r1-shaped and companion-passkey proofs), consent
+      before the authorising ceremony, `issue_grant`, return, chain
+      read; a read-only grant; a two-element batch; an account with zero
+      DUST refused with `temporarily_unavailable`; and the attack suite
+      of Testing item 4.
+- [ ] E5: cross-implementation vectors (TypeScript and Rust, the Rust
+      side linking no compiled contract module) for `grant_id` on every
+      arm including the `JubjubPoint` layout, `object_commit`,
+      `spent_commit`, `scope_digest`, every grant challenge,
+      `envelope_digest`, `origin_hash`, `request_digest` over JCS, the
+      sign-in digest, and the sealed viewing secret, bit-identical;
+      `pk` normalisation from SEC 1; negative vectors for weak and
+      low-order keys; published.
+- [ ] E6: deploy budget for the full 30-key (33 with p256)
+      `spec_version = 2` contract against the per-block parameters; the
+      wave plan; hand-built maintenance updates after wave one; authority
+      retirement after the last wave confirmed.
+- [ ] `[CRYPTO]` E7: read handover: a read-only grant first; seal to a
+      PRF-derived X25519 key on the dApp origin; decrypt; the inbox walk
+      from the dApp side with commitment verification;
+      rotate-before-share then confirmation that the delegate cannot
+      read spent history; rotate on revoke then confirmation that the
+      delegate reads no new entries; a low-order `read_pk` refused; a
+      silent-reconnect re-seal to the bound key succeeds and to another
+      key is refused.
+- [ ] E8: an agent grantee: a jubjub grant issued to the reference
+      signer acting as an agent in the non-browser binding, a spend
+      within scope through the jubjub twin, the scope mirrored as an
+      Open Wallet Standard PE-1 policy document; a jubjub grant issued
+      to a `self:` delegate from the owner's own client with no
+      authoriser page.
+- [ ] `[CIRCUIT]` E9: revoke plus issue in one client-built transaction
+      with consecutive use counters; a two-element batch issuance in one
+      transaction; two grant calls under one grant in one transaction
+      with consecutive nonces; atomicity or the documented sequential
+      fallback.
+- [ ] E10: a grantee shielded spend with the change entry appended in
+      the same transaction under the one-hop default; owner and grantee
+      attempting to spend the same coin concurrently (proving failure,
+      no mis-spend); a coin above `max_coin_value` aborts.
+- [ ] `[DEP]` E11: an r1 grantee end to end once the secp256r1 surface
+      ships; an extension-bearing assertion as a negative case. Until
+      then the r1 arm and `schnorr_bip340` are marked pending in the
+      registry.
+- [ ] A public reference implementation passing E2 as its conformance
+      suite with the E5 vectors published.
+- [ ] A second independent implementation of the grantee side (a wallet
+      provider or an Open Wallet Standard plugin) producing bit-identical
+      challenges from the byte recipes alone.
+- [ ] Public-testnet deployment of a `spec_version = 2` account with at
+      least one grant issued, exercised, and revoked by a third-party
+      dApp.
+- [ ] A dApp not written by the authors completing E4 from the text
+      alone.
+- [ ] `[DEP]` The scope mapping table of section 5.2 accepted by the
+      Open Wallet Standard upstream, or a documented divergence.
+
+### Implementation Plan
+
+1. Name the external co-author (O1) and settle O2 to O24 with the
+   Foundation and the editors; fold the outcomes into the text.
+2. Extend the reference contract to `spec_version = 2` and run E1, E2,
+   E3, E6, E9, and E10; correct any byte recipe the compiled encoding
+   contradicts and publish the E5 vectors.
+3. Build a reference authoriser page and a reference dApp against the
+   text and run E4 and E7; then E8 with the reference signer as agent.
+4. Commission the cryptographer review; fold findings into the
+   specification before editor numbering if substantive.
+5. Open the companion PRs: MPS-0018 Recommended MIPs; the authorisation
+   MIP erratum of section 13; the custody MIP R9 wording note.
+6. Register tag families when the MPS-0027 registry lands; file the two
+   registry spellings and the `k1` and `r1` grantee rows into the
+   schemes MIP.
+7. Submit for editor numbering; open a Discussion; raise the origin
+   binding in MIP-0015's open question thread; iterate through community
+   commentary.
+8. Run E11 when the secp256r1 surface ships and move the r1 arm to
+   Active.
+
+## Backwards Compatibility Assessment
+
+This MIP introduces a new contract standard. It requires no ledger,
+consensus, or node change and no hard fork: every mechanism used
+(in-circuit hashing and curve arithmetic, contract state, witness
+arguments, the kernel block-time comparison, the maintenance-update
+path) exists in the current stable network protocol.
+
+**Schema change: grant support is a redeploy.** `grants`,
+`grant_generation`, and the two structs are new ledger cells and types.
+A contract's ledger schema is fixed at deploy; only its circuits evolve
+by maintenance update. A grant-capable account therefore exposes
+`spec_version = 2`, and **an existing `spec_version = 1` account cannot
+gain grants by maintenance update**; migration is a new account and is
+out of scope. Clients MUST read `spec_version` before requesting a grant
+and MUST report `account_not_capable` otherwise. The redeploy SHOULD be
+shared with the device-identity remedy for the authorisation MIP's
+erratum 8 `[RULING]`, since accounts are not yet deployed at scale.
+Within a `spec_version = 2` account, twins, lifecycle circuits, pure
+derivations, and tag families are maintenance updates while the
+authority is live, and enabling the reserved window bounds later is a
+circuit revision, not a redeploy.
+
+**Relation to the custody MIP.** A grant is an "authorisation-policy
+object behind the same seam" (its section 2), and INV-1 to INV-8 hold:
+grants are inside the seam (INV-1); no coin description is stored in
+the clear and the running total is a salted commitment (INV-2); the
+change rule and inbox backfill fall on the grantee and are made atomic
+by the `change_entry` argument (INV-3, INV-4); one-hop remains the
+client default (INV-6); every grant call bumps `round` (INV-7). No new
+InboxEntry version is defined; GrantViewSeal is a new container with
+its own numbering. A companion note to its R9 is raised on the write
+channel the viewing secret opens.
+
+**Relation to the authorisation MIP.** Additive in every existing
+circuit and cell: the device seam, custody chips, and device challenge
+preimages are untouched, so its conformance suite passes unchanged.
+AUTH-3 to AUTH-8 and AUTH-10 hold as written for devices; GR-4, GR-5,
+GR-9, and GR-12 give the grant analogues. AUTH-1, AUTH-2, and AUTH-9 are
+addressed by the companion erratum of section 13, not by
+reinterpretation `[RULING]`. The recovery seam's obligation is
+unchanged; clearing `grants` is optional hygiene. Device keys, wallet
+keys under MIP-0003, and wallets unaware of this standard are
+unaffected; a wallet provider becomes involved only when its key is
+enrolled as an envelope-1 grantee, in which case the connector surface
+it already exposes suffices for `read`.
+
+**Relation to the schemes MIP.** The `k1` and `r1` grantee arms reuse
+its registry, its WebAuthn envelope, and its signature-form policy; two
+registry spellings and a grantee Status per arm are filed into it. The
+`r1` arm is `[DEP]` on the same language surface that MIP is.
+
+## Security Considerations
+
+The dominant residual risk is stated first: **`read` is total.** A
+grant with `read`, which every shielded spend grant implies, delivers
+the account encryption secret, which decrypts every current and future
+shielded holding across all colors until rotation; no schema field
+bounds it; read-granted parties are not isolated from each other; and
+revoking one blinds all until re-consent. The controls are
+rotate-before-share (MUST), sealed delivery to a bound `read_pk`, the
+declarative flag for audit, rotate-and-re-encrypt on revoke (client
+MUST), the disclosure sentence as the first consent item, and the
+custody MIP's R9 successor named as the dependency for spend without
+full disclosure.
+
+**Observability (normative).** A passive observer of the register
+learns, per account, the number of connections ever made (records
+including tombstones), and for each the admitted operations, whether it
+holds `read`, its caps, its expiry, its call count, and its status; from
+a call it learns which grant acted and that the call count advanced. It
+does not learn the grantee key, the origin, the color, the counterparty
+(except a contract recipient, which the send path publishes regardless),
+or any amount. This is within INV-2 (no part of a held coin's
+description in the clear; the caps are the owner's policy, not a coin's
+value) and, per the companion erratum, outside AUTH-9's scope (a grant
+identifier is not a device handle). The consent screen tells the user
+the connection and its bounds are publicly visible. The rejected
+accumulator register is the privacy-preserving successor for call count
+and status, with its revocation race stated in R2.
+
+| | Attack | Mitigation |
+|---|---|---|
+| S1 | Grant injection (login CSRF): the victim approves a URL carrying the attacker's key under the dApp's name | possession proof over `request_digest` by the grantee key; browser-attested `clientDataJSON.origin == client_id` whenever the request arrives by navigation, regardless of `client_id` form; `state` bound to the dApp session; the return-leg recomputation of `grant_id` matches no pending key at the victim's dApp |
+| S2 | Open redirector through an attacker-controlled return URL | `redirect_uri` MUST be `https`, same-origin with the proven `client_id`, exact-string matched; non-browser bindings carry no `redirect_uri`; no navigation to a target that failed validation |
+| S3 | Binding downgrade by choosing an `rdns:` or `self:` `client_id` in a navigation | rejected with `invalid_request`; the binding is a property of the transport |
+| S4 | Mix-up: the response attributed to the wrong authoriser | `iss` in the response compared by string equality; the grant is read from chain state, never from redirect parameters |
+| S5 | Request replay at another authoriser or later | `aud`, `iat`, `exp` covered by `request_digest`; one-time `nonce`; `account` MUST when known and flagged on the consent screen when absent |
+| S6 | Key substitution at issue by a compromised authoriser | the authoriser is trusted for grantee identity exactly as it is trusted to render consent and, during the ceremony, holds the derived device key; the contract accepts an opaque `grant_id` as it accepts an opaque device entry; the mitigations are testable: the dApp MUST reproduce the consent fingerprint and MUST treat a `grant_id` mismatch on return as a compromised authoriser with a prompt to revoke; in-circuit derivation is the rejected alternative (R2) |
+| S7 | Grantee signature replay | the record's `nonce` read in-circuit, covered, and advanced; `grant_id` bound (no cross-grant reuse); `issued_at` bound (no cross-incarnation reuse); identical resubmission is a conformance abort case |
+| S8 | Blind-signing oracle through connector `signData` | envelope-1 grantees admit `read` only; spend `[DEP]` on a structured-display connector surface |
+| S9 | Scope creep by the grantee or upward adjustment by the authoriser | only device-gated circuits write scope; grant twins write only `nonce` and `spent_commit`; attenuation only; modify is revoke plus issue |
+| S10 | Object-scope bypass: declared color in scope, witness coin of another color or of a large value | `coin.color` and `coin.value` are asserted against the commitment and `max_coin_value` before the chip; the `color` argument only selects the witness |
+| S11 | Change orphaning by a grantee (send `C` from a coin of value `V`, never backfill) | `max_coin_value` bounds `V`; the change entry is an argument of the shielded twins appended in the same transaction; the owner's discovery walk verifies entries against chain data |
+| S12 | Revocation escape (the erratum 8 pattern) | contract-recomputed identity from the presented key; the bounded `slot` makes every record of a grantee enumerable; tombstone read at use; `revoke_all_grants` O(1); no grantee can call `issue_grant`; an unrecognised live id in the owner's reconciliation is treated as possible compromise, with `revoke_all_grants` and re-issue as the remedy |
+| S13 | Device compromise not contained by `remove_device` | the owner's client MUST compose `revoke_all_grants` with a compromise removal; a contract-level cascade is `[RULING]` |
+| S14 | Epoch or generation confusion, pre-planting (the erratum 7 pattern) | `epoch`, `gen`, `issued_at` contract-written; both asserted at use |
+| S15 | Weak keys (erratum 6) | the per-arm table of implemented checks; off-curve keys `[CIRCUIT]` with negative vectors |
+| S16 | Origin spoofing through a free parameter | the origin is the browser-attested value in the browser binding; the contract records only a commitment; chain-side origin enforcement does not exist and this MIP says so |
+| S17 | Consent deception by dApp-supplied strings or display units | consent rendered from the exact plaintext scope and the proven `client_id`; no dApp-supplied name, icon, statement, or color name; atomic units with a smallest-unit label; hex color always |
+| S18 | Consent as a DOM event on a page already holding signing material | consent precedes the authorising ceremony; the assertion challenge is the issue challenge; the derived key is used once and discarded; `frame-ancestors 'none'`, top-window check, COOP |
+| S19 | Bearer leakage through URLs, logs, referrers, history | fragment transport on both legs; `no-referrer`; no third-party resources; `history.replaceState` on both legs; the only secret (`view`) is sealed to a validated `read_pk`; `scope_salt` in the fragment is a readability key, not authority; browser history, session restore, profile sync, and extensions with host permissions remain exposure surfaces |
+| S20 | Low-order or malicious `read_pk` makes the seal publicly decryptable | reject the known low-order points; abort on an all-zero shared secret; AAD binds `eph_pk`, `grant_id`, `account` |
+| S21 | Silent reconnect re-delegates the secret to an attacker-chosen key | re-seal only to `read_pk_hash`; full read consent on every re-seal; re-seals recorded in the roster |
+| S22 | Owner liveness griefing by a racing grantee | grant calls never touch `auth_nonce` |
+| S23 | Register or inbox growth as denial of service | only devices create records; a grantee writes at most one 192-byte inbox entry per spend, under a spend it paid for; counters `Uint<32>` or wider; growth bounded by the owner's own issuance |
+| S24 | Cumulative-cap wrap | the sum is compared to `cap` in the widened type before the narrowing cast |
+| S25 | Inbox forgery with the delegated secret (phantom coins) | conforming readers verify each entry's coin against chain data (custody MIP section 6.5, restated as a MUST); forged entries are inert noise; the companion note to R9 |
+| S26 | Cross-account and cross-dApp linkage of a grantee key by a chain observer | the key is never stored; `kernel.self()` in the identity preimage; per-connection keys MUST; publicly known keys (the wallet-provider form) are linkable and this MIP says so |
+| S27 | Dictionary test "is this account connected to origin X" | `origin_hash` is a private argument inside a preimage that also contains a per-connection key; the plaintext origin is never on chain; the test succeeds for a publicly known key, stated |
+| S28 | Sibling-origin assertion against the authoriser's credential | authoriser and dApp RP IDs MUST equal their full hosts; Related Origin Requests excluded |
+| S29 | Address disclosure by "sign-in" | no identity-only grant; sign-in-only never touches the authoriser or chain; every grant discloses the address, stated |
+| S30 | Cross-network replay after a state-preserving fork | no cell defeats it; `kernel.self()` plus the never-reuse-deploy-content client rule separate independent networks; expiry and revocation on the surviving chain are the defence |
+| S31 | Kernel argument disclosure per call | `expires_at` reaches the public transcript; harmless because the record is public |
+| S32 | Maintenance authority above the seam | grant circuits are part of the wave plan and the authority is retired after the last wave; a live authority remains the strongest attacker, as for devices |
+| S33 | Malleated ECDSA twins | both `s` forms accepted; inert because `nonce` advances and signatures are never identifiers (SIG-4) |
+| S34 | Pending private key stored before consent | non-extractable storage SHOULD; unavoidable in kind and documented |
+| S35 | Concurrent coin selection by owner and grantee | proving failure or a fee-wasting race, never a mis-spend (INV-5); a deterministic selection rule recommended |
+| S36 | Fee-payment linkability outside the contract | a dApp paying DUST from an address linked to its web identity links itself to the account; noted, outside the contract's scope |
+| S37 | Authoriser unavailability | a recoverable error carrying no state; any device-key holder can act as authoriser; a local authoriser is documented |
+| S38 | Toolchain hazards | the negative conformance suite includes the vacuous-verifier control the authorisation MIP's S10 mandates; toolchain versions whose hash outputs are stable are pinned |
+
+## Implementation
+
+- **Evidence held.** In-circuit cap, color, tombstone, and epoch
+  enforcement on a devnet node with a bearer grantee (the
+  account-custody prototype's v0 grants: withdraw only, one color,
+  cumulative cap, no expiry, tombstone revoke, epoch-scoped); the k256
+  envelope arm compiled and measured on a ledger-9 network (the
+  wallet-key gate experiment: k=15 and k=16, 31,046 and 32,900 rows,
+  0.5 to 0.8 s); the r1 WebAuthn envelope verified against a real
+  platform assertion (k=16, 36,466 rows, 1.1 to 1.2 s); the wave-deploy
+  and block-limit numbers of the reference implementation; the kernel
+  block-time comparison compiling and executing (its on-chain unit is
+  not held); contract-to-contract composition validated (the
+  cross-contract-calls experiment). Not yet held: any connection
+  protocol on Midnight, origin binding, expiry on node, signature-based
+  grantee authentication in the grant seam, and the cost of grant
+  verification under real signature circuits; these are the
+  experiments of Path to Active.
+- **Reference implementation changes.** The reference contract gains
+  `grants`, `grant_generation`, the two structs, per-arm
+  `derive_grant_id_with_*`, the commitment and scope-digest derivations,
+  `challenge_*_with_grant_*`, the three seam chips, three twins per
+  grantee arm, three lifecycle circuits per device arm, and
+  `spec_version = 2` in the constructor; the k1 branch's
+  `envelope_digest` is reused verbatim. The TypeScript client gains a
+  grant-authorisation branch in its argument builder and the
+  `<operation>_with_grant_<arm>` call shapes; the Rust signer produces
+  bit-identical `grant_id`, commitments, and challenges from the byte
+  recipes alone, which is the R5 discipline of the authorisation MIP
+  carried to grants and the answer to the byte-framing gap raised
+  upstream.
+- **Reference authoriser and dApp.** A static consent page implementing
+  section 9 and a dApp implementing the return leg and sign-in, each
+  runnable locally, are the E4 and E7 artefacts and the basis of the
+  "dApp not written by the authors" criterion.
+- **Companion documents.** The MPS-0018 Recommended MIPs bullet; the
+  authorisation MIP erratum of section 13; the custody MIP R9 note; the
+  schemes MIP registry rows and spellings.
+- This MIP contains no implementation code; the artefacts above are its
+  evidence base, and the reference implementation is an acceptance
+  criterion, to be linked at its public location on submission.
+
+## Testing
+
+Conformance is demonstrated by a suite exercising, against a real node,
+the following. Each item names the invariants it exercises.
+
+1. **Grant happy path.** Issue a grant from a device; a grant call with
+   a valid grantee signature within scope executes; the record's `nonce`
+   advances, `spent_commit` re-commits, `round` advances, `auth_nonce`
+   is unchanged (GR-1, GR-5, GR-13; INV-7).
+2. **Rejection matrix.** The same call aborts with no state change
+   under each single fault: out-of-scope operation; over `per_call_cap`;
+   over `cap`; a cumulative wrap attempt; the declared color in scope
+   with a witness coin of another color; a witness coin above
+   `max_coin_value`; wrong recipient under a pin; recipient-kind
+   mismatch; revoked; expired; stale epoch; stale generation; identical
+   argument tuple and signature resubmitted after success; a signature
+   from a prior incarnation against a re-issue; a cross-scheme key; a
+   wrong envelope (k1); the identity, small-order, off-curve, and
+   invalid-curve keys; a grantee calling any device-gated or lifecycle
+   circuit (no ABI exists); re-issue of a live id rejected; issue over
+   an absent id succeeds; revoke of an absent id aborts; revoke one of
+   two slots held by one key, then prove the other still authorises and
+   only that one; `device_count` untouched; and the vacuous-verifier
+   control (GR-2, GR-3, GR-4, GR-5, GR-6, GR-7, GR-9, GR-12, GR-14; the
+   authorisation MIP's S10).
+3. **Owner liveness.** A pending owner signature still verifies after a
+   grant call; a permissionless deposit between grantee signing and
+   submission does not invalidate the grantee's call (GR-5; AUTH-8).
+4. **Redirect attack suite.** Open redirect; crafted-URL injection with a
+   `state` mismatch; `iss` mismatch; `aud` mismatch; expired request;
+   replayed `nonce`; proof failure; `clientDataJSON.origin` mismatch; an
+   `rdns:` `client_id` by navigation refused; an envelope-1 grantee
+   requesting a withdraw refused; a low-order `read_pk` refused; a
+   `grant_id` mismatch on return treated as compromise; a sibling-origin
+   assertion attempt against the authoriser credential; fragment leakage
+   under a logging reverse proxy and in browser history before and after
+   `replaceState` (GR-16, GR-17).
+5. **Cross-implementation vectors.** Every derivation of section 4 and
+   every challenge of section 6.3, `envelope_digest`, `origin_hash`,
+   `request_digest`, the sign-in digest, and GrantViewSeal, bit-identical
+   between the compiled contract, the TypeScript client, and a Rust
+   implementation linking no compiled module; `pk` normalisation from
+   SEC 1; published negative vectors (GR-3, GR-4).
+6. **Deploy budget.** The full `spec_version = 2` roster deployed in
+   waves within the per-block parameters; authority retirement after the
+   last wave; a `spec_version = 1` account shown unable to gain grants
+   (Backwards Compatibility).
+7. **Read handover.** Read-only grant; seal, decrypt, inbox walk with
+   commitment verification from the dApp side; rotate-before-share hides
+   spent history; rotate on revoke blinds the delegate; re-seal to the
+   bound key succeeds and to another key is refused; a forged inbox
+   entry is quarantined (GR-18).
+8. **Agent and self grantees.** A jubjub grant to the reference signer
+   in the non-browser binding, a spend within scope, the scope mirrored
+   as a PE-1 policy; a `self:` grant issued from the owner's client with
+   no authoriser page (GR-1, GR-17 non-browser clause).
+9. **Composition.** Revoke plus issue in one transaction; batch issuance
+   in one transaction; two grant calls under one grant in one
+   transaction with consecutive nonces; reordering invalidates
+   (GR-5, GR-11, GR-13).
+10. **Change and concurrency.** A grantee shielded spend with the change
+    entry appended in the same transaction under one-hop; owner and
+    grantee selecting the same coin (proving failure, no mis-spend); a
+    coin above `max_coin_value` aborts (GR-7; INV-3, INV-4, INV-5,
+    INV-6).
+11. **Kill totality.** `revoke_all_grants` inerts every record in one
+    call; a recovery epoch bump inerts every record; re-issue under the
+    new generation or epoch succeeds (GR-9).
+12. **r1 grantee.** `[DEP]` End to end once the secp256r1 surface ships;
+    an extension-bearing assertion as a negative case (GR-14).
+
+## References
+
+**Midnight documents**
+
+- [MPS-0018](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0018-asset-custody-model.md):
+  Multi-key Account Custody for Midnight-Native Assets (the parent
+  problem statement).
+- [MIP-0012](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0012-native-asset-custody.md):
+  Contract Custody of Midnight-Native Assets (the seam semantics, INV-1
+  to INV-8, the viewing capability, R9).
+- [MIP-0013](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0013-account-authorisation.md):
+  Multi-key Account Authorisation for Custody Contracts (the device
+  seam, AUTH-1 to AUTH-10, section 10 versioning, the reservation of
+  scoped grants); its
+  [discussion](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/244)
+  (the VRF objection answered in R12).
+- Signature Schemes for Custody-Account Authorisation (the schemes MIP;
+  local draft, number pending): registry, r1 WebAuthn envelope, k1
+  interim arm, SIG-1 to SIG-5.
+- [MIP-0003](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0003-ecdsa-support.md):
+  ECDSA support (the connector `signData` `scheme` discriminator).
+- [MIP-0008](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0008-caip-2-network-identifiers.md):
+  CAIP-2 network identifiers (the wire `chain` member).
+- [MIP-0015](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0015-wallet-derived-deterministic-secrets.md):
+  Wallet-derived deterministic secrets (consent and error vocabulary,
+  aligned with informatively).
+- [MIP-0007](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-0007-name-service-registry-and-resolver.md):
+  Midnight Name Service (contract-owned names; a candidate authoriser
+  discovery record).
+- [MPS-0003](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0003-caip-support.md):
+  CAIP support (connection framed as a chain-identifier problem).
+- [MPS-0015](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0015-agent-identity.md):
+  Agent identity (agents as a grantee class).
+- [MPS-0027](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0027-domain-separation.md):
+  Domain Separation for Midnight Hash Constructions (the tag registry).
+- [MPS-0029](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-0029-compact-caller-identity.md):
+  Caller identity in Compact circuits (why a separate verifier is not
+  available).
+- Upstream proposals: Private Mandate Tokens
+  ([PR #251](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/251),
+  R13); Midnight Agent Identity Standard
+  ([PR #110](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/110));
+  Soulbound Credential Primitive
+  ([PR #214](https://github.com/midnightntwrk/midnight-improvement-proposals/pull/214)).
+- Upstream discussions: a ZK-attested scoped-grant primitive offered as
+  prior art ([#223](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/223));
+  platform gaps for cross-implementation proofs, including
+  `persistentHash` byte framing
+  ([#260](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/260)).
+- The Midnight dApp connector API specification (scheme strings, the
+  `midnight_signed_message:32:` prefix, `Rejected` and
+  `PermissionRejected`, `rdns`); the Open Wallet Standard (policy engine
+  PE-1 to PE-7, the Midnight contract-execution specification).
+
+**External standards**
+
+- RFC 2119 (key words); RFC 6749 (OAuth 2.0; parameter names, section
+  4.1.2.1 errors); RFC 9700 (OAuth 2.0 Security Best Current Practice;
+  sections 2.1, 4.1.3, 4.2, 4.10); RFC 9207 (`iss` in authorization
+  responses); RFC 8785 (JSON Canonicalization Scheme); RFC 6454 (web
+  origin); RFC 7748 (X25519, contributory behaviour); RFC 5869
+  (HKDF); RFC 9591 (FROST; the v1 threshold arm).
+- W3C Web Authentication Level 3 (client data, authenticator data, RP ID
+  scoping, the PRF extension, Related Origin Requests).
+- SEC 1 and SEC 2 (point encodings; secp256k1, secp256r1); the Jubjub
+  curve specification (Zcash protocol specification, section 5.4.9.3).
+- CAIP-2, CAIP-10, CAIP-25, CAIP-217 (chain identifiers, account
+  identifiers, session scopes, scope objects).
+- EIP-4361 Sign-In with Ethereum (the sign-in message shape); UCAN
+  (attenuation, explicit `exp: null`); ERC-7715 (the adjustment
+  pitfall); NEAR access keys and wallet login (the redirect flow whose
+  defects section 9 closes).
+
+**Workspace evidence** (to be linked at public locations on submission)
+
+- The account custody reference implementation, `contract/` (MIP-0012
+  and MIP-0013 in one contract with co-resident device arms; the
+  connector-envelope branch with `envelope_digest`).
+- The account-custody prototype, `experiments/account-custody-prototype/`
+  (v0 grants: colour-scoped, value-capped withdraw grants on node).
+- The wallet-key gate experiment, `experiments/bip340-wallet-gate/`
+  (k256 envelope arm costs; the recommendation to adopt connector
+  scheme strings).
+- The P-256 in-circuit experiment, `experiments/p256-in-circuit/` (the
+  WebAuthn envelope against a real platform assertion).
+- The cross-contract-calls experiment, `experiments/cross-contract-calls/`
+  (composition in one transaction).
+- The Schnorr-wallet reference signers, `experiments/redjubjub-wallet/`
+  and `experiments/redjubjub-wallet-rs/` (the client-agnostic signing
+  boundary and the `JubjubPoint` layout the Rust side reproduces).
+
+## Acknowledgements
+
+The IOG Advanced Research and Creativity department and the Midnight
+Foundation. The connector specification and MIP-0015 maintainers, for
+the vocabulary this MIP reuses. The team that offered a compatible
+scoped-grant primitive in the upstream discussion, to be named here once
+the offer is answered `[RULING]`.
+
+## Copyright Waiver
+
+This document is licensed under the Apache License, Version 2.0, and its
+contribution is made under the Midnight Foundation Contributor License
+Agreement.
+
+Portions of this document were drafted with the assistance of a large
+language model. The named authors reviewed all content and are solely
+accountable for it.

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -37,7 +37,7 @@ MPS: MPS-0018
      | O1 | external co-author | named (Hector Bulgarini); the team that offered prior art in upstream discussion #223 is still to be answered and credited in Acknowledgements |
      | O2 | one spec_version = 2 redeploy carrying the grant cells and the device-identity remedy for MIP-0013 erratum 8 | SHOULD, in Backwards Compatibility |
      | O3 | companion erratum to MIP-0013 AUTH-1, AUTH-2, AUTH-9 (section 12); wordings in .planning/grants-mip/erratum-wordings.md, to travel in the erratum PR | acceptance is an acceptance criterion |
-     | O4 | on-chain unit of kernel.blockTimeLessThan (the never-expires arm and both comparison directions execute in the local simulator, whose unit is seconds; the node's unit is not pinned) | pinned before Draft leaves; recorded in the registry entry |
+     | O4 | on-chain unit of kernel.blockTimeLessThan | resolved (E3): whole seconds since the UNIX epoch on ledger 9 (node 2.1.0), on the client and the node alike; the comparison is a transcript read enforced at client build (wall clock) and at node admission (block context), not a proof constraint; the never-expires arm records no read; the admission-time block time runs about one block interval plus a network-defined tolerance ahead of the wall clock (8.2 to 10.2 s measured on a 6 s-block localnet); recorded in the registry entry (section 14) |
      | O5 | tombstone pruning and window enforcement | deferred to a circuit revision |
      | O6 | one MIP or two | one MIP under MPS-0018; the split offered in the PR body |
      | O7 | editor deviation from brief T3: rp_id_hash is committed under scope_salt (rp_commit) rather than stored clear, so the "observer does not learn the origin" claim of brief 5.5 holds for r1 grants | commitment; one extra opening on the p256 seam |
@@ -48,7 +48,7 @@ MPS: MPS-0018
      | O12 | Replaces: none per the brief and the published family | adopted |
      | O13 | Security Considerations rendered as a table where the published family uses bold-titled Sn bullets | table retained; the divergence is offered to the editors |
      | O14 | approved deviation from brief T5: canonical JSON (RFC 8785, JCS) replaced by signing the `request` parameter bytes as received, with the proof carried as a detached `proof` fragment parameter and no canonicalisation step anywhere | adopted (sections 9.1 to 9.4, 9.6, R10, R21) |
-     | O15 | E1 stage one folded: the grant seam compiled and measured on the reference contract at spec_version 2 (k256 grantee arm, unshielded and shielded twins, lifecycle on the k256 device arm, 27 recipe vectors agreed three ways). The brief's section 13 [CIRCUIT] items are settled (struct as Map value, Boolean in a hash tuple, tuple arity above ten, kernel.blockTimeLessThan in an assert, if-guarded lifecycle bodies, the Map reset primitive, cost figures) except three: proving times per twin, the node's unit of block time (O4, E3), and the change-description precomputation on node (6.5) | fifteen corrections applied in the text; the remainder is stage two (Path to Active E1) |
+     | O15 | E1 stage one folded: the grant seam compiled and measured on the reference contract at spec_version 2 (k256 grantee arm, unshielded and shielded twins, lifecycle on the k256 device arm, 27 recipe vectors agreed three ways). The brief's section 13 [CIRCUIT] items are settled (struct as Map value, Boolean in a hash tuple, tuple arity above ten, kernel.blockTimeLessThan in an assert, if-guarded lifecycle bodies, the Map reset primitive, cost figures) except two: proving times per twin and the change-description precomputation on node (6.5); the node's unit of block time is settled by E3 (O4) | fifteen corrections applied in the text; the remainder is stage two (Path to Active E1) |
 
      Upstream dependencies: secp256r1 in the Compact language surface (r1
      arm); secp256k1 point operations (schnorr_bip340); a connector
@@ -408,7 +408,7 @@ export ledger grant_generation: Uint<32>;  // bumped only by revoke_all_grants
 | `object_commit` | `Bytes<32>` | 32 | salted commitment to `color`, `recipient_kind`, `recipient`, `max_coin_value` (section 4.5) |
 | `per_call_cap` | `Uint<128>` | 16 | `amount <= per_call_cap` on every call; MUST be `<= cap` |
 | `cap` | `Uint<128>` | 16 | `spent + amount <= cap` cumulatively |
-| `expires_at` | `Uint<64>` | 8 | in the unit of `kernel.blockTimeLessThan`; `0` means never |
+| `expires_at` | `Uint<64>` | 8 | whole seconds since the UNIX epoch, the unit of `kernel.blockTimeLessThan` (section 5.1); `0` means never |
 | `rp_commit` | `Bytes<32>` | 32 | salted commitment to `rp_id_hash` (SHA-256 of the dApp host for `r1`, zero otherwise); committed for every arm so the record reveals neither host nor arm |
 | `read_pk_hash` | `Bytes<32>` | 32 | SHA-256 of the delegate's X25519 `read_pk` when `read`; zero otherwise |
 | `window_len` | `Uint<64>` | 8 | reserved; MUST be `0` |
@@ -584,16 +584,29 @@ is the coin the grantee selects and could leave without change (R7);
 clients SHOULD recommend `max_coin_value == cap` where the owner can
 pre-split coins.
 
-`expires_at` is in the unit of `kernel.blockTimeLessThan` on the target
-ledger, with `0` meaning never, stated explicitly. The comparison
-compiles inside the seam and executes in both directions in the local
-circuit simulator, where the never-expires arm never expires and the
-unit is seconds; the node's unit is not yet pinned and is recorded from
-a ledger-9 network before this MIP leaves Draft, in the registry entry
-(E3). Clients MUST sanity-check a non-zero `expires_at`
-against a freshly read block time before signing, and an authoriser
-SHOULD refuse a value already in the past. There is no `network_id`
-cell (R15); the wire `chain` member remains normative for the request.
+`expires_at` is a count of whole seconds since the UNIX epoch, the unit
+of `kernel.blockTimeLessThan` on ledger 9 (node 2.1.0, recorded on-node,
+E3), with `0` meaning never, stated explicitly. The comparison is a
+ledger read whose Boolean result the transaction records in its public
+transcript and the node re-executes at mempool admission; it is not a
+proof constraint (one public input, no constraints). A record with
+`expires_at == 0` records no time read at all (the generated code and
+the ZKIR guard the query on `expires_at != 0`), so a never-expiring
+grant is insensitive to block time on the node exactly as in the
+simulator. The client evaluates the seam against its own wall clock,
+not a block time: a clock running ahead of the network refuses calls
+the chain would still accept, and a clock running behind builds calls
+the network refuses at admission. The node's admission-time block time
+runs about one block interval plus a network-defined tolerance ahead of
+the wall clock (measured 8.2 to 10.2 s ahead on a 6 s-block localnet;
+the tolerance is the node's and is not pinned here), so `expires_at` is
+a bound, and the grant stops being usable about that margin before it.
+Clients MUST sanity-check a non-zero `expires_at` against their own wall
+clock and a freshly read head block time before signing, SHOULD treat a
+value within one block interval plus the tolerance of the head block
+time as already expired, and an authoriser SHOULD refuse a value already
+in the past. There is no `network_id` cell (R15); the wire `chain`
+member remains normative for the request.
 
 #### 5.2 Feature strings and the mapping table
 
@@ -688,8 +701,11 @@ order:
 3. **Liveness.** Assert `g.active`, `g.epoch == device_epoch`,
    `g.gen == grant_generation`, and
    `g.scope.expires_at == 0 || kernel.blockTimeLessThan(g.scope.expires_at)`
-   (a select, both sides evaluated; the comparison argument reaches the
-   public transcript, harmless because the record is public).
+   (the ledger read is guarded on `expires_at != 0`, so a never-expiring
+   record records no time read; when the read happens its Boolean result
+   is one public input the proof asserts and the node re-executes at
+   admission, and the comparison argument reaches the public transcript,
+   harmless because the record is public).
 4. **Operation.** Assert the twin's own flag.
 5. **Object and bounds.** With `obj_color = coin.color` on the shielded
    twins and `obj_color = color` on the unshielded twin, the predicate
@@ -805,6 +821,22 @@ A grantee MUST re-read `nonce` and `enc_key` and re-sign if its
 transaction is not included, and MUST persist `scope_salt`, the
 returned scope, and its running `spent` alongside the key.
 
+Expiry surfaces as one of two signals, both leaving state untouched and
+the signed challenge valid: a build-time abort (`failed assert:
+expired`) when the grantee's own clock is at or past `expires_at`, and
+a mempool refusal when the network's admission-time block time is (the
+node answers `Invalid Transaction: Custom error: 104` on a transcript
+read mismatch, which the client submission layer surfaces as a
+`SubmissionError` whose reason is visible only in the RPC log line). On
+either signal the grantee MUST re-read the grant record and the chain
+head, and MUST re-sign only if `expires_at` is `0` or exceeds the head's
+block time by more than the inclusion margin of section 5.1; otherwise
+it treats the grant as expired and requests a new one. Retrying an
+admission refusal without re-reading is pointless, since the network's
+time only advances. A grantee SHOULD NOT take an indexer's latest-block
+timestamp as the head time (measured two blocks behind the node on the
+reference stack).
+
 #### 6.5 Grantee private state and coin selection
 
 A grantee spending shielded value maintains a wallet-local coin store per
@@ -825,7 +857,8 @@ evidenced; the fallback is a bounded standalone append twin with an
 
 Disclosed per grant call: `grant_id` (lookup and write-back), the
 rewritten `nonce` and `spent_commit`, the `expires_at` argument of the
-kernel comparison, and what the custody chip already discloses
+kernel comparison (no read is recorded when it is `0`), and what the
+custody chip already discloses
 (`color`, `amount`, and `recipient` on the unshielded twin, whose
 balances are public; the contract address of a contract-recipient
 output; the change-entry ciphertext on a shielded twin). Not disclosed:
@@ -1136,8 +1169,9 @@ it in a `proof` parameter.
 }
 ```
 
-`iat` and `exp` are Unix seconds; `bounds.expires_at` is in the ledger's
-block-time unit (section 5.1), a distinct unit. `recipient`, when
+`iat`, `exp`, and `bounds.expires_at` are all whole seconds since the
+UNIX epoch; the first two are evaluated by the authoriser and the third
+by the ledger (section 5.1). `recipient`, when
 present, is `{ "kind": "user" | "zswap" | "contract", "value": "<64 hex>" }`
 mapping to `recipient_kind` `1`, `2`, and `3`. `grants` carries one or more
 elements for the single grantee key, each with a distinct `slot`: one
@@ -1648,7 +1682,10 @@ MIP's SIG-1 through SIG-5 for the arms it deploys.
   with the schemes MIP's sunset, envelope-1 grantees `read`-only; `r1`
   Active upon the schemes MIP receiving a number and the secp256r1
   surface shipping; `schnorr_bip340` reserved. The registry entry
-  records the pinned block-time unit.
+  records the block-time unit as measured (E3): whole seconds since the
+  UNIX epoch on ledger 9 (node 2.1.0), enforced at client build and at
+  node admission, with the admission-time block time about one block
+  interval plus a network-defined tolerance ahead of the wall clock.
 - **Tag families**, all to be registered under the MPS-0027 registry (an
   acceptance criterion):
 
@@ -1774,6 +1811,17 @@ was the earlier choice; it added a specification every implementer had
 to get byte-exact for no gain once the parameter value itself is the
 signed unit.
 
+**R22. Expiry as a transcript read, not a constraint.** The kernel
+comparison compiles to a ledger read whose Boolean result is one public
+input the proof asserts; it adds no constraints, and a never-expiring
+record adds not even the read. The ledger applies no tolerance of its
+own to the comparison: the client evaluates it against its wall clock,
+and the node re-executes it at admission against an admission-time
+block time that runs about one block interval plus a tolerance ahead of
+the wall clock. That tolerance is the node's and is network-defined,
+measured rather than specified here, which is why section 5.1 states
+`expires_at` as a bound and leaves the margin to the client (E3).
+
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
 | R3 identity element | one-byte `slot`; request `nonce` bound only in `request_digest` | a 32-byte request nonce in `grant_id` | an unbounded nonce let one key hold records the owner could not enumerate and made the nonce a capability secret in URLs |
@@ -1818,9 +1866,13 @@ signed unit.
       stage two lists the remainder).
 - [ ] E2: Testing item 2 green on a node, each case ending with the
       invariants it exercises.
-- [ ] E3: the on-chain unit of `kernel.blockTimeLessThan` and the
+- [x] E3: the on-chain unit of `kernel.blockTimeLessThan` and the
       never-expires arm pinned on a ledger-9 network and recorded in the
-      registry entry, with past, future, zero, and wrong-unit cases.
+      registry entry, with past, future, zero, and wrong-unit cases
+      (registry entry: ledger 9, node 2.1.0, whole seconds since the
+      UNIX epoch; enforcement at client build and at node admission;
+      admission-time block time about one block interval plus a
+      network-defined tolerance ahead of the wall clock).
 - [ ] E4: Testing item 4 with two origins and two platform passkeys, a
       read-only grant, a two-element batch, and a zero-DUST refusal.
 - [ ] E5: the vectors of Testing item 5 published, the Rust side linking
@@ -1849,8 +1901,8 @@ signed unit.
 1. Name the external co-author and settle the open items with the
    Foundation and the editors; fold the outcomes into the text.
 2. Extend the reference contract to `spec_version = 2` and run E1, E2,
-   E3, E6, E9, and E10; correct any byte recipe the compiled encoding
-   contradicts and publish the E5 vectors.
+   E6, E9, and E10 (E3 is held); correct any byte recipe the compiled
+   encoding contradicts and publish the E5 vectors.
 3. Build a reference authoriser page and a reference dApp against the
    text and run E4 and E7; then E8 with the reference signer as agent.
 4. Commission the cryptographer review; fold findings in before editor
@@ -1973,13 +2025,15 @@ the salt.
 | the wallet-key gate experiment on a ledger-9 network (k=15 and k=16; 31,046 and 32,900 rows; 0.5 to 0.8 s) | the k256 envelope arm compiled and measured; the connector prefix as envelope `1` |
 | the P-256 in-circuit experiment against a real platform assertion (k=16, 36,466 rows, 1.1 to 1.2 s) | the r1 WebAuthn envelope |
 | the reference implementation's wave deploy and block-limit numbers | the deploy budget rule of section 6.7 |
-| the kernel block-time comparison compiling and executing | lazy expiry is expressible; its unit is not held |
+| E3: the kernel block-time comparison on a ledger-9 node (node 2.1.0): 21 unit and enforcement cases and a 13-case admission-time sweep over a probe contract carrying the seam's comparison shape, each case recording the host clock, the node head, the client phase reached, and the node outcome | the unit is whole seconds since the UNIX epoch on the client and the node alike; the comparison is a transcript read (one public input, no constraints) enforced at client build against the wall clock and at node admission against the node's block context, never by the proof; the never-expires arm records no read; the admission-time block time ran 8.2 to 10.2 s ahead of the wall clock on a 6 s-block localnet; the client-side and node-side refusal texts of section 6.4 |
 | the cross-contract-calls experiment | composition in one transaction |
 | E1 stage one: the grant seam compiled on the reference contract at `spec_version = 2` (the two cells and structs, the pure derivations, the k256 seam chips, the unshielded and shielded k256 grant twins, and the three lifecycle circuits on the k256 device arm), measured at k=16 to 17, 58,771 to 91,862 rows, 2,745-byte k256 and 2,313-byte jubjub verifier keys, and executed off-node in a circuit simulator (lifecycle, the unshielded twin, its rejection matrix) | the circuit items settled: a struct as a `Map` value, `Boolean` as a one-byte hash element, tuple arities of thirteen and seventeen hashed as the raw concatenation, the kernel block-time comparison inside an assert, the `if`-guarded lifecycle bodies, and the `Map` reset primitive; the byte recipes of sections 4 and 6.3 reproduced two ways from the text alone (a TypeScript recipe and a Rust recipe linking no compiled module) against the compiled circuits, 27 vectors and two pinned signatures; the deploy budget of section 6.7 |
 
 Not yet held: any connection protocol on Midnight, origin binding,
-expiry on node, proving times per twin, the on-node matrix, the jubjub
-grantee twins, the remaining k256 twin
+proving times per twin, the on-node matrix (which carries the expiry
+rows of Testing items 1 and 2 onto the grant twins; E3 pinned the
+comparison on a probe contract), the jubjub grantee twins, the
+remaining k256 twin
 (`withdraw_shielded_to_contract_with_grant_k256`), and the lifecycle
 circuits on the jubjub device arm; these are stage two of E1 and the
 remaining experiments of Path to Active.
@@ -2006,15 +2060,27 @@ the following. Each item names the invariants it exercises.
 1. **Grant happy path.** Issue from a device; a grant call within scope
    executes; `nonce` advances, `spent_commit` re-commits, `round`
    advances, `auth_nonce` is unchanged (GR-1, GR-5, GR-13; INV-7).
+   Expiry rows: a record with `expires_at = 0` and one with
+   `expires_at = head + 3600` each execute on node with state advancing,
+   and the `0` record produces no time read in the transcript (GR-7).
    Status: green off-node for the unshielded k256 twin in the circuit
    simulator (no proof, no node); the shielded twins and the node run
-   are pending.
+   are pending; the expiry rows are green on node for the comparison
+   shape in a probe contract (E3) and pending on the grant twins.
 2. **Rejection matrix.** The same call aborts with no state change under
    each single fault: out-of-scope operation; over `per_call_cap`; over
    `cap`; a cumulative wrap attempt; a witness coin of another color; a
    witness coin above `max_coin_value`; wrong recipient under a pin;
-   recipient-kind mismatch; a stale `enc_pk`; revoked; expired; stale
-   epoch; stale generation; identical resubmission after success; a
+   recipient-kind mismatch; a stale `enc_pk`; revoked; `expires_at` in
+   the past (the grantee's build aborts with `failed assert: expired`,
+   nothing is submitted); `expires_at` within one block interval plus
+   tolerance of the wall clock (the build succeeds, the node refuses at
+   admission with `Custom error: 104` on a transcript read mismatch,
+   state unchanged); a client clock skewed behind the network by more
+   than the margin (the same admission refusal, showing the check does
+   not rest on the grantee's clock) and skewed ahead (the client refuses
+   a call the chain would accept, a client-quality control rather than
+   a protocol property); stale epoch; stale generation; identical resubmission after success; a
    prior-incarnation signature against a re-issue; a cross-scheme key; a
    wrong envelope (k1); an envelope-1 grantee against any withdraw twin
    refused in-circuit (k1); the identity, small-order, off-curve, and
@@ -2176,6 +2242,12 @@ the following. Each item names the invariants it exercises.
 - E1 stage one (Implementation): the findings at `contract/GRANTS-E1.md`
   and the vectors at `contract/src/tests/vectors/grants-e1.json` on the
   branch `nicolasdp/grants-seam-e1` of the
+  [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
+  repository.
+- E3 (Implementation): the findings at `contract/GRANTS-E3.md` and the
+  evidence at `contract/evidence/block-time-unit.json` and
+  `contract/evidence/block-time-sweep.json` on the branch
+  `nicolasdp/grants-e3-block-time` of the
   [midnightntwrk/passport](https://github.com/midnightntwrk/passport)
   repository.
 

--- a/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
+++ b/docs/mps-mip/mips/mip-xxxx-scoped-grants.md
@@ -2,6 +2,7 @@
 MIP: xxxx
 Title: Scoped Grants and dApp Connection for Custody Accounts
 Authors:
+  - Hector Bulgarini (hbulgarini)
   - Nicolas Di Prima (NicolasDP)
 Status: Draft
 Category: Standards
@@ -33,7 +34,7 @@ MPS: MPS-0018
 
      | Id | Item | Current default in the text |
      |---|---|---|
-     | O1 | external co-author | the offer in upstream discussion #223 answered first; Acknowledgements reserves the slot |
+     | O1 | external co-author | named (Hector Bulgarini); the team that offered prior art in upstream discussion #223 is still to be answered and credited in Acknowledgements |
      | O2 | one spec_version = 2 redeploy carrying the grant cells and the device-identity remedy for MIP-0013 erratum 8 | SHOULD, in Backwards Compatibility |
      | O3 | companion erratum to MIP-0013 AUTH-1, AUTH-2, AUTH-9 (section 12); wordings in .planning/grants-mip/erratum-wordings.md, to travel in the erratum PR | acceptance is an acceptance criterion |
      | O4 | on-chain unit of kernel.blockTimeLessThan, and that the never-expires arm executes | pinned before Draft leaves; recorded in the registry entry |


### PR DESCRIPTION
Draft of the successor extension MIP-0013 reserves behind
`require_authorised()`: **Scoped Grants and dApp Connection for Custody
Accounts**, covering components C10 (scoped grant primitive), C11 (grant
lifecycle), C12 (chain-side enforcement), and the issuance half of C23
(dApp connection). Standardises the work tracked by #16, #17, #69, and
#70, and specifies the ceremony #68 implements. Advances #29 and #63.
Co-authored with the Midnight Foundation.

### What it standardises

- A **grant** is a contract-maintained record in the account custody
  contract admitting one grantee key of a registered signature scheme
  to a bounded subset of the asset-facing circuits: three spend
  operations, one token color, a per-call and a cumulative cap, a bound
  on the value of any coin touched, an optional recipient pin, and an
  explicit expiry. Scope is enforced in-circuit on every call through
  per-arm grant twins over the unchanged custody chips; any active
  device revokes from chain state; `revoke_all_grants` is an O(1) kill.
- The record is keyed by a contract-recomputable identity over the
  account, the grantee key, its origin, and a slot; color, recipient,
  coin bound, relying-party host, and the running spent total are
  stored as salted commitments, so the custody invariants of MIP-0012
  hold unchanged and observers learn neither which dApps an account
  uses nor what it spends.
- The **connection ceremony**: the dApp navigates the user to an
  authoriser page with a `GrantRequest` and a detached possession proof
  in the URL fragment, signed as the transmitted bytes (no
  canonicalisation; a JWS container was considered and rejected, see
  Rationale R21); the proof is a WebAuthn assertion made on the dApp
  origin, so the consent screen names an origin the browser attested
  rather than one the page typed; the user approves with the account
  passkey; the authoriser submits one device-gated `issue_grant`; the
  dApp verifies its grant by reading chain state and thereafter signs
  in with the passkey registered for its origin.
- **Read access** is the MIP-0012 viewing capability sealed to a
  dApp-supplied key and recorded declaratively; the text says plainly
  that the ledger enforces spend scope and not read scope.
- Account-linked sign-in; unlinkable sign-in stays with the
  DecentralisedAuth MIP.

### Evidence held

The reference implementation on branch `nicolasdp/grants-seam-e1` now
carries the whole thirty-circuit roster at `spec_version = 2`: both
grantee arms with their three twins each, and the lifecycle circuits on
both device arms. The conformance suite has run against a ledger-9 node,
and eleven of its twelve evidence groups pass. Four experiments back
this text, and this PR quotes only what they measured.

**The change coin is precomputable, so section 6.5 loses its fallback.**
The kernel evolves both output nonces from the input coin's nonce, so
the entry a grantee seals into its challenge is the entry the send
actually produces, matched bit for bit on every spend of the run. The
bounded standalone append twin the text carried as a fallback is
deleted. What replaces it is narrower: the change output is not reliably
the last commitment of its window, so a grantee resolves the tree index
by trial before signing, since the qualified coin is bound into the
challenge and a retry would otherwise cost a fresh signature.

**The deploy budget is a measurement rather than an estimate.** The
per-update ceiling is bounded to between 29,484 and 32,229 verifier
bytes on the reference node, closed to a single key. Two different
refusals bound a contract's size and only one of them warns you: the
client fee computation refuses an over-large deploy before a transaction
exists, while an over-large maintenance update is refused by the node at
admission with nothing client-side objecting first. The thirty-circuit
roster still plans as three waves, so the figure in section 6.7 stands.

Costs and proving times are now measured for every circuit the run
exercised, on a named stack: about 3.4 s at k=15, 5.6 to 8.0 s at k=16,
and 11.2 to 17.4 s at k=17, with the JubJub arm cheaper than k256 at
every k they share. Every byte recipe is reproduced three ways, by the
compiled circuits, a TypeScript recipe, and a Rust recipe linking no
compiled module, over 34 vectors and three pinned signatures.

Section 3.3 gains what the run found about key validation: which
rejections the seam performs per arm, and that issuance cannot check a
grantee key at all, since `issue_grant` takes a grant identity and never
the key. Every Testing item the evidence touches now carries a status
saying green, partial, or open, with the missing clause named. E1 is
ticked in Path to Active. E2 and E6 stay open: the rejection matrix is
partly covered, and the deploy control needs a pre-grants build that
does not exist. Details in `contract/GRANTS-E1.md`, `GRANTS-E2.md`, and
`GRANTS-E3.md` on the evidence branch.

### Compatibility

Grant-capable accounts are `spec_version = 2` (a redeploy, stated in
Backwards Compatibility); the bump is proposed to carry the erratum-8
device-identity remedy as well. A companion erratum to MIP-0013 section
9 (AUTH-1, AUTH-2, AUTH-9) travels separately. Reuses the dApp
connector's scheme names and signing envelope, CAIP-2 identifiers, and
a CAIP-217 carriage so OWS and CAIP-25 sessions can carry the scopes.
The k256 spend seam refuses connector envelope-1 keys in-circuit; such
grants are read-only by construction.

### How it was produced

Design brief from five independent design angles judged through three
lenses and refuted adversarially, then a draft reviewed through four
lenses (format and rigour, cryptography, consistency with MIP-0012 and
MIP-0013 and the reference implementation, prose), then corrected
against the E1 stage-one build. Open items for the editors are
collected in a comment at the head of the file (O1 to O15).

### Not in this PR

No contract changes; the evidence branch is a separate PR. The
connection ceremony itself is the next experiment: the authoriser page,
a reference dApp, the read handover, and the agent grantee are E4, E7,
and E8, and with the r1 arm they gate the move to Proposed. The upstream
MPS-0018 header amendment and the MIP-0013 erratum are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
